### PR TITLE
Model Swift's type metadata and value witness table for memory layout information

### DIFF
--- a/JavaSwiftKitDemo/src/main/java/org/example/HelloJava2Swift.java
+++ b/JavaSwiftKitDemo/src/main/java/org/example/HelloJava2Swift.java
@@ -68,5 +68,11 @@ public class HelloJava2Swift {
 
         obj.voidMethod();
         obj.takeIntMethod(42);
+
+        MemorySegment swiftType = SwiftKit.getTypeByMangledNameInEnvironment("SiSg");
+        System.out.println("Memory layout for Swift.Int?:");
+        System.out.println("  size = " + SwiftKit.sizeOfSwiftType(swiftType));
+        System.out.println("  stride = " + SwiftKit.strideOfSwiftType(swiftType));
+        System.out.println("  alignment = " + SwiftKit.alignmentOfSwiftType(swiftType));
     }
 }

--- a/JavaSwiftKitDemo/src/main/java/org/example/HelloJava2Swift.java
+++ b/JavaSwiftKitDemo/src/main/java/org/example/HelloJava2Swift.java
@@ -74,5 +74,6 @@ public class HelloJava2Swift {
         System.out.println("  size = " + SwiftKit.sizeOfSwiftType(swiftType));
         System.out.println("  stride = " + SwiftKit.strideOfSwiftType(swiftType));
         System.out.println("  alignment = " + SwiftKit.alignmentOfSwiftType(swiftType));
+        System.out.println("  Java layout = " + SwiftKit.layoutOfSwiftType(swiftType));
     }
 }

--- a/JavaSwiftKitDemo/src/main/java/org/swift/javakit/SwiftKit.java
+++ b/JavaSwiftKitDemo/src/main/java/org/swift/javakit/SwiftKit.java
@@ -348,4 +348,23 @@ public class SwiftKit {
         long flags = getSwiftInt(valueWitnessTable(typeMetadata), valueWitnessTable$flags$offset);
         return (flags & 0xFF) + 1;
     }
+
+    /**
+     * Produce a layout that describes a Swift type based on its
+     * type metadata. The resulting layout is completely opaque to Java, but
+     * has appropriate size/alignment to model the memory associated with a
+     * Swift type.
+     *
+     * In the future, this layout could be extended to provide more detail,
+     * such as the fields of a Swift struct.
+     */
+    public static MemoryLayout layoutOfSwiftType(MemorySegment typeMetadata) {
+        long size = sizeOfSwiftType(typeMetadata);
+        long stride = strideOfSwiftType(typeMetadata);
+        return MemoryLayout.structLayout(
+            MemoryLayout.sequenceLayout(size, JAVA_BYTE)
+              .withByteAlignment(alignmentOfSwiftType(typeMetadata)),
+            MemoryLayout.paddingLayout(stride - size)
+        );
+    }
 }


### PR DESCRIPTION
Extend the Java SwiftKit with the ability to query the memory layout of an arbitrary Swift type given its Swift type metadata pointer (e.g., `Any.Type` in the Swift world). Use this to show the size, stride, and alignment of `Int?` from the Java side, determine the name of a Swift type from its metadata, and produce a [`java.lang.foreign.MemoryLayout`](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/foreign/MemoryLayout.html) for any Swift type. Here's some example output for the Swift type `Int?` (mangled name: `SiSg`):

    Memory layout for Swift.Int?:
      size = 9
      stride = 16
      alignment = 8
      Java layout = [8%[9:b1]x7](Swift.Optional<Swift.Int>)

