### PR TITLE
Add Support for Static Fields to Java2Swift tool

### DIFF
--- a/Sources/Java2Swift/JavaTranslator.swift
+++ b/Sources/Java2Swift/JavaTranslator.swift
@@ -347,23 +347,28 @@ extension JavaTranslator {
 
     // Format the class declaration.
     classDecl = classDecl.formatted(using: format).cast(DeclSyntax.self)
-      
-    // TODO: Handle static fields in https://github.com/swiftlang/swift-java/issues/39
-
-    if staticMethods.isEmpty {
+    
+    if staticMethods.isEmpty && staticFields.isEmpty {
       return [classDecl]
     }
 
     // Translate static members.
     var staticMembers: [DeclSyntax] = []
-    staticMembers.append(
-      contentsOf: javaClass.getMethods().compactMap {
-        $0.flatMap { method in
-          // Skip the instance methods; they were handled above.
-          if !method.isStatic {
-            return nil
-          }
 
+    staticMembers.append(
+      contentsOf: staticFields.compactMap { field in
+        // Translate each static field.
+        do {
+          return try translateField(field)
+        } catch {
+          logUntranslated("Unable to translate '\(fullName)' field '\(field.getName())': \(error)")
+          return nil
+        }
+      }
+    )
+    
+    staticMembers.append(
+      contentsOf: staticMethods.compactMap { method in
           // Translate each static method.
           do {
             return try translateMethod(
@@ -376,7 +381,6 @@ extension JavaTranslator {
             return nil
           }
         }
-      }
     )
 
     if staticMembers.isEmpty {
@@ -447,7 +451,7 @@ extension JavaTranslator {
     
   func translateField(_ javaField: Field) throws -> DeclSyntax {
     let typeName = try getSwiftTypeNameAsString(javaField.getGenericType()!, outerOptional: true)
-    let fieldAttribute: AttributeSyntax = "@JavaField";
+    let fieldAttribute: AttributeSyntax = javaField.isStatic ? "@JavaStaticField" : "@JavaField";
     return """
       \(fieldAttribute)
       public var \(raw: javaField.getName()): \(raw: typeName)

--- a/Sources/Java2Swift/JavaTranslator.swift
+++ b/Sources/Java2Swift/JavaTranslator.swift
@@ -257,7 +257,7 @@ extension JavaTranslator {
           do {
             return try translateField(field)
           } catch {
-            logUntranslated("Unable to translate '\(fullName)' field '\(field.getName())': \(error)")
+            logUntranslated("Unable to translate '\(fullName)' static field '\(field.getName())': \(error)")
             return nil
           }
         }

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -93,6 +93,21 @@ public macro JavaInterface(_ fullClassName: String, extends: (any AnyJavaObject.
 @attached(accessor)
 public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
 
+
+/// Attached macro that turns a Swift property into one that accesses a Java static field on the underlying Java object.
+///
+/// The macro must be used within a specific JavaClass instance.
+///
+/// ```swift
+/// @JavaClass("org.swift.example.HelloSwift")
+/// struct HelloSwift {
+///     @JavaField
+///     var counter: Int32
+/// }
+/// ```
+@attached(accessor)
+public macro StaticJavaField(_ javaFieldName: String? = nil) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
+
 /// Attached macro that turns a Swift method into one that wraps a Java method on the underlying Java object.
 ///
 /// The macro must be used in an AnyJavaObject-conforming type.

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -99,10 +99,9 @@ public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: 
 /// The macro must be used within a specific JavaClass instance.
 ///
 /// ```swift
-/// @JavaClass("org.swift.example.HelloSwift")
-/// struct HelloSwift {
-///     @JavaField
-///     var counter: Int32
+/// extension JavaClass<HelloSwift> {
+///   @JavaStaticField
+///   var initialValue: Double
 /// }
 /// ```
 @attached(accessor)

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -106,7 +106,7 @@ public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: 
 /// }
 /// ```
 @attached(accessor)
-public macro StaticJavaField(_ javaFieldName: String? = nil) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
+public macro JavaStaticField(_ javaFieldName: String? = nil) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
 
 /// Attached macro that turns a Swift method into one that wraps a Java method on the underlying Java object.
 ///

--- a/Sources/JavaKitExample/JavaKitExample.swift
+++ b/Sources/JavaKitExample/JavaKitExample.swift
@@ -103,13 +103,13 @@ struct HelloSwift {
 }
 
 extension JavaClass<HelloSwift> {
-  @JavaField
+  @JavaStaticField
   var initialValue: Double
 }
 
 @JavaClass("com.example.swift.HelloSubclass", extends: HelloSwift.self)
 struct HelloSubclass {
-  @JavaStaticField
+  @JavaField
   var greeting: String
 
   @JavaMethod

--- a/Sources/JavaKitExample/JavaKitExample.swift
+++ b/Sources/JavaKitExample/JavaKitExample.swift
@@ -109,7 +109,7 @@ extension JavaClass<HelloSwift> {
 
 @JavaClass("com.example.swift.HelloSubclass", extends: HelloSwift.self)
 struct HelloSubclass {
-  @JavaField
+  @JavaStaticField
   var greeting: String
 
   @JavaMethod


### PR DESCRIPTION
Closes #39 

This adds support to adding static fields to the Java2Swift tool. The issue recommends adding a `@JavaStaticField` macro, but it looks like due to the fact that the subscript created by the `JavaField` macro works for static properties when defined on a `JavaClass`, so I'm not sure a `@JavaStaticField` really buys anything here, so I'm open to removing it.

Same testing as in #55 (since that one also adds a static String).

I also noticed that we had a `staticMethods` array, but were re-requesting all methods in the `Java2Swift` tool when handling static methods, so I updated it to just use the `staticMethods` array to simplify the code a bit.