### PR TITLE
javac plugin: keep parameter names

### DIFF
--- a/Plugins/JavaCompilerPlugin/JavaCompilerPlugin.swift
+++ b/Plugins/JavaCompilerPlugin/JavaCompilerPlugin.swift
@@ -58,7 +58,8 @@ struct JavaCompilerBuildToolPlugin: BuildToolPlugin {
           .appending(path: "bin")
           .appending(path: "javac"),
         arguments: javaFiles.map { $0.path(percentEncoded: false) } + [
-          "-d", javaClassFileURL.path()
+          "-d", javaClassFileURL.path(),
+          "-parameters", // keep parameter names, which allows us to emit them in generated Swift decls
         ],
         inputFiles: javaFiles,
         outputFiles: classFiles


### PR DESCRIPTION
By adding `-parameters` when we build java code using the java compiler plugin we retain parameter names and therefore we get:

```
  func sayHello(_ x: Int32, _ y: Int32) -> Int32
```

rather than

```
  func sayHello(_ arg0: Int32, _ arg1: Int32) -> Int32
```

which is a slightly nicer developer experience.

When using with already built jars we can't influence that, but whenever using with java sources we actually build we should recommend keeping that flag probably.