### PR TITLE
Rework makefile to split JavaKit targets from jextract-swift targets

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -106,6 +106,6 @@ jobs:
       # run the actual build
       - name: Generate sources (make) (Temporary)
         # TODO: this should be triggered by the respective builds
-        run: "make jextract-run"
+        run: "make jextract-generate"
       - name: Test Swift
         run: "swift test"

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,17 @@ endif
 
 SAMPLES_DIR := "Samples"
 
-all: generate-all
+all:
+	@echo "Welcome to swift-java! There are several makefile targets to choose from:"
+	@echo "  javakit-run: Run the JavaKit example program that uses Java libraries from Swift."
+	@echo "  javakit-generate: Regenerate the Swift wrapper code for the various JavaKit libraries from Java. This only has to be done when changing the Java2Swift tool."
+	@echo "  jextract-run: Run the Java example code that uses the wrapped Swift library. NOTE: this requires development toolchain described in the README."
+	@echo "  jextract-generate: Generate Java wrapper code for the example Swift library allowing Swift to be called from Java. NOTE: this requires development toolchain described in the README."
 
 $(BUILD_DIR)/debug/libJavaKit.$(LIB_SUFFIX) $(BUILD_DIR)/debug/Java2Swift:
 	swift build
 
-run: $(BUILD_DIR)/debug/libJavaKit.$(LIB_SUFFIX) $(BUILD_DIR)/debug/libExampleSwiftLibrary.$(LIB_SUFFIX)
+javakit-run: $(BUILD_DIR)/debug/libJavaKit.$(LIB_SUFFIX) $(BUILD_DIR)/debug/libExampleSwiftLibrary.$(LIB_SUFFIX)
 	./gradlew Samples:JavaKitSampleApp:run
 
 Java2Swift: $(BUILD_DIR)/debug/Java2Swift
@@ -79,8 +84,8 @@ generate-JavaKitNetwork: Java2Swift generate-JavaKit
 	mkdir -p Sources/JavaKitNetwork/generated
 	$(BUILD_DIR)/debug/Java2Swift --module-name JavaKitNetwork --manifests Sources/JavaKit/generated/JavaKit.swift2java -o Sources/JavaKitNetwork/generated java.net.URI java.net.URL java.net.URLClassLoader
 
-generate-all: generate-JavaKit generate-JavaKitReflection generate-JavaKitJar generate-JavaKitNetwork \
-			  jextract-swift
+javakit-generate: generate-JavaKit generate-JavaKitReflection generate-JavaKitJar generate-JavaKitNetwork
+
 clean:
 	rm -rf .build; \
 	rm -rf Samples/SwiftKitExampleApp/src/generated/java/*
@@ -112,11 +117,11 @@ jextract-swift: generate-JExtract-interface-files
 	swift build
 
 generate-JExtract-interface-files: $(BUILD_DIR)/debug/libJavaKit.$(LIB_SUFFIX)
-	echo "Generate .swiftinterface files..."
+	@echo "Generate .swiftinterface files..."
 	@$(call make_swiftinterface, "ExampleSwiftLibrary", "MySwiftLibrary")
 	@$(call make_swiftinterface, "SwiftKitSwift", "SwiftKit")
 
-jextract-run: jextract-swift generate-JExtract-interface-files
+jextract-generate: jextract-swift generate-JExtract-interface-files
 	swift run jextract-swift  \
 		--package-name com.example.swift.generated \
 		--swift-module ExampleSwiftLibrary \
@@ -129,5 +134,5 @@ jextract-run: jextract-swift generate-JExtract-interface-files
 		$(BUILD_DIR)/jextract/SwiftKitSwift/SwiftKit.swiftinterface
 
 
-jextract-run-java: jextract-swift generate-JExtract-interface-files
+jextract-run: jextract-generate generate-JExtract-interface-files
 	./gradlew Samples:SwiftKitSampleApp:run

--- a/Makefile
+++ b/Makefile
@@ -134,5 +134,5 @@ jextract-generate: jextract-swift generate-JExtract-interface-files
 		$(BUILD_DIR)/jextract/SwiftKitSwift/SwiftKit.swiftinterface
 
 
-jextract-run: jextract-generate generate-JExtract-interface-files
+jextract-run: jextract-generate
 	./gradlew Samples:SwiftKitSampleApp:run

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ This project contains quite a few builds, Swift, Java, and depends on some custo
 Easiest way to get going is to:
 
 ```bash
-make
+make javakit-run # Run the JavaKit example of Swift code using Java libraries
+make jextract-run # Run the jextract-swift example of Java code using Swift libraries
 swift test # test all Swift code, e.g. jextract-swift
 ./gradlew test # test all Java code, including integration tests that actually use jextract-ed sources
 ```

--- a/Samples/SwiftKitSampleApp/build.gradle
+++ b/Samples/SwiftKitSampleApp/build.gradle
@@ -103,7 +103,7 @@ task jextract(type: Exec) {
 
     workingDir = rootDir
     commandLine "make"
-    args "jextract-run"
+    args "jextract-generate"
 }
 
 tasks.named("compileGeneratedJava").configure {

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -33,11 +33,11 @@ services:
 
   test-java:
     <<: *common
-    command: /bin/bash -xcl "uname -a && swift -version && java -version && make jextract-run && ./gradlew test --debug"
+    command: /bin/bash -xcl "uname -a && swift -version && java -version && make jextract-generate && ./gradlew test --debug"
 
   test:
     <<: *common
-    command: /bin/bash -xcl "uname -a && swift -version && java -version && make jextract-run && swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} && ./gradlew test --debug"
+    command: /bin/bash -xcl "uname -a && swift -version && java -version && make jextract-generate && swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} && ./gradlew test --debug"
 
   # util
 


### PR DESCRIPTION
The JavaKit targets (Swift calling into Java via JNI) have fewer requirements (for JVM installations and development toolchains) and are a bit easier to get started with. Split those targets out, and turn `make` with no specified target into a little help target.

Fixes issue #68.