### PR TITLE
Expose Java-friendly instance methods and constructors for Swift types

### DIFF
--- a/JavaSwiftKitDemo/src/main/java/org/example/HelloJava2Swift.java
+++ b/JavaSwiftKitDemo/src/main/java/org/example/HelloJava2Swift.java
@@ -60,9 +60,12 @@ public class HelloJava2Swift {
 
         JavaKitExample.globalTakeInt(1337);
 
-        MySwiftClass obj = MySwiftClass.init(2222, 7777);
+        MySwiftClass obj = new MySwiftClass(2222, 7777);
 
         SwiftKit.retain(obj.$memorySegment());
         System.out.println("[java] obj ref count = " + SwiftKit.retainCount(obj.$memorySegment()));
+
+        obj.voidMethod();
+        obj.takeIntMethod(42);
     }
 }

--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -48,6 +48,14 @@ public struct ImportedNominalType: ImportedDecl {
       javaType: javaType
     )
   }
+
+  /// The Java class name without the package.
+  public var javaClassName: String {
+    switch javaType {
+    case .class(package: _, name: let name): name
+    default: javaType.description
+    }
+  }
 }
 
 public enum NominalTypeKind {
@@ -116,7 +124,7 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
   /// this will contain that declaration's imported name.
   ///
   /// This is necessary when rendering accessor Java code we need the type that "self" is expecting to have.
-  var parentName: TranslatedType?
+  public var parentName: TranslatedType?
   public var hasParent: Bool { parentName != nil }
 
   /// This is a full name such as init(cap:name:).
@@ -152,7 +160,7 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
       //
       // allocating initializer takes a Self.Type instead, but it's also a pointer
       switch selfVariant {
-      case nil:
+      case nil, .wrapper:
         break
 
       case .pointer:
@@ -174,10 +182,6 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
             type: parentForSelf
           )
         )
-
-      case .wrapper:
-        let selfParam: FunctionParameterSyntax = "self$: \(raw: parentName.swiftTypeName)"
-        params.append(ImportedParam(param: selfParam, type: parentName))
       }
 
       // TODO: add any metadata for generics and other things we may need to add here

--- a/Sources/JExtractSwift/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwift/Swift2JavaVisitor.swift
@@ -163,7 +163,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
     }
 
     let initIdentifier =
-      "init(\(params.compactMap { $0.effectiveName ?? "_" }.joined(separator: ":")))"
+      "init(\(String(params.flatMap { "\($0.effectiveName ?? "_"):" })))"
 
     var funcDecl = ImportedFunc(
       parentName: currentType.translatedType,

--- a/Sources/JExtractSwift/TranslatedType.swift
+++ b/Sources/JExtractSwift/TranslatedType.swift
@@ -223,6 +223,14 @@ public struct TranslatedType {
   var swiftTypeName: String {
     originalSwiftType.trimmedDescription
   }
+
+  /// Produce the "unqualified" Java type name.
+  var unqualifiedJavaTypeName: String {
+    switch javaType {
+    case .class(package: _, name: let name): name
+    default: javaType.description
+    }
+  }
 }
 
 /// Describes the C-compatible layout as it should be referenced from Java.


### PR DESCRIPTION
When projecting a Swift type into a Java class, map Swift methods into instance methods (rather than static methods) and Swift initializers into Java constructors (rather than static 'init' methods). This means our example Swift class like this:

```swift
public class MySwiftClass {
  public init(len: Int, cap: Int) { ... }
  public func voidMethod() { ... }
} 
```

turns into

```java
public final class MySwiftClass {
  public MySwiftClass(long let, long cap) { /* downcall to Swift */ }
  public void voidMethod() { /* downcall to Swift */ }
}
```

as one would expect.