### PR TITLE
Improve lookup of JavaClass instances in an environment

### DIFF
--- a/Sources/JavaKit/AnyJavaObject.swift
+++ b/Sources/JavaKit/AnyJavaObject.swift
@@ -81,10 +81,12 @@ extension AnyJavaObject {
   }
 
   /// Retrieve the Java class for this type.
-  public static func getJNIClass(in environment: JNIEnvironment) -> jclass? {
-    return environment.interface.FindClass(
-      environment,
-      fullJavaClassNameWithSlashes
-    )
+  public static func getJNIClass(in environment: JNIEnvironment) throws -> jclass {
+    try environment.translatingJNIExceptions {
+      environment.interface.FindClass(
+        environment,
+        fullJavaClassNameWithSlashes
+      )
+    }!
   }
 }

--- a/Sources/JavaKit/Exceptions/ExceptionHandling.swift
+++ b/Sources/JavaKit/Exceptions/ExceptionHandling.swift
@@ -42,7 +42,7 @@ extension JNIEnvironment {
     // Otherwise, create a exception with a message.
     _ = interface.ThrowNew(
       self,
-      JavaClass<Exception>.getJNIClass(in: self),
+      try! JavaClass<Exception>.getJNIClass(in: self),
       String(describing: error)
     )
   }

--- a/Sources/JavaKit/JavaClass.swift
+++ b/Sources/JavaKit/JavaClass.swift
@@ -17,4 +17,12 @@ import JavaRuntime
 /// Wrapper around a Java class that provides access to the static members of
 /// the class.
 @JavaClass("java.lang.Class")
-public struct JavaClass<ObjectType: AnyJavaObject> { }
+public struct JavaClass<ObjectType: AnyJavaObject> {
+  /// Lookup this Java class within the given environment.
+  public init(in environment: JNIEnvironment) throws {
+    self.init(
+      javaThis: try ObjectType.getJNIClass(in: environment),
+      environment: environment
+    )
+  }
+}

--- a/Sources/JavaKit/JavaObject+Inheritance.swift
+++ b/Sources/JavaKit/JavaObject+Inheritance.swift
@@ -27,7 +27,7 @@ extension AnyJavaObject {
   private func isInstanceOf<OtherClass: AnyJavaObject>(
     _ otherClass: OtherClass.Type
   ) -> jclass? {
-    guard let otherJavaClass = otherClass.getJNIClass(in: javaEnvironment) else {
+    guard let otherJavaClass = try? otherClass.getJNIClass(in: javaEnvironment) else {
       return nil
     }
 

--- a/Sources/JavaKit/JavaObject+MethodCalls.swift
+++ b/Sources/JavaKit/JavaObject+MethodCalls.swift
@@ -247,7 +247,7 @@ extension AnyJavaObject {
     in environment: JNIEnvironment,
     arguments: repeat each Param
   ) throws -> Self {
-    let thisClass = Self.getJNIClass(in: environment)!
+    let thisClass = try Self.getJNIClass(in: environment)
 
     // Compute the method signature so we can find the right method, then look up the
     // method within the class.

--- a/Sources/JavaKit/Optional+JavaObject.swift
+++ b/Sources/JavaKit/Optional+JavaObject.swift
@@ -70,7 +70,7 @@ extension Optional: JavaValue where Wrapped: AnyJavaObject {
 
   public static func jniNewArray(in environment: JNIEnvironment) -> JNINewArray {
     return { environment, size in
-      let jniClass = Wrapped.getJNIClass(in: environment)
+      let jniClass = try! Wrapped.getJNIClass(in: environment)
       return environment.interface.NewObjectArray(environment, size, jniClass, nil)
     }
   }

--- a/Tests/JavaKitTests/BasicRuntimeTests.swift
+++ b/Tests/JavaKitTests/BasicRuntimeTests.swift
@@ -59,15 +59,23 @@ struct BasicRuntimeTests {
   }
 
   @Test("Static methods")
-  func staticMethods() {
-    let urlConnectionClass = JavaClass<URLConnection>(
-      javaThis: URLConnection.getJNIClass(in: jvm.environment)!,
-      environment: jvm.environment
-    )
-
+  func staticMethods() throws {
+    let urlConnectionClass = try JavaClass<URLConnection>(in: jvm.environment)
     #expect(urlConnectionClass.getDefaultAllowUserInteraction() == false)
   }
+
+  @Test("Class instance lookup")
+  func classInstanceLookup() throws {
+    do {
+      _ = try JavaClass<Nonexistent>(in: jvm.environment)
+    } catch {
+      #expect(String(describing: error) == "org/swift/javakit/Nonexistent")
+    }
+  }
 }
+
+@JavaClass("org.swift.javakit.Nonexistent")
+struct Nonexistent { }
 
 /// Whether we're running on Linux.
 var isLinux: Bool {


### PR DESCRIPTION
Teach the low-level getJNIClass API to properly check for Java exceptions and turn them into Swift errors. Then add a higher-level API `JavaClass.init(in:)` to look up a specific imported Java class within the given environment.