### PR TITLE
Temporarily switch JavaKitTests target to XCTest

### DIFF
--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -41,7 +41,7 @@ final class VariableImportTests {
     )
     st.log.logLevel = .error
 
-    try st.analyze(swiftInterfacePath: "/fake/Fake.swiftinterface", text: class_interfaceFile)
+    try await st.analyze(swiftInterfacePath: "/fake/Fake.swiftinterface", text: class_interfaceFile)
 
     let identifier = "counterInt"
     let varDecl: ImportedVariable? =
@@ -59,6 +59,7 @@ final class VariableImportTests {
     }
 
     assertOutput(
+      dump: true,
       output,
       expected:
       """

--- a/Tests/JavaKitTests/BasicRuntimeTests.swift
+++ b/Tests/JavaKitTests/BasicRuntimeTests.swift
@@ -17,19 +17,13 @@ import JavaKitNetwork
 import JavaKitVM
 import Testing
 
-#if os(Linux)
-import Glibc
-#else
-import Darwin
-#endif
-
 @MainActor
 let jvm = try! JavaVirtualMachine(vmOptions: [])
 
 @Suite
 @MainActor
 struct BasicRuntimeTests {
-  @Test("Object management", .disabled(if: isMacOSTerminal || isLinux, "JVM creation fails occasionally in terminal on macOS, and some issues on Linux"))
+  @Test("Object management", .disabled(if: isLinux, "Attempts to refcount a null pointer on Linux"))
   func javaObjectManagement() throws {
     let sneakyJavaThis: jobject
     do {
@@ -55,7 +49,7 @@ struct BasicRuntimeTests {
     #expect(url.javaHolder === urlAgain.javaHolder)
   }
 
-  @Test("Java exceptions", .disabled(if: isMacOSTerminal || isLinux, "JVM creation fails occasionally in terminal on macOS, and some issues on Linux"))
+  @Test("Java exceptions", .disabled(if: isLinux, "Attempts to refcount a null pointer on Linux"))
   func javaExceptionsInSwift() throws {
     do {
       _ = try URL("bad url", environment: jvm.environment)
@@ -64,13 +58,13 @@ struct BasicRuntimeTests {
     }
   }
 
-  @Test("Static methods", .disabled(if: isMacOSTerminal || isLinux, "JVM creation fails occasionally in terminal on macOS, and some issues on Linux"))
+  @Test("Static methods", .disabled(if: isMacOS, "Fails on macOS command line"))
   func staticMethods() throws {
     let urlConnectionClass = try JavaClass<URLConnection>(in: jvm.environment)
     #expect(urlConnectionClass.getDefaultAllowUserInteraction() == false)
   }
 
-  @Test("Class instance lookup", .disabled(if: isMacOSTerminal || isLinux, "JVM creation fails occasionally in terminal on macOS, and some issues on Linux"))
+  @Test("Class instance lookup")
   func classInstanceLookup() throws {
     do {
       _ = try JavaClass<Nonexistent>(in: jvm.environment)
@@ -90,11 +84,6 @@ var isLinux: Bool {
   #else
   return false
   #endif
-}
-
-/// Whether we're running on MacOS in an interactive terminal session.
-var isMacOSTerminal: Bool {
-  isMacOS && isatty(STDOUT_FILENO) == 1
 }
 
 /// Whether we're running on MacOS.

--- a/Tests/JavaKitTests/BasicRuntimeTests.swift
+++ b/Tests/JavaKitTests/BasicRuntimeTests.swift
@@ -22,7 +22,7 @@ let jvm = try! JavaVirtualMachine(vmOptions: [])
 
 @MainActor
 class BasicRuntimeTests: XCTestCase {
-  func testJavaObjectManagement() throws {
+  func testJavaObjectManagement() async throws {
     if isLinux {
       throw XCTSkip("Attempts to refcount a null pointer on Linux")
     }
@@ -51,7 +51,7 @@ class BasicRuntimeTests: XCTestCase {
     XCTAssert(url.javaHolder === urlAgain.javaHolder)
   }
 
-  func testJavaExceptionsInSwift() throws {
+  func testJavaExceptionsInSwift() async throws {
     if isLinux {
       throw XCTSkip("Attempts to refcount a null pointer on Linux")
     }
@@ -63,7 +63,7 @@ class BasicRuntimeTests: XCTestCase {
     }
   }
 
-  func testStaticMethods() throws {
+  func testStaticMethods() async throws {
     if isLinux {
       throw XCTSkip("Attempts to refcount a null pointer on Linux")
     }
@@ -72,7 +72,7 @@ class BasicRuntimeTests: XCTestCase {
     XCTAssert(urlConnectionClass.getDefaultAllowUserInteraction() == false)
   }
 
-  func testClassInstanceLookup() throws {
+  func testClassInstanceLookup() async throws {
     do {
       _ = try JavaClass<Nonexistent>(in: jvm.environment)
     } catch {

--- a/Tests/JavaKitTests/BasicRuntimeTests.swift
+++ b/Tests/JavaKitTests/BasicRuntimeTests.swift
@@ -16,7 +16,6 @@ import JavaKit
 import JavaKitNetwork
 import JavaKitVM
 import Testing
-import Foundation
 
 #if os(Linux)
 import Glibc
@@ -95,10 +94,7 @@ var isLinux: Bool {
 
 /// Whether we're running on MacOS in an interactive terminal session.
 var isMacOSTerminal: Bool {
-  isMacOS && (
-    isatty(STDOUT_FILENO) == 1 ||
-    ProcessInfo.processInfo.environment["IS_TTY"] != nil // since 'swift test' still sometimes hides the fact we're in tty
-  )
+  isMacOS && isatty(STDOUT_FILENO) == 1
 }
 
 /// Whether we're running on MacOS.


### PR DESCRIPTION
Command-line testing on macOS is broken for the JavaKitTests due to an interaction between the Java Virtual Machine, a helper test process for swift-testing (`swiftpm-testing-helper`), and some macOS security features. Work around the issue by replacing our use of swift-testing with XCTest, whose helper process doesn't seem to have this problem. Only do so for test targets that need to spin up an instance of the JVM, and keep using swift-testing everywhere we can.

This makes me very sad, but is better than the current solution of disabling these tests when running from the terminal. Once we've found a solution for the underlying issue, we'll revert this change as get back to swift-testing and its much nicer testing output.

Fixes issue https://github.com/swiftlang/swift-java/issues/43 without disabling tests.