### PR TITLE
java2swift: add non-optional-returning `as` function to `JavaClassMacro`

### DIFF
--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -37,7 +37,8 @@
   named(javaThis),
   named(javaEnvironment),
   named(init(javaHolder:)),
-  named(JavaSuperclass)
+  named(JavaSuperclass),
+  named(as)
 )
 @attached(extension, conformances: AnyJavaObject)
 @attached(peer)
@@ -73,7 +74,8 @@ public macro JavaClass(
   named(javaThis),
   named(javaEnvironment),
   named(init(javaHolder:)),
-  named(JavaSuperclass)
+  named(JavaSuperclass),
+  named(as)
 )
 @attached(extension, conformances: AnyJavaObject)
 public macro JavaInterface(_ fullClassName: String, extends: (any AnyJavaObject.Type)?...) =

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -38,7 +38,7 @@
   named(javaEnvironment),
   named(init(javaHolder:)),
   named(JavaSuperclass),
-  named(as)
+  named(`as`)
 )
 @attached(extension, conformances: AnyJavaObject)
 @attached(peer)
@@ -75,7 +75,7 @@ public macro JavaClass(
   named(javaEnvironment),
   named(init(javaHolder:)),
   named(JavaSuperclass),
-  named(as)
+  named(`as`)
 )
 @attached(extension, conformances: AnyJavaObject)
 public macro JavaInterface(_ fullClassName: String, extends: (any AnyJavaObject.Type)?...) =

--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -88,9 +88,9 @@ extension JavaClassMacro: MemberMacro {
       """
 
     let nonOptionalAs: DeclSyntax = """
-      /// It's not checking anything.
-      public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
-          return OtherClass(javaHolder: javaHolder)
+      /// Casting to <\(raw: superclass)> will never be nil because <\(raw: className.split(separator: ".").last!)> extends it.
+      public func `as`(_: \(raw: superclass)) -> \(raw: superclass) {
+          return \(raw: superclass)(javaHolder: javaHolder)
       }
       """
 

--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -88,6 +88,7 @@ extension JavaClassMacro: MemberMacro {
       """
 
     let nonOptionalAs: DeclSyntax = """
+      /// It's not checking anything.
       public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
           return OtherClass(javaHolder: javaHolder)
       }

--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -89,7 +89,7 @@ extension JavaClassMacro: MemberMacro {
 
     let nonOptionalAs: DeclSyntax = """
       /// Casting to ``\(raw: superclass)`` will never be nil because ``\(raw: className.split(separator: ".").last!)`` extends it.
-      public func `as`(_: \(raw: superclass).type) -> \(raw: superclass) {
+      public func `as`(_: \(raw: superclass).Type) -> \(raw: superclass) {
           return \(raw: superclass)(javaHolder: javaHolder)
       }
       """

--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -87,6 +87,12 @@ extension JavaClassMacro: MemberMacro {
       }
       """
 
+    let nonOptionalAs: DeclSyntax = """
+      public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
+          return OtherClass(javaHolder: javaHolder)
+      }
+      """
+
     return [
       fullJavaClassNameMember,
       superclassTypealias,
@@ -94,6 +100,7 @@ extension JavaClassMacro: MemberMacro {
       javaThisMember,
       javaEnvironmentMember,
       initMember,
+      nonOptionalAs,
     ]
   }
 }

--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -88,8 +88,8 @@ extension JavaClassMacro: MemberMacro {
       """
 
     let nonOptionalAs: DeclSyntax = """
-      /// Casting to <\(raw: superclass)> will never be nil because <\(raw: className.split(separator: ".").last!)> extends it.
-      public func `as`(_: \(raw: superclass)) -> \(raw: superclass) {
+      /// Casting to ``\(raw: superclass)`` will never be nil because ``\(raw: className.split(separator: ".").last!)`` extends it.
+      public func `as`(_: \(raw: superclass).type) -> \(raw: superclass) {
           return \(raw: superclass)(javaHolder: javaHolder)
       }
       """

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -79,6 +79,7 @@ class JavaKitMacroTests: XCTestCase {
                 self.javaHolder = javaHolder
             }
 
+            /// It's not checking anything.
             public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
                 return OtherClass(javaHolder: javaHolder)
             }

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -79,9 +79,9 @@ class JavaKitMacroTests: XCTestCase {
                 self.javaHolder = javaHolder
             }
 
-            /// It's not checking anything.
-            public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
-                return OtherClass(javaHolder: javaHolder)
+            /// Casting to <JavaObject> will never be nil because <HelloWorld> extends it.
+            public func `as`(_: JavaObject) -> JavaObject {
+                return JavaObject(javaHolder: javaHolder)
             }
         }
       """,

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -79,8 +79,8 @@ class JavaKitMacroTests: XCTestCase {
                 self.javaHolder = javaHolder
             }
 
-            /// Casting to <JavaObject> will never be nil because <HelloWorld> extends it.
-            public func `as`(_: JavaObject) -> JavaObject {
+            /// Casting to ``JavaObject`` will never be nil because ``HelloWorld`` extends it.
+            public func `as`(_: JavaObject.type) -> JavaObject {
                 return JavaObject(javaHolder: javaHolder)
             }
         }

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -78,6 +78,10 @@ class JavaKitMacroTests: XCTestCase {
             public init(javaHolder: JavaObjectHolder) {
                 self.javaHolder = javaHolder
             }
+
+            public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
+                return OtherClass(javaHolder: javaHolder)
+            }
         }
       """,
       macros: Self.javaKitMacros

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -80,7 +80,7 @@ class JavaKitMacroTests: XCTestCase {
             }
 
             /// Casting to ``JavaObject`` will never be nil because ``HelloWorld`` extends it.
-            public func `as`(_: JavaObject.type) -> JavaObject {
+            public func `as`(_: JavaObject.Type) -> JavaObject {
                 return JavaObject(javaHolder: javaHolder)
             }
         }


### PR DESCRIPTION
closes #20 