### PR TITLE
Include Swift samples/ in Ci verification

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,4 +108,4 @@ jobs:
         run: "swift test"
       - name: Build (Swift) Sample Apps
         run: |
-          find Samples/ -name Package.swift -depth 2 -exec swift build --package-path $(dirname {}) \;;
+          find Samples/ -name Package.swift -maxdepth 2 -exec swift build --package-path $(dirname {}) \;;

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -106,3 +106,6 @@ jobs:
         run: "make jextract-generate"
       - name: Test Swift
         run: "swift test"
+      - name: Build (Swift) Sample Apps
+        run: |
+          find Samples/ -name Package.swift -depth 2 -exec swift build --package-path $(dirname {}) \;;


### PR DESCRIPTION
At the very least we'll know that they continue building.

This does a `swift build` for every Sample that has a `Package.swift`