### PR TITLE
Replace `ImportedFunc.swiftDemangledMangledName` with a Swift full name

### DIFF
--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -86,7 +86,6 @@ public struct ImportedTypeName: Hashable {
   public var swiftTypeName: String
 
   public var swiftMangledName: String = ""
-  public var swiftDemangledMangledName: String = ""
 
   public var javaType: JavaType
 
@@ -124,13 +123,24 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
   public var parentName: ImportedTypeName?
   public var hasParent: Bool { parentName != nil }
 
-  public var identifier: String  // FIXME: this is init(cap:name:) complete swift identifier; change that to be base
+  /// This is a full name such as init(cap:name:).
+  public var identifier: String
 
   public var baseIdentifier: String {
     guard let idx = identifier.firstIndex(of: "(") else {
       return identifier
     }
     return String(identifier[..<idx])
+  }
+
+  /// A display name to use to refer to the Swift declaration with its
+  /// enclosing type.
+  public var displayName: String {
+    if let parentName {
+      return "\(parentName.swiftTypeName).\(identifier)"
+    }
+
+    return identifier
   }
 
   public var returnType: ImportedTypeName
@@ -173,7 +183,6 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
   }
 
   public var swiftMangledName: String = ""
-  public var swiftDemangledMangledName: String = ""
 
   public var swiftDeclRaw: String? = nil
 

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -441,7 +441,7 @@ extension Swift2JavaTranslator {
   public func printDowncallMethods(_ printer: inout CodePrinter, _ decl: ImportedFunc) {
     printer.printSeparator(decl.identifier)
 
-    printer.printTypeDecl("private static class \(decl.identifier)") { printer in
+    printer.printTypeDecl("private static class \(decl.baseIdentifier)") { printer in
       printFunctionDescriptorValue(&printer, decl);
       printFindMemorySegmentAddrByMangledName(&printer, decl)
       printMethodDowncallHandleForAddrDesc(&printer)
@@ -455,8 +455,8 @@ extension Swift2JavaTranslator {
        * \(/*TODO: make a printSnippet func*/decl.swiftDeclRaw ?? "")
        * }
        */
-      public static FunctionDescriptor \(decl.identifier)$descriptor() {
-          return \(decl.identifier).DESC;
+      public static FunctionDescriptor \(decl.baseIdentifier)$descriptor() {
+          return \(decl.baseIdentifier).DESC;
       }
       """
     )
@@ -469,8 +469,8 @@ extension Swift2JavaTranslator {
        * \(/*TODO: make a printSnippet func*/decl.swiftDeclRaw ?? "")
        * }
        */
-      public static MethodHandle \(decl.identifier)$handle() {
-          return \(decl.identifier).HANDLE;
+      public static MethodHandle \(decl.baseIdentifier)$handle() {
+          return \(decl.baseIdentifier).HANDLE;
       }
       """
     )
@@ -483,8 +483,8 @@ extension Swift2JavaTranslator {
        * \(/*TODO: make a printSnippet func*/decl.swiftDeclRaw ?? "")
        * }
        */
-      public static MemorySegment \(decl.identifier)$address() {
-          return \(decl.identifier).ADDR;
+      public static MemorySegment \(decl.baseIdentifier)$address() {
+          return \(decl.baseIdentifier).ADDR;
       }
       """
     )
@@ -542,8 +542,8 @@ extension Swift2JavaTranslator {
          * \(/*TODO: make a printSnippet func*/decl.swiftDeclRaw ?? "")
          * }
          */
-        public static \(returnTy) \(decl.identifier)(\(renderJavaParamDecls(decl, selfVariant: .wrapper))) {
-          \(maybeReturnCast) \(decl.identifier)(\(renderForwardParams(decl, selfVariant: .memorySegment)));
+        public static \(returnTy) \(decl.baseIdentifier)(\(renderJavaParamDecls(decl, selfVariant: .wrapper))) {
+          \(maybeReturnCast) \(decl.baseIdentifier)(\(renderForwardParams(decl, selfVariant: .memorySegment)));
         }
         """
       )
@@ -557,8 +557,8 @@ extension Swift2JavaTranslator {
        * \(/*TODO: make a printSnippet func*/decl.swiftDeclRaw ?? "")
        * }
        */
-      public static \(returnTy) \(decl.identifier)(\(renderJavaParamDecls(decl, selfVariant: selfVariant))) {
-        var mh$ = \(decl.identifier).HANDLE;
+      public static \(returnTy) \(decl.baseIdentifier)(\(renderJavaParamDecls(decl, selfVariant: selfVariant))) {
+        var mh$ = \(decl.baseIdentifier).HANDLE;
         try {
           if (TRACE_DOWNCALLS) {
              traceDowncall(\(renderForwardParams(decl, selfVariant: .memorySegment)));

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -502,9 +502,8 @@ extension Swift2JavaTranslator {
     printer.print(
       """
       /**
-       * Demangled representation:
        * {@snippet lang = Swift:
-       * \(decl.swiftDemangledMangledName)
+       * \(decl.displayName)
        * }
        */
       public static final MemorySegment ADDR = \(swiftModuleName).findOrThrow("\(decl.swiftMangledName)");

--- a/Sources/JExtractSwift/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwift/Swift2JavaVisitor.swift
@@ -103,9 +103,18 @@ final class Swift2JavaVisitor: SyntaxVisitor {
       return .skipChildren
     }
 
+    let argumentLabels = node.signature.parameterClause.parameters.map { param in
+      param.firstName.identifier?.name ?? "_"
+    }
+    let argumentLabelsStr = String(argumentLabels.flatMap { label in
+      label + ":"
+    })
+
+    let fullName = "\(node.name.text)(\(argumentLabelsStr))"
+
     var funcDecl = ImportedFunc(
       parentName: currentTypeDecl?.name,
-      identifier: node.name.text,
+      identifier: fullName,
       returnType: javaResultType,
       parameters: params
     )
@@ -156,7 +165,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
 
     var funcDecl = ImportedFunc(
       parentName: currentTypeDecl.name,
-      identifier: initIdentifier,  // FIXME: what is the name of the inits?
+      identifier: initIdentifier,
       returnType: currentTypeDecl.name,
       parameters: params
     )

--- a/Sources/JExtractSwift/SwiftDylib.swift
+++ b/Sources/JExtractSwift/SwiftDylib.swift
@@ -46,7 +46,6 @@ package struct SwiftDylib {  // FIXME: remove this entire utility; replace with 
     if let name = names.first {
       log.trace("Selected mangled name for '\(decl.name.javaType.description)': \(name)")
       decl.name.swiftMangledName = name.mangledName
-      decl.name.swiftDemangledMangledName = name.descriptiveName
     }
 
     return decl
@@ -64,7 +63,6 @@ package struct SwiftDylib {  // FIXME: remove this entire utility; replace with 
     if let name = names.first {
       log.trace("Selected mangled name for '\(decl.identifier)': \(name)")
       decl.swiftMangledName = name.mangledName
-      decl.swiftDemangledMangledName = name.descriptiveName
     }
 
     return decl
@@ -85,7 +83,6 @@ package struct SwiftDylib {  // FIXME: remove this entire utility; replace with 
     if let name = names.first {
       log.trace("Selected mangled name for '\(decl.identifier)': \(name)")
       decl.swiftMangledName = name.mangledName
-      decl.swiftDemangledMangledName = name.descriptiveName
     }
 
     return decl
@@ -103,7 +100,6 @@ package struct SwiftDylib {  // FIXME: remove this entire utility; replace with 
     if let name = names.first {
       log.trace("Selected mangled name: \(name)")
       decl.swiftMangledName = name.mangledName
-      decl.swiftDemangledMangledName = name.descriptiveName
     }
 
     return decl

--- a/Sources/JExtractSwift/SwiftDylib.swift
+++ b/Sources/JExtractSwift/SwiftDylib.swift
@@ -59,7 +59,7 @@ package struct SwiftDylib {  // FIXME: remove this entire utility; replace with 
     }
 
     var decl = decl
-    let names = try await nmSymbolNames(grepDemangled: [decl.identifier])
+    let names = try await nmSymbolNames(grepDemangled: [decl.baseIdentifier])
     if let name = names.first {
       log.trace("Selected mangled name for '\(decl.identifier)': \(name)")
       decl.swiftMangledName = name.mangledName

--- a/Tests/JExtractSwiftTests/FuncImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncImportTests.swift
@@ -60,7 +60,7 @@ final class MethodImportTests: XCTestCase {
 
     try await st.analyze(swiftInterfacePath: "/fake/Fake.swiftinterface", text: class_interfaceFile)
 
-    let funcDecl = st.importedGlobalFuncs.first { $0.identifier == "helloWorld" }!
+    let funcDecl = st.importedGlobalFuncs.first { $0.baseIdentifier == "helloWorld" }!
 
     let output = CodePrinter.toString { printer in
       st.printFuncDowncallMethod(&printer, decl: funcDecl, selfVariant: nil)
@@ -100,7 +100,7 @@ final class MethodImportTests: XCTestCase {
     try await st.analyze(swiftInterfacePath: "/fake/__FakeModule/SwiftFile.swiftinterface", text: class_interfaceFile)
 
     let funcDecl = st.importedGlobalFuncs.first {
-      $0.identifier == "globalTakeInt"
+      $0.baseIdentifier == "globalTakeInt"
     }!
 
     let output = CodePrinter.toString { printer in
@@ -141,7 +141,7 @@ final class MethodImportTests: XCTestCase {
     try await st.analyze(swiftInterfacePath: "/fake/__FakeModule/SwiftFile.swiftinterface", text: class_interfaceFile)
 
     let funcDecl = st.importedGlobalFuncs.first {
-      $0.identifier == "globalTakeIntLongString"
+      $0.baseIdentifier == "globalTakeIntLongString"
     }!
 
     let output = CodePrinter.toString { printer in
@@ -184,7 +184,7 @@ final class MethodImportTests: XCTestCase {
     let funcDecl: ImportedFunc = st.importedTypes.first {
       $0.name.javaClassName == "MySwiftClass"
     }!.methods.first {
-      $0.identifier == "helloMemberFunction"
+      $0.baseIdentifier == "helloMemberFunction"
     }!
 
     let output = CodePrinter.toString { printer in
@@ -227,7 +227,7 @@ final class MethodImportTests: XCTestCase {
     let funcDecl: ImportedFunc = st.importedTypes.first {
       $0.name.javaClassName == "MySwiftClass"
     }!.methods.first {
-      $0.identifier == "helloMemberFunction"
+      $0.baseIdentifier == "helloMemberFunction"
     }!
 
     let output = CodePrinter.toString { printer in
@@ -270,7 +270,7 @@ final class MethodImportTests: XCTestCase {
     let funcDecl: ImportedFunc = st.importedTypes.first {
       $0.name.javaClassName == "MySwiftClass"
     }!.methods.first {
-      $0.identifier == "helloMemberFunction"
+      $0.baseIdentifier == "helloMemberFunction"
     }!
 
     let output = CodePrinter.toString { printer in
@@ -305,7 +305,7 @@ final class MethodImportTests: XCTestCase {
     let funcDecl: ImportedFunc = st.importedTypes.first {
       $0.name.javaClassName == "MySwiftClass"
     }!.methods.first {
-      $0.identifier == "makeInt"
+      $0.baseIdentifier == "makeInt"
     }!
 
     let output = CodePrinter.toString { printer in

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -63,7 +63,7 @@ final class FunctionDescriptorTests: XCTestCase {
     try await st.analyze(swiftInterfacePath: "/fake/Sample.swiftinterface", text: interfaceFile)
 
     let funcDecl = st.importedGlobalFuncs.first {
-      $0.identifier == methodIdentifier
+      $0.baseIdentifier == methodIdentifier
     }!
 
     let output = CodePrinter.toString { printer in


### PR DESCRIPTION
We don't want to go through a demangler as part of binding generation. Instead of using the demangled name as a reference, use the full swift name, e.g., `print(_:separator:terminator:)`. 