### PR TITLE
Manually exclude Java2Swift.config files from targets that don't use the plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,7 @@ let package = Package(
     .target(
       name: "JavaKit",
       dependencies: ["JavaRuntime", "JavaKitMacros", "JavaTypes"],
+      exclude: ["Java2Swift.config"],
       swiftSettings: [
         .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
@@ -168,6 +169,7 @@ let package = Package(
     .target(
       name: "JavaKitJar",
       dependencies: ["JavaKit"],
+      exclude: ["Java2Swift.config"],
       swiftSettings: [
         .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
@@ -176,6 +178,7 @@ let package = Package(
     .target(
       name: "JavaKitNetwork",
       dependencies: ["JavaKit"],
+      exclude: ["Java2Swift.config"],
       swiftSettings: [
         .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])
@@ -184,6 +187,7 @@ let package = Package(
     .target(
       name: "JavaKitReflection",
       dependencies: ["JavaKit"],
+      exclude: ["Java2Swift.config"],
       swiftSettings: [
         .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"])


### PR DESCRIPTION
This eliminates warnings about the Java2Swift.config files being "unhandled". SwiftPM is correct to warn here, because the files aren't used from SwiftPM themselves (we're not using the build plugin to generate them).