### PR TITLE
Package cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,25 +52,21 @@ let package = Package(
   products: [
     .library(
       name: "JavaKit",
-      type: .dynamic,
       targets: ["JavaKit"]
     ),
 
     .library(
       name: "JavaKitJar",
-      type: .dynamic,
       targets: ["JavaKitReflection"]
     ),
 
     .library(
       name: "JavaKitNetwork",
-      type: .dynamic,
       targets: ["JavaKitReflection"]
     ),
 
     .library(
       name: "JavaKitReflection",
-      type: .dynamic,
       targets: ["JavaKitReflection"]
     ),
 
@@ -82,19 +78,16 @@ let package = Package(
 
     .library(
       name: "JavaKitVM",
-      type: .dynamic,
       targets: ["JavaKitVM"]
     ),
 
     .library(
       name: "JavaTypes",
-      type: .dynamic,
       targets: ["JavaTypes"]
     ),
 
     .library(
       name: "JExtractSwift",
-      type: .dynamic,
       targets: ["JExtractSwift"]
     ),
 

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -19,7 +19,6 @@ import JavaKitJar
 import JavaKitNetwork
 import JavaKitReflection
 import JavaKitVM
-import JavaRuntime
 import SwiftSyntax
 import SwiftSyntaxBuilder
 

--- a/Sources/JavaKit/BridgedValues/JavaValue+Array.swift
+++ b/Sources/JavaKit/BridgedValues/JavaValue+Array.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import JavaRuntime
 import JavaTypes
 
 extension Array: JavaValue where Element: JavaValue {

--- a/Sources/JavaKit/BridgedValues/JavaValue+Bool.swift
+++ b/Sources/JavaKit/BridgedValues/JavaValue+Bool.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import JavaRuntime
 import JavaTypes
 
 extension Bool: JavaValue {

--- a/Sources/JavaKit/BridgedValues/JavaValue+FloatingPoint.swift
+++ b/Sources/JavaKit/BridgedValues/JavaValue+FloatingPoint.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import JavaRuntime
 import JavaTypes
 
 extension Float: JavaValue {

--- a/Sources/JavaKit/BridgedValues/JavaValue+Integers.swift
+++ b/Sources/JavaKit/BridgedValues/JavaValue+Integers.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import JavaRuntime
 import JavaTypes
 
 extension Int8: JavaValue {

--- a/Sources/JavaKit/BridgedValues/JavaValue+String.swift
+++ b/Sources/JavaKit/BridgedValues/JavaValue+String.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import JavaRuntime
 import JavaTypes
 
 extension String: JavaValue {

--- a/Sources/JavaKit/JavaRuntime+Reexport.swift
+++ b/Sources/JavaKit/JavaRuntime+Reexport.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import JavaRuntime

--- a/Sources/JavaKitVM/JavaVirtualMachine.swift
+++ b/Sources/JavaKitVM/JavaVirtualMachine.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import JavaKit
-import JavaRuntime
 
 typealias JavaVMPointer = UnsafeMutablePointer<JavaVM?>
 

--- a/Tests/JavaKitTests/BasicRuntimeTests.swift
+++ b/Tests/JavaKitTests/BasicRuntimeTests.swift
@@ -15,7 +15,6 @@
 import JavaKit
 import JavaKitNetwork
 import JavaKitVM
-import JavaRuntime
 import Testing
 
 @MainActor

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -57,7 +57,6 @@ Now, in the `HelloSwift` Swift library, define a `struct` that provides the `mai
 
 ```swift
 import JavaKit
-import JavaRuntime
 
 @JavaClass("org.swift.javakit.HelloSwiftMain")
 struct HelloSwiftMain {
@@ -87,7 +86,6 @@ The easiest way to build a command-line program in Swift is with the [Swift argu
 ```swift
 import ArgumentParser
 import JavaKit
-import JavaRuntime
 
 @JavaClass("org.swift.javakit.HelloSwiftMain")
 struct HelloSwiftMain: ParsableCommand {


### PR DESCRIPTION
Two small cleanups to the package itself to make it slightly easier to use:
* Re-export JavaRuntime from the JavaKit module
* Don't build everything as dynamic libraries. It's just the top-level Swift libraries (like the example code) that need to be dynamic