### PR TITLE
Skipping the JVM tests on macOS terminal since unreliable (crashes in JVM create)

### DIFF
--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -41,7 +41,7 @@ final class VariableImportTests {
     )
     st.log.logLevel = .error
 
-    try await st.analyze(swiftInterfacePath: "/fake/Fake.swiftinterface", text: class_interfaceFile)
+    try st.analyze(swiftInterfacePath: "/fake/Fake.swiftinterface", text: class_interfaceFile)
 
     let identifier = "counterInt"
     let varDecl: ImportedVariable? =
@@ -59,7 +59,6 @@ final class VariableImportTests {
     }
 
     assertOutput(
-      dump: true,
       output,
       expected:
       """


### PR DESCRIPTION
I don't have a good workaround and it's quite annoying to be unable to run tests on mac locally -- disabling them contextually for now. This is the problem described in https://github.com/swiftlang/swift-java/issues/43