### PR TITLE
Introduce the @JavaStaticMethod and use it for calling static Java methods

### DIFF
--- a/Sources/Java2Swift/JavaTranslator.swift
+++ b/Sources/Java2Swift/JavaTranslator.swift
@@ -416,8 +416,9 @@ extension JavaTranslator {
 
     let throwsStr = javaMethod.throwsCheckedException ? "throws" : ""
 
+    let methodAttribute: AttributeSyntax = javaMethod.isStatic ? "@JavaStaticMethod" : "@JavaMethod";
     return """
-      @JavaMethod
+      \(methodAttribute)
       public func \(raw: javaMethod.getName())\(raw: genericParameterClause)(\(raw: parametersStr))\(raw: throwsStr)\(raw: resultTypeStr)\(raw: whereClause)
       """
   }

--- a/Sources/JavaKit/JavaObject+MethodCalls.swift
+++ b/Sources/JavaKit/JavaObject+MethodCalls.swift
@@ -301,9 +301,10 @@ extension AnyJavaObject {
 extension JavaClass {
   /// Call a Java static method with the given name and arguments, which must be
   /// of the correct type, that produces the given result type.
-  public func dynamicJavaMethodCall<each Param: JavaValue, Result: JavaValue>(
+  public func dynamicJavaStaticMethodCall<each Param: JavaValue, Result: JavaValue>(
     methodName: String,
-    args: repeat each Param
+    arguments: repeat each Param,
+    resultType: Result.Type
   ) throws -> Result {
     let thisClass = javaThis
     let environment = javaEnvironment
@@ -325,7 +326,7 @@ extension JavaClass {
 
     // Retrieve the method that performs this call, then
     let jniMethod = Result.jniStaticMethodCall(in: environment)
-    let jniArgs = getJValues(repeat each args, in: environment)
+    let jniArgs = getJValues(repeat each arguments, in: environment)
     let jniResult = try environment.translatingJNIExceptions {
       jniMethod(environment, thisClass, methodID, jniArgs)
     }
@@ -335,9 +336,9 @@ extension JavaClass {
 
   /// Call a Java static method with the given name and arguments, which must be
   /// of the correct type, that produces the given result type.
-  public func dynamicJavaMethodCall<each Param: JavaValue>(
+  public func dynamicJavaStaticMethodCall<each Param: JavaValue>(
     methodName: String,
-    args: repeat each Param
+    arguments: repeat each Param
   ) throws {
     let thisClass = javaThis
     let environment = javaEnvironment
@@ -359,7 +360,7 @@ extension JavaClass {
 
     // Retrieve the method that performs this call, then
     let jniMethod = environment.interface.CallStaticVoidMethodA
-    let jniArgs = getJValues(repeat each args, in: environment)
+    let jniArgs = getJValues(repeat each arguments, in: environment)
     try environment.translatingJNIExceptions {
       jniMethod!(environment, thisClass, methodID, jniArgs)
     }

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -95,7 +95,7 @@ public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: 
 
 /// Attached macro that turns a Swift method into one that wraps a Java method on the underlying Java object.
 ///
-/// The macro must be used within either a AnyJavaObject-conforming type or a specific JavaClass instance.
+/// The macro must be used in an AnyJavaObject-conforming type.
 ///
 /// ```swift
 /// @JavaMethod
@@ -114,6 +114,18 @@ public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: 
 /// corresponds to the Java constructor `HelloSwift(String name)`.
 @attached(body)
 public macro JavaMethod() = #externalMacro(module: "JavaKitMacros", type: "JavaMethodMacro")
+
+/// Attached macro that turns a Swift method on JavaClass into one that wraps
+/// a Java static method on the underlying Java class object.
+///
+/// The macro must be used within a specific JavaClass instance.
+///
+/// ```swift
+/// @JavaMethod
+/// func sayHelloBack(_ i: Int32) -> Double
+/// ```
+@attached(body)
+public macro JavaStaticMethod() = #externalMacro(module: "JavaKitMacros", type: "JavaMethodMacro")
 
 /// Macro that exposes the given Swift method as a native method in Java.
 ///

--- a/Sources/JavaKitMacros/JavaMethodMacro.swift
+++ b/Sources/JavaKitMacros/JavaMethodMacro.swift
@@ -34,6 +34,7 @@ extension JavaMethodMacro: BodyMacro {
       fatalError("not a function")
     }
 
+    let isStatic = node.attributeName.trimmedDescription == "JavaStaticMethod"
     let funcName = funcDecl.name.text
     let params = funcDecl.signature.parameterClause.parameters
     let resultType: String =
@@ -54,7 +55,7 @@ extension JavaMethodMacro: BodyMacro {
       ? "try" : "try!"
 
     return [
-      "return \(raw: tryKeyword) dynamicJavaMethodCall(methodName: \(literal: funcName)\(raw: parametersAsArgs)\(raw: resultType))"
+      "return \(raw: tryKeyword) dynamicJava\(raw: isStatic ? "Static" : "")MethodCall(methodName: \(literal: funcName)\(raw: parametersAsArgs)\(raw: resultType))"
     ]
   }
 

--- a/Sources/JavaKitNetwork/generated/URI.swift
+++ b/Sources/JavaKitNetwork/generated/URI.swift
@@ -125,6 +125,6 @@ public struct URI {
   public func wait() throws
 }
 extension JavaClass<URI> {
-  @JavaMethod
+  @JavaStaticMethod
   public func create(_ arg0: String) -> URI?
 }

--- a/Sources/JavaKitNetwork/generated/URLClassLoader.swift
+++ b/Sources/JavaKitNetwork/generated/URLClassLoader.swift
@@ -74,12 +74,12 @@ public struct URLClassLoader {
   public func wait() throws
 }
 extension JavaClass<URLClassLoader> {
-  @JavaMethod
+  @JavaStaticMethod
   public func newInstance(_ arg0: [URL?]) -> URLClassLoader?
 
-  @JavaMethod
+  @JavaStaticMethod
   public func getSystemResource(_ arg0: String) -> URL?
 
-  @JavaMethod
+  @JavaStaticMethod
   public func getSystemResources(_ arg0: String) throws -> Enumeration<URL>?
 }

--- a/Sources/JavaKitNetwork/generated/URLConnection.swift
+++ b/Sources/JavaKitNetwork/generated/URLConnection.swift
@@ -146,7 +146,7 @@ extension JavaClass<URLConnection> {
   @JavaMethod
   public func setDefaultAllowUserInteraction(_ arg0: Bool)
 
-  @JavaMethod
+  @JavaStaticMethod
   public func getDefaultAllowUserInteraction() -> Bool
 
   @JavaMethod

--- a/Sources/JavaKitReflection/generated/AccessibleObject.swift
+++ b/Sources/JavaKitReflection/generated/AccessibleObject.swift
@@ -65,6 +65,6 @@ public struct AccessibleObject {
   public func wait() throws
 }
 extension JavaClass<AccessibleObject> {
-  @JavaMethod
+  @JavaStaticMethod
   public func setAccessible(_ arg0: [AccessibleObject?], _ arg1: Bool)
 }

--- a/Sources/JavaKitReflection/generated/Constructor.swift
+++ b/Sources/JavaKitReflection/generated/Constructor.swift
@@ -122,6 +122,6 @@ public struct Constructor<T: AnyJavaObject> {
   public func wait() throws
 }
 extension JavaClass {
-  @JavaMethod
+  @JavaStaticMethod
   public func setAccessible<T: AnyJavaObject>(_ arg0: [AccessibleObject?], _ arg1: Bool) where ObjectType == Constructor<T>
 }

--- a/Sources/JavaKitReflection/generated/Executable.swift
+++ b/Sources/JavaKitReflection/generated/Executable.swift
@@ -119,6 +119,6 @@ public struct Executable {
   public func wait() throws
 }
 extension JavaClass<Executable> {
-  @JavaMethod
+  @JavaStaticMethod
   public func setAccessible(_ arg0: [AccessibleObject?], _ arg1: Bool)
 }

--- a/Sources/JavaKitReflection/generated/Method.swift
+++ b/Sources/JavaKitReflection/generated/Method.swift
@@ -137,6 +137,6 @@ public struct Method {
   public func wait() throws
 }
 extension JavaClass<Method> {
-  @JavaMethod
+  @JavaStaticMethod
   public func setAccessible(_ arg0: [AccessibleObject?], _ arg1: Bool)
 }

--- a/Sources/_Subprocess/Subprocess+IO.swift
+++ b/Sources/_Subprocess/Subprocess+IO.swift
@@ -145,10 +145,10 @@ extension Subprocess {
             case fileDescriptor(FileDescriptor?, Bool)
         }
         
-        let storage: Mutex<Storage>
+        let storage: LockedState<Storage>
 
         internal init(storage: Storage) {
-            self.storage = .init(storage)
+          self.storage = .init(initialState: storage)
         }
 
         internal func getReadFileDescriptor() -> FileDescriptor? {
@@ -250,10 +250,10 @@ extension Subprocess {
             case collected(Int, FileDescriptor?, FileDescriptor?)
         }
         
-        private let storage: Mutex<Storage>
+        private let storage: LockedState<Storage>
 
         internal init(storage: Storage) {
-            self.storage = .init(storage)
+          self.storage = .init(initialState: storage)
         }
 
         internal func getWriteFileDescriptor() -> FileDescriptor? {

--- a/Tests/JavaKitTests/BasicRuntimeTests.swift
+++ b/Tests/JavaKitTests/BasicRuntimeTests.swift
@@ -66,4 +66,14 @@ struct BasicRuntimeTests {
       #expect(String(describing: error) == "no protocol: bad url")
     }
   }
+
+  @Test("Static methods")
+  func staticMethods() {
+    let urlConnectionClass = JavaClass<URLConnection>(
+      javaThis: URLConnection.getJNIClass(in: jvm.environment)!,
+      environment: jvm.environment
+    )
+
+    #expect(urlConnectionClass.getDefaultAllowUserInteraction() == false)
+  }
 }


### PR DESCRIPTION
The use of the `@JavaMethod` macro within an extension of `JavaClass` to
represent static Java methods on that class didn't quite work, because
JavaClass is itself an AnyJavaObject with its own methods. Introduce
a `@JavaStaticMethod` macro that will be used for this purpose, and
have it call through a separate API (`dynamicJavaStaticMethodCall`).

Thank you to @lokesh-tr  for reporting this bug!

As a bonus, unbreak the macOS build