### PR TITLE
Reduce package requirements down to macOS 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,11 +43,7 @@ let javaIncludePath = "\(javaHome)/include"
 let package = Package(
   name: "JavaKit",
   platforms: [
-    .macOS(.v13),
-    .iOS(.v13),
-    .tvOS(.v13),
-    .watchOS(.v6),
-    .macCatalyst(.v13),
+    .macOS(.v10_15)
   ],
   products: [
     // ==== JavaKit (i.e. calling Java directly Swift utilities)

--- a/Samples/JavaProbablyPrime/Package.swift
+++ b/Samples/JavaProbablyPrime/Package.swift
@@ -7,11 +7,7 @@ import PackageDescription
 let package = Package(
   name: "JavaProbablyPrime",
   platforms: [
-    .macOS(.v13),
-    .iOS(.v13),
-    .tvOS(.v13),
-    .watchOS(.v6),
-    .macCatalyst(.v13),
+    .macOS(.v10_15),
   ],
 
   products: [

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -78,7 +78,7 @@ extension Swift2JavaTranslator {
     let targetFilePath = [javaPackagePath, filename].joined(separator: PATH_SEPARATOR)
     print("Writing '\(targetFilePath)'...", terminator: "")
     try contents.write(
-      to: Foundation.URL(filePath: targetDirectory).appending(path: filename),
+      to: Foundation.URL(fileURLWithPath: targetDirectory).appendingPathComponent(filename),
       atomically: true,
       encoding: .utf8
     )

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -75,7 +75,7 @@ struct JavaToSwift: ParsableCommand {
     if jarFile {
       generationMode = .configuration(jarFile: input)
     } else {
-      let config = try JavaTranslator.readConfiguration(from: URL(filePath: input))
+      let config = try JavaTranslator.readConfiguration(from: URL(fileURLWithPath: input))
       generationMode = .classWrappers(config)
     }
 
@@ -90,7 +90,7 @@ struct JavaToSwift: ParsableCommand {
       let swiftModuleName = String(dependentConfig[..<equalLoc])
       let configFileName = String(dependentConfig[afterEqual...])
 
-      let config = try JavaTranslator.readConfiguration(from: URL(filePath: configFileName))
+      let config = try JavaTranslator.readConfiguration(from: URL(fileURLWithPath: configFileName))
 
       return (swiftModuleName, config)
     }
@@ -218,7 +218,7 @@ struct JavaToSwift: ParsableCommand {
 
     print("Writing \(description) to '\(filename)'...", terminator: "")
     try contents.write(
-      to: Foundation.URL(filePath: outputDirectory).appending(path: filename),
+      to: Foundation.URL(fileURLWithPath: outputDirectory).appendingPathComponent(filename),
       atomically: true,
       encoding: .utf8
     )
@@ -242,7 +242,7 @@ struct JavaToSwift: ParsableCommand {
       // If any of the segments of the Java name start with a number, it's a
       // local class that cannot be mapped into Swift.
       for segment in entry.getName().split(separator: "$") {
-        if segment.starts(with: /\d/) {
+        if let firstChar = segment.first, firstChar.isNumber {
           continue
         }
       }

--- a/Sources/Java2SwiftLib/StringExtras.swift
+++ b/Sources/Java2SwiftLib/StringExtras.swift
@@ -34,4 +34,9 @@ extension String {
 
     return "`\(self)`"
   }
+
+  /// Replace all occurrences of one character in the string with another.
+  public func replacing(_ character: Character, with replacement: Character) -> String {
+    return replacingOccurrences(of: String(character), with: String(replacement))
+  }
 }


### PR DESCRIPTION
We were only using a handful of APIs introduced in macOS 13. Switch away from (or reimplement) those, and drop the package requirements down to macOS 10.15.