### PR TITLE
build: require swift 6 toolchain

### DIFF
--- a/JavaSwiftKitDemo/src/test/java/org/example/swift/SwiftKitTest.java
+++ b/JavaSwiftKitDemo/src/test/java/org/example/swift/SwiftKitTest.java
@@ -42,7 +42,7 @@ public class SwiftKitTest {
 
     @Test
     void call_retain_retainCount_release() {
-        var obj = MySwiftClass.init(1, 2);
+        var obj = new MySwiftClass(1, 2);
 
         assertEquals(1, SwiftKit.retainCount(obj.$memorySegment()));
         // TODO: test directly on SwiftHeapObject inheriting obj

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
@@ -119,16 +119,23 @@ let package = Package(
       dependencies: [
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+      ],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
       ]
     ),
     .target(
-      name: "JavaTypes"
+      name: "JavaTypes",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
     ),
     .target(
       name: "JavaKit",
       dependencies: ["JavaRuntime", "JavaKitMacros", "JavaTypes"],
       exclude: ["generated/JavaKit.swift2java"],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),
@@ -137,6 +144,7 @@ let package = Package(
       dependencies: ["JavaKit"],
       exclude: ["generated/JavaKitJar.swift2java"],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),
@@ -145,6 +153,7 @@ let package = Package(
       dependencies: ["JavaKit"],
       exclude: ["generated/JavaKitNetwork.swift2java"],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),
@@ -153,6 +162,7 @@ let package = Package(
       dependencies: ["JavaKit"],
       exclude: ["generated/JavaKitReflection.swift2java"],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),
@@ -160,6 +170,7 @@ let package = Package(
       name: "JavaKitVM",
       dependencies: ["JavaKit"],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ],
       linkerSettings: [
@@ -179,6 +190,7 @@ let package = Package(
       name: "JavaKitExample",
       dependencies: ["JavaKit"],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),
@@ -186,6 +198,7 @@ let package = Package(
     .target(
       name: "JavaRuntime",
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),
@@ -205,6 +218,7 @@ let package = Package(
         "JavaTypes",
       ],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .enableUpcomingFeature("BareSlashRegexLiterals")
       ]
     ),
@@ -216,6 +230,9 @@ let package = Package(
       dependencies: [
         "_SubprocessCShims",
         .product(name: "SystemPackage", package: "swift-system"),
+      ],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
       ]
     ),
     .target(
@@ -225,6 +242,9 @@ let package = Package(
           "_CRT_SECURE_NO_WARNINGS",
           .when(platforms: [.windows])
         )
+      ],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
       ]
     ),
 
@@ -237,6 +257,9 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         "_Subprocess",
         "JavaTypes",
+      ],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
       ]
     ),
 
@@ -244,17 +267,26 @@ let package = Package(
       name: "JExtractSwiftTool",
       dependencies: [
         "JExtractSwift",
+      ],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
       ]
     ),
 
     .testTarget(
       name: "JavaKitTests",
-      dependencies: ["JavaKit", "JavaKitNetwork", "JavaKitVM"]
+      dependencies: ["JavaKit", "JavaKitNetwork", "JavaKitVM"],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
     ),
 
     .testTarget(
       name: "JavaTypesTests",
-      dependencies: ["JavaTypes"]
+      dependencies: ["JavaTypes"],
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
     ),
 
     .testTarget(
@@ -263,6 +295,7 @@ let package = Package(
         "JExtractSwift"
       ],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
       ]
     ),


### PR DESCRIPTION
Since we require swift 6 anyway, we should reflect this in the
package.swift so it's more obvious when using an older swift to attempt
to build.