### PR TITLE
Java2Swift improvements for producing configuration files from Jar files

### DIFF
--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -247,6 +247,11 @@ struct JavaToSwift: ParsableCommand {
         }
       }
 
+      // TODO: For now, skip all nested classes.
+      if entry.getName().contains("$") {
+        continue
+      }
+
       let javaCanonicalName = String(entry.getName().replacing("/", with: ".")
         .dropLast(".class".count))
       configuration.classes[javaCanonicalName] =

--- a/Sources/Java2SwiftLib/JavaTranslator+Configuration.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator+Configuration.swift
@@ -16,18 +16,14 @@ import Foundation
 
 extension JavaTranslator {
   /// Read a configuration file from the given URL.
-  package func readConfiguration(from url: URL) throws -> Configuration {
+  package static func readConfiguration(from url: URL) throws -> Configuration {
     let contents = try Data(contentsOf: url)
     return try JSONDecoder().decode(Configuration.self, from: contents)
   }
 
   /// Load the configuration file with the given name to populate the known set of
   /// translated Java classes.
-  package func loadDependentConfiguration(forSwiftModule swiftModule: String, from url: URL) throws {
-    let config = try readConfiguration(from: url)
-
-    // TODO: Should we merge the class path from our dependencies?
-
+  package func addConfiguration(_ config: Configuration, forSwiftModule swiftModule: String) {
     for (javaClassName, swiftName) in config.classes {
       translatedClasses[javaClassName] = (
         swiftType: swiftName,

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -429,20 +429,21 @@ extension JavaTranslator {
     }
 
     let throwsStr = javaMethod.throwsCheckedException ? "throws" : ""
-
+    let swiftMethodName = javaMethod.getName().escapedSwiftName
     let methodAttribute: AttributeSyntax = javaMethod.isStatic ? "@JavaStaticMethod" : "@JavaMethod";
     return """
       \(methodAttribute)
-      public func \(raw: javaMethod.getName())\(raw: genericParameterClause)(\(raw: parametersStr))\(raw: throwsStr)\(raw: resultTypeStr)\(raw: whereClause)
+      public func \(raw: swiftMethodName)\(raw: genericParameterClause)(\(raw: parametersStr))\(raw: throwsStr)\(raw: resultTypeStr)\(raw: whereClause)
       """
   }
     
   package func translateField(_ javaField: Field) throws -> DeclSyntax {
     let typeName = try getSwiftTypeNameAsString(javaField.getGenericType()!, outerOptional: true)
     let fieldAttribute: AttributeSyntax = javaField.isStatic ? "@JavaStaticField" : "@JavaField";
+    let swiftFieldName = javaField.getName().escapedSwiftName
     return """
       \(fieldAttribute)
-      public var \(raw: javaField.getName()): \(raw: typeName)
+      public var \(raw: swiftFieldName): \(raw: typeName)
       """
   }
 

--- a/Sources/Java2SwiftLib/StringExtras.swift
+++ b/Sources/Java2SwiftLib/StringExtras.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import SwiftParser
 
 extension String {
   /// Split the Swift type name into parent type + innermost type name.
@@ -23,5 +24,14 @@ extension String {
       parentType: String(self[startIndex..<lastDot]),
       name: String(suffix(from: index(after: lastDot)))
     )
+  }
+
+  /// Escape a name with backticks if it's a Swift keyword.
+  var escapedSwiftName: String {
+    if isValidSwiftIdentifier(for: .variableName) {
+      return self
+    }
+
+    return "`\(self)`"
   }
 }

--- a/Sources/JavaKitNetwork/Java2Swift.config
+++ b/Sources/JavaKitNetwork/Java2Swift.config
@@ -1,0 +1,7 @@
+{
+  "classes" : {
+    "java.net.URI" : "URI",
+    "java.net.URL" : "URL",
+    "java.net.URLClassLoader" : "URLClassLoader"
+  }
+}

--- a/Sources/JavaKitReflection/Java2Swift.config
+++ b/Sources/JavaKitReflection/Java2Swift.config
@@ -1,0 +1,18 @@
+{
+  "classes" : {
+    "java.lang.annotation.Annotation" : "Annotation",
+    "java.lang.reflect.AccessibleObject" : "AccessibleObject",
+    "java.lang.reflect.AnnotatedType" : "AnnotatedType",
+    "java.lang.reflect.Constructor" : "Constructor",
+    "java.lang.reflect.Executable" : "Executable",
+    "java.lang.reflect.Field" : "Field",
+    "java.lang.reflect.GenericArrayType" : "GenericArrayType",
+    "java.lang.reflect.GenericDeclaration" : "GenericDeclaration",
+    "java.lang.reflect.Method" : "Method",
+    "java.lang.reflect.Parameter" : "Parameter",
+    "java.lang.reflect.ParameterizedType" : "ParameterizedType",
+    "java.lang.reflect.Type" : "Type",
+    "java.lang.reflect.TypeVariable" : "TypeVariable",
+    "java.lang.reflect.WildcardType" : "WildcardType"
+  }
+}

--- a/Sources/JavaKitVM/JavaVirtualMachine.swift
+++ b/Sources/JavaKitVM/JavaVirtualMachine.swift
@@ -45,7 +45,7 @@ public final class JavaVirtualMachine: @unchecked Sendable {
   private init(
     classPath: [String] = [],
     vmOptions: [String] = [],
-    ignoreUnrecognized: Bool = true
+    ignoreUnrecognized: Bool = false
   ) throws {
     var jvm: JavaVMPointer? = nil
     var environment: UnsafeMutableRawPointer? = nil
@@ -176,7 +176,7 @@ extension JavaVirtualMachine {
   public static func shared(
     classPath: [String] = [],
     vmOptions: [String] = [],
-    ignoreUnrecognized: Bool = true
+    ignoreUnrecognized: Bool = false
   ) throws -> JavaVirtualMachine {
     try sharedJVM.withLock { (sharedJVMPointer: inout JavaVirtualMachine?) in
       // If we already have a JavaVirtualMachine instance, return it.


### PR DESCRIPTION
Improve the experience of producing `Java2Swift.config` files from Jar files and better cope with layers of Swift-wrapped Java libraries. This includes:

* Filtering out nested classes from Jar files, since we cannot handle them yet
* Combining the class paths from all of the dependent `Java2Swift.config` files with the one being used and providing those to the JVM instance
* Fixing an issue where Java2Swift would generate `func init()` for a Java method named `init`