### PR TITLE
Prepare accessor function descriptors for properties: get set

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -122,7 +122,8 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-    .package(url: "https://github.com/apple/swift-system", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-system", from: "1.0.0"), // TODO: remove, we should not need 'nm' or process callouts
+    .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.1.0")),
   ],
   targets: [
     .macro(
@@ -282,6 +283,7 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "Collections", package: "swift-collections"),
         "_Subprocess",
         "JavaTypes",
       ],

--- a/Samples/SwiftKitSampleApp/build.gradle
+++ b/Samples/SwiftKitSampleApp/build.gradle
@@ -95,7 +95,11 @@ application {
 task jextract(type: Exec) {
     description = "Extracts Java accessor sources using jextract"
     outputs.dir(layout.buildDirectory.dir("generated"))
-    inputs.dir("$rootDir/Sources/ExampleSwiftLibrary")
+    inputs.dir("$rootDir/Sources/ExampleSwiftLibrary") // monitored library
+
+    // any changes in the source generator sources also mean the resulting output might change
+    inputs.dir("$rootDir/Sources/JExtractSwift")
+    inputs.dir("$rootDir/Sources/JExtractSwiftTool")
 
     workingDir = rootDir
     commandLine "make"

--- a/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/generated/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/generated/MySwiftClassTest.java
@@ -15,6 +15,7 @@
 package com.example.swift.generated;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,6 +32,24 @@ public class MySwiftClassTest {
         System.setProperty("jextract.trace.downcalls", "true");
     }
 
-    // TODO: test member methods on MySwiftClass
+    @Test
+    void test_MySwiftClass_voidMethod() {
+        MySwiftClass o = new MySwiftClass(12, 42);
+        o.voidMethod();
+    }
+
+    @Test
+    void test_MySwiftClass_makeIntMethod() {
+        MySwiftClass o = new MySwiftClass(12, 42);
+        var got = o.makeIntMethod();
+        assertEquals(12, got);
+    }
+
+    @Test
+    void test_MySwiftClass_property_len() {
+        MySwiftClass o = new MySwiftClass(12, 42);
+        var got = o.makeIntMethod();
+        assertEquals(12, got);
+    }
 
 }

--- a/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/generated/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/generated/MySwiftClassTest.java
@@ -16,6 +16,8 @@ package com.example.swift.generated;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,12 +35,14 @@ public class MySwiftClassTest {
     }
 
     @Test
+    @DisabledOnOs(OS.LINUX) // FIXME: enable on Linux when we get new compiler with mangled names in swift interfaces
     void test_MySwiftClass_voidMethod() {
         MySwiftClass o = new MySwiftClass(12, 42);
         o.voidMethod();
     }
 
     @Test
+    @DisabledOnOs(OS.LINUX) // FIXME: enable on Linux when we get new compiler with mangled names in swift interfaces
     void test_MySwiftClass_makeIntMethod() {
         MySwiftClass o = new MySwiftClass(12, 42);
         var got = o.makeIntMethod();
@@ -46,6 +50,7 @@ public class MySwiftClassTest {
     }
 
     @Test
+    @DisabledOnOs(OS.LINUX) // FIXME: enable on Linux when we get new compiler with mangled names in swift interfaces
     void test_MySwiftClass_property_len() {
         MySwiftClass o = new MySwiftClass(12, 42);
         var got = o.makeIntMethod();

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -55,6 +55,8 @@ public class MySwiftClass {
     p("Deinit, self = 0x\(String(addr, radix: 16, uppercase: true))")
   }
 
+  public var counter: Int32 = 0
+
   public func voidMethod() {
     p("")
   }

--- a/Sources/JExtractSwift/Convenience/String+Extensions.swift
+++ b/Sources/JExtractSwift/Convenience/String+Extensions.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+
+  // TODO: naive implementation good enough for our simple case `methodMethodSomething` -> `MethodSomething`
+  var toCamelCase: String {
+    guard let f = first else {
+      return self
+    }
+
+    return "\(f.uppercased())\(String(dropFirst()))"
+  }
+}

--- a/Sources/JExtractSwift/ImportedDecls+Printing.swift
+++ b/Sources/JExtractSwift/ImportedDecls+Printing.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import JavaTypes
+import SwiftSyntax
+import OrderedCollections
+
+extension ImportedFunc {
+  /// Render a `@{@snippet ... }` comment section that can be put inside a JavaDoc comment
+  /// when referring to the original declaration a printed method refers to.
+  var renderCommentSnippet: String? {
+    if let syntax {
+      """
+      * {@snippet lang=swift :
+      * \(syntax)
+      * }
+      """
+    } else {
+      nil
+    }
+  }
+}
+
+extension VariableAccessorKind {
+  public var renderDescFieldName: String {
+    switch self {
+    case .get: "DESC_GET"
+    case .set: "DESC_SET"
+    }
+  }
+
+  public var renderAddrFieldName: String {
+    switch self {
+    case .get: "ADDR_GET"
+    case .set: "ADDR_SET"
+    }
+  }
+
+  public var renderHandleFieldName: String {
+    switch self {
+    case .get: "HANDLE_GET"
+    case .set: "HANDLE_SET"
+    }
+  }
+
+  /// Renders a "$get" part that can be used in a method signature representing this accessor.
+  public var renderMethodNameSegment: String {
+    switch self {
+    case .get: "$get"
+    case .set: "$set"
+    }
+  }
+}

--- a/Sources/JExtractSwift/ImportedDecls+Printing.swift
+++ b/Sources/JExtractSwift/ImportedDecls+Printing.swift
@@ -34,6 +34,14 @@ extension ImportedFunc {
 }
 
 extension VariableAccessorKind {
+
+  public var fieldSuffix: String {
+    switch self {
+      case .get: "_GET"
+      case .set: "_SET"
+    }
+  }
+
   public var renderDescFieldName: String {
     switch self {
     case .get: "DESC_GET"

--- a/Sources/JExtractSwift/ImportedDecls+Printing.swift
+++ b/Sources/JExtractSwift/ImportedDecls+Printing.swift
@@ -62,4 +62,33 @@ extension VariableAccessorKind {
     case .set: "$set"
     }
   }
+
+  func renderMethodName(_ decl: ImportedFunc) -> String? {
+    switch self {
+    case .get: "get\(decl.identifier.toCamelCase)"
+    case .set: "set\(decl.identifier.toCamelCase)"
+    }
+  }
+}
+
+extension Optional where Wrapped == VariableAccessorKind {
+  public var renderDescFieldName: String {
+    self?.renderDescFieldName ?? "DESC"
+  }
+
+  public var renderAddrFieldName: String {
+    self?.renderAddrFieldName ?? "ADDR"
+  }
+
+  public var renderHandleFieldName: String {
+    self?.renderHandleFieldName ?? "HANDLE"
+  }
+
+  public var renderMethodNameSegment: String {
+    self?.renderMethodNameSegment ?? ""
+  }
+
+  func renderMethodName(_ decl: ImportedFunc) -> String {
+    self?.renderMethodName(decl) ?? decl.baseIdentifier
+  }
 }

--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -15,6 +15,7 @@
 import Foundation
 import JavaTypes
 import SwiftSyntax
+import OrderedCollections
 
 /// Any imported (Swift) declaration
 protocol ImportedDecl {
@@ -232,13 +233,6 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
 public enum VariableAccessorKind {
   case get
   case set
-
-  public var renderDescFieldName: String {
-    switch self {
-    case .get: "DESC_GET"
-    case .set: "DESC_SET"
-    }
-  }
 }
 
 public struct ImportedVariable: ImportedDecl, CustomStringConvertible {
@@ -257,7 +251,7 @@ public struct ImportedVariable: ImportedDecl, CustomStringConvertible {
   /// Usually this will be all the accessors the variable declares,
   /// however if the getter is async or throwing we may not be able to import it
   /// (yet), and therefore would skip it from the supported set.
-  public var supportedAccessorKinds: Set<VariableAccessorKind> = [.get, .set]
+  public var supportedAccessorKinds: OrderedSet<VariableAccessorKind> = [.get, .set]
 
   /// This is the base identifier for the function, e.g., "init" for an
   /// initializer or "f" for "f(a:b:)".

--- a/Sources/JExtractSwift/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwift/Swift2JavaVisitor.swift
@@ -131,15 +131,13 @@ final class Swift2JavaVisitor: SyntaxVisitor {
   }
 
   override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-    self.log.warning("NODE: \(node.debugDescription)")
-
     guard let binding = node.bindings.first else {
       return .skipChildren
     }
 
     let fullName = "\(binding.pattern.trimmed)"
 
-    // TODO filter out kinds of variables we cannot import
+    // TODO: filter out kinds of variables we cannot import
 
     self.log.info("Import variable: \(node.kind) \(fullName)")
 

--- a/Sources/JExtractSwift/TranslatedType.swift
+++ b/Sources/JExtractSwift/TranslatedType.swift
@@ -234,6 +234,17 @@ public struct TranslatedType {
   }
 }
 
+extension TranslatedType {
+  public static var void: Self {
+    TranslatedType(
+      cCompatibleConvention: .direct,
+      originalSwiftType: "Void",
+      cCompatibleSwiftType: "Swift.Void",
+      cCompatibleJavaMemoryLayout: .primitive(.void),
+      javaType: JavaType.void)
+  }
+}
+
 /// Describes the C-compatible layout as it should be referenced from Java.
 enum CCompatibleJavaMemoryLayout {
   /// A primitive Java type that has a direct counterpart in C.

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -17,6 +17,7 @@ import Testing
 import struct Foundation.CharacterSet
 
 func assertOutput(
+  dump: Bool = false,
   _ got: String,
   expected: String,
   fileID: String = #fileID,
@@ -38,7 +39,7 @@ func assertOutput(
 
     let ge = g.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
     let ee = e.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-    if ge != ee {
+    if ge.commonPrefix(with: ee) != ee {
       //      print("")
       //      print("[\(file):\(line)] " + "Difference found on line: \(no + 1)!".red)
       //      print("Expected @ \(file):\(Int(line) + no + 3 /*formatting*/ + 1):")
@@ -55,15 +56,19 @@ func assertOutput(
 
   }
 
-  if diffLineNumbers.count > 0 {
+  let hasDiff = diffLineNumbers.count > 0
+  if hasDiff || dump{
     print("")
-    print("error: Number of not matching lines: \(diffLineNumbers.count)!".red)
+    if hasDiff {
+      print("error: Number of not matching lines: \(diffLineNumbers.count)!".red)
 
-    print("==== ---------------------------------------------------------------")
-    print("Expected output:")
-    for (n, e) in expectedLines.enumerated() {
-      print("\(e)".yellow(if: diffLineNumbers.contains(n)))
+      print("==== ---------------------------------------------------------------")
+      print("Expected output:")
+      for (n, e) in expectedLines.enumerated() {
+        print("\(e)".yellow(if: diffLineNumbers.contains(n)))
+      }
     }
+
     print("==== ---------------------------------------------------------------")
     print("Got output:")
     for (n, g) in gotLines.enumerated() {

--- a/Tests/JExtractSwiftTests/FuncImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncImportTests.swift
@@ -83,6 +83,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func helloWorld()
          * }
@@ -125,6 +126,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift: 
          * {@snippet lang=swift :
          * public func globalTakeInt(i: Int)
          * }
@@ -167,6 +169,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func globalTakeIntLongString(i32: Int32, l: Int64, s: String)
          * }
@@ -209,6 +212,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func helloMemberFunction()
          * }
@@ -251,6 +255,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func helloMemberInExtension()
          * }
@@ -293,6 +298,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func helloMemberFunction()
          * }
@@ -335,6 +341,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func helloMemberFunction()
          * }
@@ -369,6 +376,7 @@ final class MethodImportTests {
       expected:
         """
         /**
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public func makeInt() -> Int
          * }

--- a/Tests/JExtractSwiftTests/FuncImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncImportTests.swift
@@ -62,7 +62,7 @@ final class MethodImportTests {
     }
     """
 
-  @Test
+  @Test("Import: public func helloWorld()")
   func method_helloWorld() async throws {
     let st = Swift2JavaTranslator(
       javaPackage: "com.example.swift",
@@ -102,8 +102,8 @@ final class MethodImportTests {
     )
   }
 
-  @Test
-  func method_globalTakeInt() async throws {
+  @Test("Import: public func globalTakeInt(i: Int)")
+  func func_globalTakeInt() async throws {
     let st = Swift2JavaTranslator(
       javaPackage: "com.example.swift",
       swiftModuleName: "__FakeModule"
@@ -144,8 +144,8 @@ final class MethodImportTests {
     )
   }
 
-  @Test
-  func method_globalTakeIntLongString() async throws {
+  @Test("Import: public func globalTakeIntLongString(i32: Int32, l: Int64, s: String)")
+  func func_globalTakeIntLongString() async throws {
     let st = Swift2JavaTranslator(
       javaPackage: "com.example.swift",
       swiftModuleName: "__FakeModule"

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -162,8 +162,8 @@ extension FunctionDescriptorTests {
   }
 
   func variableAccessorDescriptorTest(
-    _ methodIdentifier: String,
-    _ kind: VariableAccessorKind,
+    _ identifier: String,
+    _ accessorKind: VariableAccessorKind,
     javaPackage: String = "com.example.swift",
     swiftModuleName: String = "SwiftModule",
     logLevel: Logger.Level = .trace,
@@ -180,15 +180,15 @@ extension FunctionDescriptorTests {
     let varDecl: ImportedVariable? =
       st.importedTypes.values.compactMap {
           $0.variables.first {
-            $0.identifier == methodIdentifier
+            $0.identifier == identifier
           }
         }.first
     guard let varDecl else {
-      fatalError("Cannot find descriptor of: \(methodIdentifier)")
+      fatalError("Cannot find descriptor of: \(identifier)")
     }
 
     let getOutput = CodePrinter.toString { printer in
-      st.printPropertyAccessorDescriptorValue(&printer, varDecl, kind)
+      st.printFunctionDescriptorValue(&printer, varDecl.accessorFunc(kind: accessorKind)!, accessorKind: accessorKind)
     }
 
     try await body(getOutput)

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -184,7 +184,7 @@ extension FunctionDescriptorTests {
           }
         }.first
     guard let varDecl else {
-      fatalError("Cannot find descriptor of: \(methodIdentifier)") as! ImportedVariable
+      fatalError("Cannot find descriptor of: \(methodIdentifier)")
     }
 
     let getOutput = CodePrinter.toString { printer in

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -117,6 +117,50 @@ final class VariableImportTests {
       public static MemorySegment counterInt$set$address() {
           return counterInt.ADDR_SET;
       }
+      /**
+       * Downcall to Swift:
+       * 
+       */
+      public static long getCounterInt(java.lang.foreign.MemorySegment self$) {
+          var mh$ = counterInt.HANDLE_GET;
+          try {
+              if (TRACE_DOWNCALLS) {
+                  traceDowncall(self$);
+              }
+              return (long) mh$.invokeExact(self$);
+          } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+          }
+      }
+      /**
+       * Downcall to Swift:
+       *
+       */
+      public long getCounterInt() {
+        return (long) getCounterInt($memorySegment());
+      }
+      /**
+       * Downcall to Swift:
+       *
+       */
+      public static void setCounterInt(long newValue, java.lang.foreign.MemorySegment self$) {
+        var mh$ = counterInt.HANDLE_SET;
+        try {
+          if (TRACE_DOWNCALLS) {
+             traceDowncall(newValue, self$);
+          }
+           mh$.invokeExact(newValue, self$);
+        } catch (Throwable ex$) {
+          throw new AssertionError("should not reach here", ex$);
+        }
+      }
+      /**
+       * Downcall to Swift:
+       *
+       */
+      public void setCounterInt(long newValue) {
+         setCounterInt(newValue, $memorySegment());
+      }
       """
     )
   }

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import JExtractSwift
+import Testing
+
+final class VariableImportTests {
+  let class_interfaceFile =
+    """
+    // swift-interface-format-version: 1.0
+    // swift-compiler-version: Apple Swift version 6.0 effective-5.10 (swiftlang-6.0.0.7.6 clang-1600.0.24.1)
+    // swift-module-flags: -target arm64-apple-macosx15.0 -enable-objc-interop -enable-library-evolution -module-name MySwiftLibrary
+    import Darwin.C
+    import Darwin
+    import Swift
+    import _Concurrency
+    import _StringProcessing
+    import _SwiftConcurrencyShims
+
+    public class MySwiftClass {
+      public var counterInt: Int
+    }
+    """
+
+  @Test("Import: var counter: Int")
+  func variable_() async throws {
+    let st = Swift2JavaTranslator(
+      javaPackage: "com.example.swift",
+      swiftModuleName: "__FakeModule"
+    )
+    st.log.logLevel = .error
+
+    try await st.analyze(swiftInterfacePath: "/fake/Fake.swiftinterface", text: class_interfaceFile)
+
+    let identifier = "counterInt"
+    let varDecl: ImportedVariable? =
+      st.importedTypes.values.compactMap {
+          $0.variables.first {
+            $0.identifier == identifier
+          }
+        }.first
+    guard let varDecl else {
+      fatalError("Cannot find: \(identifier)")
+    }
+
+    let output = CodePrinter.toString { printer in
+      st.printVariableDowncallMethods(&printer, varDecl)
+    }
+
+    assertOutput(
+      dump: true,
+      output,
+      expected:
+      """
+      // ==== --------------------------------------------------
+      // counterInt
+      private static class counterInt {
+        public static final FunctionDescriptor DESC_GET =   FunctionDescriptor.of(
+            /* -> */SWIFT_INT,
+            SWIFT_POINTER
+        );
+        public static final FunctionDescriptor DESC_SET =   FunctionDescriptor.ofVoid(
+            SWIFT_INT,
+            SWIFT_POINTER
+          );
+      }
+      /**
+       * Function descriptor for:
+       *
+       */
+      public static FunctionDescriptor counterInt$get$descriptor() {
+          return counterInt.DESC_GET;
+      }
+      /**
+       * Downcall method handle for:
+       *
+       */
+      public static MethodHandle counterInt$get$handle() {
+          return counterInt.HANDLE_GET;
+      }
+      /**
+       * Address for:
+       *
+       */
+      public static MemorySegment counterInt$get$address() {
+          return counterInt.ADDR_GET;
+      }
+      /**
+       * Function descriptor for:
+       *
+       */
+      public static FunctionDescriptor counterInt$set$descriptor() {
+          return counterInt.DESC_SET;
+      }
+      /**
+       * Downcall method handle for:
+       *
+       */
+      public static MethodHandle counterInt$set$handle() {
+          return counterInt.HANDLE_SET;
+      }
+      /**
+       * Address for:
+       *
+       */
+      public static MemorySegment counterInt$set$address() {
+          return counterInt.ADDR_SET;
+      }
+      """
+    )
+  }
+}

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -67,13 +67,17 @@ final class VariableImportTests {
       // counterInt
       private static class counterInt {
         public static final FunctionDescriptor DESC_GET =   FunctionDescriptor.of(
-            /* -> */SWIFT_INT,
-            SWIFT_POINTER
-        );
-        public static final FunctionDescriptor DESC_SET =   FunctionDescriptor.ofVoid(
-            SWIFT_INT,
+              /* -> */SWIFT_INT,
             SWIFT_POINTER
           );
+        public static final MemorySegment ADDR_GET = __FakeModule.findOrThrow("g");
+        public static final MethodHandle HANDLE_GET = Linker.nativeLinker().downcallHandle(ADDR_GET, DESC_GET);
+        public static final FunctionDescriptor DESC_SET =   FunctionDescriptor.ofVoid(
+          SWIFT_INT,
+            SWIFT_POINTER
+          );
+        public static final MemorySegment ADDR_SET = __FakeModule.findOrThrow("s");
+        public static final MethodHandle HANDLE_SET = Linker.nativeLinker().downcallHandle(ADDR_SET, DESC_SET);
       }
       /**
        * Function descriptor for:


### PR DESCRIPTION
Started progress on variables/properties.

- [x] function descriptors
- [x] addresses
- [x] getter downcall method
- [x] setter downcall method
- [ ] filter out async/throwing etc
- [ ] computed properties

Just the function descriptors for now, will do the complete thing in this PR.


Resolves https://github.com/swiftlang/swift-java/issues/24