### PR TITLE
Use getDeclaredMethods() so we can see non-public methods of classes

### DIFF
--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/HelloSwift.java
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/HelloSwift.java
@@ -27,8 +27,8 @@ public class HelloSwift {
         this.value = initialValue;
     }
 
-    public native int sayHello(int x, int y);
-    public native String throwMessageFromSwift(String message) throws Exception;
+    native int sayHello(int x, int y);
+    native String throwMessageFromSwift(String message) throws Exception;
 
     // To be called back by the native code
     public double sayHelloBack(int i) {

--- a/Sources/JavaKitReflection/JavaClass+Reflection.swift
+++ b/Sources/JavaKitReflection/JavaClass+Reflection.swift
@@ -30,6 +30,9 @@ extension JavaClass {
   public func getCanonicalName() -> String
 
   @JavaMethod
+  public func getDeclaredMethods() -> [Method?]
+
+  @JavaMethod
   public func getMethods() -> [Method?]
     
   @JavaMethod


### PR DESCRIPTION
When we are translating a class that was built as part of the Swift module, use getDeclaredMethods() so we also see non-public methods.

Part of issue #106.