### PR TITLE
java2swift: Add Support for Enum Cases

### DIFF
--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -241,14 +241,14 @@ extension JavaTranslator {
             staticFields.append(field)
 
             if field.isEnumConstant() {
-              return "public static let \(raw: field.getName()) = try! JavaClass<Self>(environment: JavaVirtualMachine.environment()).\(raw: field.getName())"
+              return "public static let \(raw: field.getName()) = try! JavaClass<Self>(in: JavaVirtualMachine.shared().environment()).\(raw: field.getName())!"
             } else {
               return nil
             }
           }
           
           do {
-            return try translateField(field, isOptional: true)
+            return try translateField(field)
           } catch {
             logUntranslated("Unable to translate '\(fullName)' static field '\(field.getName())': \(error)")
             return nil
@@ -353,7 +353,7 @@ extension JavaTranslator {
         // Translate each static field.
         do {
           // Enum constants are guaranteed to not be optional
-          return try translateField(field, isOptional: !field.isEnumConstant())
+          return try translateField(field)
         } catch {
           logUntranslated("Unable to translate '\(fullName)' field '\(field.getName())': \(error)")
           return nil
@@ -443,8 +443,8 @@ extension JavaTranslator {
       """
   }
     
-  package func translateField(_ javaField: Field, isOptional: Bool) throws -> DeclSyntax {
-    let typeName = try getSwiftTypeNameAsString(javaField.getGenericType()!, outerOptional: isOptional)
+  package func translateField(_ javaField: Field) throws -> DeclSyntax {
+    let typeName = try getSwiftTypeNameAsString(javaField.getGenericType()!, outerOptional: true)
     let fieldAttribute: AttributeSyntax = javaField.isStatic ? "@JavaStaticField" : "@JavaField";
     let swiftFieldName = javaField.getName().escapedSwiftName
     return """

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -77,7 +77,6 @@ extension JavaTranslator {
   package static let defaultTranslatedClasses: [String: (swiftType: String, swiftModule: String?, isOptional: Bool)] = [
     "java.lang.Class": ("JavaClass", "JavaKit", true),
     "java.lang.String": ("String", "JavaKit", false),
-    "java.lang.Object": ("JavaObject", "JavaKit", true)
   ]
 }
 

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -484,17 +484,16 @@ extension JavaTranslator {
     """
 
     let initSyntax: DeclSyntax = """
-    public init?(_ enumValue: \(raw: name), environment: JNIEnvironment) throws {
-      let classObj = try JavaClass<Self>(in: environment)
+    public init(_ enumValue: \(raw: name), environment: JNIEnvironment) {
+      let classObj = try! JavaClass<Self>(in: environment)
       switch enumValue {
     \(raw: enumFields.map {
-      let caseName = $0.getName()
       return """
-          case .\(caseName):
-            if let \(caseName) = classObj.\(caseName) {
-              self = \(caseName)
+          case .\($0.getName()):
+            if let \($0.getName()) = classObj.\($0.getName()) {
+              self = \($0.getName())
             } else {
-              return nil
+              fatalError("Enum value \($0.getName()) was unexpectedly nil, please re-run Java2Swift on the most updated Java class") 
             }
       """
     }.joined(separator: "\n"))

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -62,9 +62,18 @@ class Java2SwiftTests: XCTestCase {
         "case APRIL",
         "public var enumValue: MonthCases?",
         """
-            } else if self.equals(self.javaClass.APRIL?.as(JavaObject.self)) {
+            } else if self.equals(classObj.APRIL?.as(JavaObject.self)) {
               return MonthCases.APRIL
             }
+        """,
+        "public init?(_ enumValue: MonthCases, environment: JNIEnvironment) throws {",
+        """
+              case .APRIL:
+                if let APRIL = classObj.APRIL {
+                  self = APRIL
+                } else {
+                  return nil
+                }
         """,
         """
           @JavaStaticField

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -24,6 +24,11 @@ var jvm: JavaVirtualMachine {
   }
 }
 
+@JavaClass("java.time.Month")
+public struct JavaMonth {
+
+}
+
 class Java2SwiftTests: XCTestCase {
   func testJavaLangObjectMapping() throws {
     try assertTranslatedClass(
@@ -45,6 +50,20 @@ class Java2SwiftTests: XCTestCase {
         """
       ]
     )
+  }
+
+  func testEnum() async throws {
+    try assertTranslatedClass(
+      JavaMonth.self,
+      swiftTypeName: "Month",
+      expectedChunks: [
+        "import JavaKit",
+        "public static let APRIL = try! JavaClass<Self>(environment: JavaVirtualMachine.environment()).APRIL",
+        """
+          @JavaStaticField
+          public var APRIL: Month
+        """
+      ])
   }
 
   func testGenericCollections() throws {

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -58,7 +58,14 @@ class Java2SwiftTests: XCTestCase {
       swiftTypeName: "Month",
       expectedChunks: [
         "import JavaKit",
-        "public static let APRIL = try! JavaClass<Self>(in: JavaVirtualMachine.shared().environment()).APRIL!",
+        "enum MonthCases: Equatable",
+        "case APRIL",
+        "public var enumValue: MonthCases?",
+        """
+            } else if self.equals(self.javaClass.APRIL?.as(JavaObject.self)) {
+              return MonthCases.APRIL
+            }
+        """,
         """
           @JavaStaticField
           public var APRIL: Month?

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -145,7 +145,6 @@ func assertTranslatedClass<JavaClassType: AnyJavaObject>(
     """
 
   for expectedChunk in expectedChunks {
-    print(swiftFileText)
     if swiftFileText.contains(expectedChunk) {
       continue
     }

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -58,10 +58,10 @@ class Java2SwiftTests: XCTestCase {
       swiftTypeName: "Month",
       expectedChunks: [
         "import JavaKit",
-        "public static let APRIL = try! JavaClass<Self>(environment: JavaVirtualMachine.environment()).APRIL",
+        "public static let APRIL = try! JavaClass<Self>(in: JavaVirtualMachine.shared().environment()).APRIL!",
         """
           @JavaStaticField
-          public var APRIL: Month
+          public var APRIL: Month?
         """
       ])
   }
@@ -145,6 +145,7 @@ func assertTranslatedClass<JavaClassType: AnyJavaObject>(
     """
 
   for expectedChunk in expectedChunks {
+    print(swiftFileText)
     if swiftFileText.contains(expectedChunk) {
       continue
     }

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -66,13 +66,13 @@ class Java2SwiftTests: XCTestCase {
               return MonthCases.APRIL
             }
         """,
-        "public init?(_ enumValue: MonthCases, environment: JNIEnvironment) throws {",
+        "public init(_ enumValue: MonthCases, environment: JNIEnvironment) {",
         """
               case .APRIL:
                 if let APRIL = classObj.APRIL {
                   self = APRIL
                 } else {
-                  return nil
+                  fatalError("Enum value APRIL was unexpectedly nil, please re-run Java2Swift on the most updated Java class")
                 }
         """,
         """


### PR DESCRIPTION
Closes #21 
Adds a few nice pieces of support for enums:
1. Adds static properties on the main struct so we can have the static member dot syntax (i.e. `.APRIL` for april static property on Month). 

There are a few things we could improve here related to the static properties that I'm interested to see if we should update:
1. Update the SNAKE_CASE static properties to lower camel case to be more _swifty_
2. Right now to get the environment we have a `try!` which is likely not great. If the programmer already is using the `java-swift` work, they likely have the JVM all set up, so this should be fine, but if not, we might want to remove the static properties or come up with another way of creating the environment statically that is not failing (if that is even possible)
3. We also need to add a force unwrap here since the java field won't compile with a non-optional value

Open Question the I'm unsure of:
- [ ] Should we add an `Equatable` conformance for these using the `equals` function, so that we can get a good implementation of `~=` for switch statements?
- [ ] Should we add an `~=` implementation itself (possibly also using `equals`)?