### PR TITLE
Add Support for Nested Classes

### DIFF
--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -342,11 +342,6 @@ struct JavaToSwift: ParsableCommand {
         }
       }
 
-      // TODO: For now, skip all nested classes.
-      if entry.getName().contains("$") {
-        continue
-      }
-
       let javaCanonicalName = String(entry.getName().replacing("/", with: ".")
         .dropLast(".class".count))
       configuration.classes[javaCanonicalName] =

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -229,10 +229,26 @@ struct JavaToSwift: ParsableCommand {
       // Note that we will be translating this Java class, so it is a known class.
       translator.translatedClasses[javaClassName] = (translatedSwiftName, nil, true)
 
-      for internalClass in javaClass.getClasses() {
+      var classes: [(classToImport: JavaClass<JavaObject>?, prefix: String)] = javaClass.getClasses().map { ($0, translatedSwiftName) }
+
+      // Go through all subclasses to find all of the classes to translate
+      while let (internalClass, prefix) = classes.popLast() {
         if let internalClass {
           let (javaName, swiftName) = names(from: internalClass.getCanonicalName())
-          translator.translatedClasses[internalClass.getCanonicalName()] = (swiftName.replacing("$", with: "."), nil, true)
+          // If we have already been through this class, don't go through it again
+          guard translator.translatedClasses[javaName] == nil else { continue }
+          let currentClassName: String
+          // If the prefix is the part of the canonical name, continue (else use the same)
+          // This is needed since `java.lang.Enum.EnumDesc` is one of the declared classes of all of the enums
+          if (internalClass.getCanonicalName().contains(prefix)) {
+            currentClassName = "\(prefix).\(swiftName)"
+          } else {
+            currentClassName = swiftName
+          }
+
+          let currentSanitizedClassName = currentClassName.replacing("$", with: ".")
+          classes.append(contentsOf: internalClass.getClasses().map { ($0, currentSanitizedClassName) })
+          translator.translatedClasses[javaName] = (currentSanitizedClassName, nil, true)
         }
       }
     }

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -243,7 +243,7 @@ struct JavaToSwift: ParsableCommand {
           if (internalClass.getCanonicalName().contains(prefix)) {
             currentClassName = "\(prefix).\(swiftName)"
           } else {
-            currentClassName = swiftName
+            continue // If we have a class that is not a nested one, ignore it
           }
 
           let currentSanitizedClassName = currentClassName.replacing("$", with: ".")
@@ -256,7 +256,7 @@ struct JavaToSwift: ParsableCommand {
     // Translate all of the Java classes into Swift classes.
     for javaClass in javaClasses {
       translator.startNewFile()
-      let swiftClassDecls = translator.translateClass(javaClass)
+      let swiftClassDecls = try! translator.translateClass(javaClass)
       let importDecls = translator.getImportDecls()
 
       let swiftFileText = """
@@ -294,15 +294,6 @@ struct JavaToSwift: ParsableCommand {
     }
 
     return (javaClassName, swiftName)
-  }
-
-  /// Return the class path augmented with the Jar file, if there is one.
-  var classPathWithJarFile: [String] {
-    if jarFile {
-      return [input] + classpath
-    }
-
-    return classpath
   }
 
   mutating func writeContents(_ contents: String, to filename: String, description: String) throws {

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -248,7 +248,7 @@ struct JavaToSwift: ParsableCommand {
     // Translate all of the Java classes into Swift classes.
     for javaClass in javaClasses {
       translator.startNewFile()
-      let swiftClassDecls = try! translator.translateClass(javaClass)
+      let swiftClassDecls = try translator.translateClass(javaClass)
       let importDecls = translator.getImportDecls()
 
       let swiftFileText = """

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -194,6 +194,15 @@ extension JavaTranslator {
     let fullName = javaClass.getCanonicalName()
     let swiftTypeName = try! getSwiftTypeNameFromJavaClassName(fullName)
 
+    for internalClass in javaClass.getClasses() {
+      if let internalClass {
+        print("Translating name \(internalClass.getName())")
+        let internalJavaClassName = internalClass.getName()
+        let translatedInternalSwiftName = internalJavaClassName.replacing("$", with: ".")
+        translatedClasses[translatedInternalSwiftName] = ("\(swiftTypeName).\(internalClass.getSimpleName())", nil, true)
+      }
+    }
+
     // Superclass.
     let extends: String
     if !javaClass.isInterface(),
@@ -238,6 +247,18 @@ extension JavaTranslator {
 
     // Members
     var members: [DeclSyntax] = []
+
+    members.append(
+      contentsOf: javaClass.getClasses().compactMap {
+        $0.flatMap { clazz in
+          let text = translateClass(clazz)
+          text.map { t in t.formatted().description  }
+            .forEach { t in print(t) }
+          print()
+          return text
+        }
+      }.flatMap(\.self)
+    )
 
     // Fields
     var staticFields: [Field] = []

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -274,7 +274,7 @@ extension JavaTranslator {
     )
 
     if !enumConstants.isEmpty {
-      let enumName = "\(swiftTypeName)Cases"
+      let enumName = "\(swiftTypeName.splitSwiftTypeName().name)Cases"
       members.append(
         contentsOf: translateToEnumValue(name: enumName, enumFields: enumConstants)
       )

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -274,7 +274,7 @@ extension JavaTranslator {
     )
 
     if !enumConstants.isEmpty {
-      let enumName = "\(swiftTypeName.splitSwiftTypeName().name)Cases"
+      let enumName = "\(swiftInnermostTypeName)Cases"
       members.append(
         contentsOf: translateToEnumValue(name: enumName, enumFields: enumConstants)
       )

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -190,9 +190,9 @@ extension JavaTranslator {
   /// Translates the given Java class into the corresponding Swift type. This
   /// can produce multiple declarations, such as a separate extension of
   /// JavaClass to house static methods.
-  package func translateClass(_ javaClass: JavaClass<JavaObject>) -> [DeclSyntax] {
+  package func translateClass(_ javaClass: JavaClass<JavaObject>) throws -> [DeclSyntax] {
     let fullName = javaClass.getCanonicalName()
-    let swiftTypeName = try! getSwiftTypeNameFromJavaClassName(fullName)
+    let swiftTypeName = try getSwiftTypeNameFromJavaClassName(fullName)
     let (swiftParentType, swiftInnermostTypeName) = swiftTypeName.splitSwiftTypeName()
 
     // If the swift parent type has not been translated, don't try to translate this one
@@ -393,7 +393,12 @@ extension JavaTranslator {
 
     let subClassDecls = javaClass.getClasses().compactMap {
       $0.flatMap { clazz in
-        return translateClass(clazz)
+        do {
+          return try translateClass(clazz)
+        } catch {
+          logUntranslated("Unable to translate '\(fullName)' subclass '\(clazz.getName())': \(error)")
+          return nil
+        }
       }
     }.flatMap(\.self)
 

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -370,7 +370,7 @@ extension JavaTranslator {
     var classDecl =
       """
       @\(raw:classOrInterface)(\(literal: fullName)\(raw: extends)\(raw: interfacesStr))
-      public struct `\(raw: swiftInnermostTypeName)`\(raw: genericParameterClause) {
+      public struct \(raw: swiftInnermostTypeName)\(raw: genericParameterClause) {
       \(raw: members.map { $0.description }.joined(separator: "\n\n"))
       }
       """ as DeclSyntax

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -191,7 +191,7 @@ extension JavaTranslator {
   /// can produce multiple declarations, such as a separate extension of
   /// JavaClass to house static methods.
   package func translateClass(_ javaClass: JavaClass<JavaObject>) throws -> [DeclSyntax] {
-    let fullName = javaClass.getCanonicalName()
+    let fullName = javaClass.getName()
     let swiftTypeName = try getSwiftTypeNameFromJavaClassName(fullName)
     let (swiftParentType, swiftInnermostTypeName) = swiftTypeName.splitSwiftTypeName()
 
@@ -207,7 +207,7 @@ extension JavaTranslator {
     let extends: String
     if !javaClass.isInterface(),
       let superclass = javaClass.getSuperclass(),
-      superclass.getCanonicalName() != "java.lang.Object"
+       superclass.getName() != "java.lang.Object"
     {
       do {
         extends = ", extends: \(try getSwiftTypeName(superclass).swiftName).self"
@@ -287,7 +287,7 @@ extension JavaTranslator {
           do {
             let implementedInSwift = constructor.isNative &&
               constructor.getDeclaringClass()!.equals(javaClass.as(JavaObject.self)!) &&
-              swiftNativeImplementations.contains(javaClass.getCanonicalName())
+              swiftNativeImplementations.contains(javaClass.getName())
 
             let translated = try translateConstructor(
               constructor,
@@ -321,7 +321,7 @@ extension JavaTranslator {
 
           let implementedInSwift = method.isNative &&
             method.getDeclaringClass()!.equals(javaClass.as(JavaObject.self)!) &&
-            swiftNativeImplementations.contains(javaClass.getCanonicalName())
+            swiftNativeImplementations.contains(javaClass.getName())
 
           // Translate the method if we can.
           do {
@@ -460,7 +460,7 @@ extension JavaTranslator {
     // Members that are native and will instead go into a NativeMethods
     // protocol.
     var nativeMembers: [DeclSyntax] = []
-    if swiftNativeImplementations.contains(javaClass.getCanonicalName()) {
+    if swiftNativeImplementations.contains(javaClass.getName()) {
       nativeMembers.append(
         contentsOf: javaClass.getDeclaredMethods().compactMap {
           $0.flatMap { method in

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -207,7 +207,7 @@ extension JavaTranslator {
     let extends: String
     if !javaClass.isInterface(),
       let superclass = javaClass.getSuperclass(),
-       superclass.getName() != "java.lang.Object"
+      superclass.getName() != "java.lang.Object"
     {
       do {
         extends = ", extends: \(try getSwiftTypeName(superclass).swiftName).self"
@@ -365,7 +365,7 @@ extension JavaTranslator {
       staticMemberWhereClause = ""
     }
 
-    // Emit the struct declaration describing the java class. Add backticks to the name since the type might interfere with Swift type names
+    // Emit the struct declaration describing the java class.
     let classOrInterface: String = javaClass.isInterface() ? "JavaInterface" : "JavaClass";
     var classDecl =
       """

--- a/Sources/JavaKitJar/generated/Attributes.swift
+++ b/Sources/JavaKitJar/generated/Attributes.swift
@@ -45,6 +45,9 @@ public struct Attributes {
   public func getValue(_ arg0: String) -> String
 
   @JavaMethod
+  public func getValue(_ arg0: Attributes.Name?) -> String
+
+  @JavaMethod
   public func isEmpty() -> Bool
 
   @JavaMethod
@@ -94,4 +97,93 @@ public struct Attributes {
 
   @JavaMethod
   public func getOrDefault(_ arg0: JavaObject?, _ arg1: JavaObject?) -> JavaObject?
+}
+extension Attributes {
+  @JavaClass("java.util.jar.Attributes$Name")
+  public struct Name {
+  @JavaMethod
+  public init(_ arg0: String, environment: JNIEnvironment? = nil)
+
+  @JavaMethod
+  public func equals(_ arg0: JavaObject?) -> Bool
+
+  @JavaMethod
+  public func toString() -> String
+
+  @JavaMethod
+  public func hashCode() -> Int32
+
+  @JavaMethod
+  public func getClass() -> JavaClass<JavaObject>?
+
+  @JavaMethod
+  public func notify()
+
+  @JavaMethod
+  public func notifyAll()
+
+  @JavaMethod
+  public func wait(_ arg0: Int64) throws
+
+  @JavaMethod
+  public func wait(_ arg0: Int64, _ arg1: Int32) throws
+
+  @JavaMethod
+  public func wait() throws
+  }
+}
+extension JavaClass<Attributes.Name> {
+  @JavaStaticField
+  public var MANIFEST_VERSION: Attributes.Name?
+
+  @JavaStaticField
+  public var SIGNATURE_VERSION: Attributes.Name?
+
+  @JavaStaticField
+  public var CONTENT_TYPE: Attributes.Name?
+
+  @JavaStaticField
+  public var CLASS_PATH: Attributes.Name?
+
+  @JavaStaticField
+  public var MAIN_CLASS: Attributes.Name?
+
+  @JavaStaticField
+  public var SEALED: Attributes.Name?
+
+  @JavaStaticField
+  public var EXTENSION_LIST: Attributes.Name?
+
+  @JavaStaticField
+  public var EXTENSION_NAME: Attributes.Name?
+
+  @JavaStaticField
+  public var EXTENSION_INSTALLATION: Attributes.Name?
+
+  @JavaStaticField
+  public var IMPLEMENTATION_TITLE: Attributes.Name?
+
+  @JavaStaticField
+  public var IMPLEMENTATION_VERSION: Attributes.Name?
+
+  @JavaStaticField
+  public var IMPLEMENTATION_VENDOR: Attributes.Name?
+
+  @JavaStaticField
+  public var IMPLEMENTATION_VENDOR_ID: Attributes.Name?
+
+  @JavaStaticField
+  public var IMPLEMENTATION_URL: Attributes.Name?
+
+  @JavaStaticField
+  public var SPECIFICATION_TITLE: Attributes.Name?
+
+  @JavaStaticField
+  public var SPECIFICATION_VERSION: Attributes.Name?
+
+  @JavaStaticField
+  public var SPECIFICATION_VENDOR: Attributes.Name?
+
+  @JavaStaticField
+  public var MULTI_RELEASE: Attributes.Name?
 }

--- a/Sources/JavaKitReflection/JavaClass+Reflection.swift
+++ b/Sources/JavaKitReflection/JavaClass+Reflection.swift
@@ -37,4 +37,10 @@ extension JavaClass {
 
   @JavaMethod
   public func getGenericInterfaces() -> [Type?]
+
+  @JavaMethod
+  public func isInterface() -> Bool
+
+  @JavaMethod
+  public func getClasses() -> [JavaClass<JavaObject>?]
 }

--- a/Sources/JavaKitReflection/JavaClass+Reflection.swift
+++ b/Sources/JavaKitReflection/JavaClass+Reflection.swift
@@ -37,10 +37,4 @@ extension JavaClass {
 
   @JavaMethod
   public func getGenericInterfaces() -> [Type?]
-
-  @JavaMethod
-  public func isInterface() -> Bool
-
-  @JavaMethod
-  public func getClasses() -> [JavaClass<JavaObject>?]
 }

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -24,9 +24,9 @@ var jvm: JavaVirtualMachine {
 }
 
 @JavaClass("java.time.Month")
-public struct JavaMonth {
-
-}
+public struct JavaMonth {}
+@JavaClass("java.lang.ProcessBuilder")
+struct ProcessBuilder {}
 
 class Java2SwiftTests: XCTestCase {
   func testJavaLangObjectMapping() throws {
@@ -114,6 +114,18 @@ class Java2SwiftTests: XCTestCase {
       ]
     )
   }
+
+  func testNestedSubclasses() async throws {
+    try assertTranslatedClass(
+      ProcessBuilder.self,
+      swiftTypeName: "ProcessBuilder",
+      expectedChunks: [
+        "import JavaKit",
+        ""
+      ]
+    )
+  }
+
 }
 
 @JavaClass("java.util.ArrayList")
@@ -145,6 +157,7 @@ func assertTranslatedClass<JavaClassType: AnyJavaObject>(
   translator.translatedClasses = translatedClasses
   translator.translatedClasses[javaType.fullJavaClassName] = (swiftTypeName, nil, true)
 
+
   translator.startNewFile()
   let translatedDecls = translator.translateClass(
     try JavaClass<JavaObject>(
@@ -160,6 +173,7 @@ func assertTranslatedClass<JavaClassType: AnyJavaObject>(
     """
 
   for expectedChunk in expectedChunks {
+    print(swiftFileText)
     if swiftFileText.contains(expectedChunk) {
       continue
     }

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -115,7 +115,7 @@ class Java2SwiftTests: XCTestCase {
     )
   }
 
-  func testNestedSubclasses() async throws {
+  func testNestedSubclasses() throws {
     try assertTranslatedClass(
       ProcessBuilder.self,
       swiftTypeName: "ProcessBuilder",

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -123,7 +123,6 @@ class Java2SwiftTests: XCTestCase {
         "java.lang.ProcessBuilder": ("ProcessBuilder", nil, true),
         "java.lang.ProcessBuilder.Redirect": ("ProcessBuilder.Redirect", nil, true),
         "java.lang.ProcessBuilder.Redirect.Type": ("ProcessBuilder.Redirect.Type", nil, true),
-        "java.lang.Enum.EnumDesc": ("Enum.EnumDesc", nil, true)
       ],
       expectedChunks: [
         "import JavaKit",

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -37,7 +37,7 @@ class Java2SwiftTests: XCTestCase {
         "import JavaKit",
         """
         @JavaClass("java.lang.Object")
-        public struct `MyJavaObject` {
+        public struct MyJavaObject {
         """,
         """
           @JavaMethod
@@ -121,20 +121,24 @@ class Java2SwiftTests: XCTestCase {
       swiftTypeName: "ProcessBuilder",
       translatedClasses: [
         "java.lang.ProcessBuilder": ("ProcessBuilder", nil, true),
-        "java.lang.ProcessBuilder.Redirect": ("ProcessBuilder.Redirect", nil, true),
-        "java.lang.ProcessBuilder.Redirect.Type": ("ProcessBuilder.Redirect.Type", nil, true),
+        "java.lang.ProcessBuilder$Redirect": ("ProcessBuilder.Redirect", nil, true),
+        "java.lang.ProcessBuilder$Redirect$Type": ("ProcessBuilder.Redirect.Type", nil, true),
       ],
       expectedChunks: [
         "import JavaKit",
         """
+          @JavaMethod
+          public func redirectInput() -> ProcessBuilder.Redirect?
+        """,
+        """
         extension ProcessBuilder {
-          @JavaClass("java.lang.ProcessBuilder.Redirect")
-          public struct `Redirect` {
+          @JavaClass("java.lang.ProcessBuilder$Redirect")
+          public struct Redirect {
         """,
         """
         extension ProcessBuilder.Redirect {
-          @JavaClass("java.lang.ProcessBuilder.Redirect.Type")
-          public struct `Type` {
+          @JavaClass("java.lang.ProcessBuilder$Redirect$Type")
+          public struct Type {
         """
       ]
     )

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -37,7 +37,7 @@ class Java2SwiftTests: XCTestCase {
         "import JavaKit",
         """
         @JavaClass("java.lang.Object")
-        public struct MyJavaObject {
+        public struct `MyJavaObject` {
         """,
         """
           @JavaMethod
@@ -127,7 +127,16 @@ class Java2SwiftTests: XCTestCase {
       ],
       expectedChunks: [
         "import JavaKit",
-        ""
+        """
+        extension ProcessBuilder {
+          @JavaClass("java.lang.ProcessBuilder.Redirect")
+          public struct `Redirect` {
+        """,
+        """
+        extension ProcessBuilder.Redirect {
+          @JavaClass("java.lang.ProcessBuilder.Redirect.Type")
+          public struct `Type` {
+        """
       ]
     )
   }
@@ -179,7 +188,6 @@ func assertTranslatedClass<JavaClassType: AnyJavaObject>(
     """
 
   for expectedChunk in expectedChunks {
-    print(swiftFileText)
     if swiftFileText.contains(expectedChunk) {
       continue
     }

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -174,8 +174,8 @@ func assertTranslatedClass<JavaClassType: AnyJavaObject>(
 
 
   translator.startNewFile()
-  let translatedDecls = translator.translateClass(
-    try JavaClass<JavaObject>(
+  let translatedDecls = try translator.translateClass(
+    JavaClass<JavaObject>(
       javaThis: javaType.getJNIClass(in: environment),
       environment: environment)
   )

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -119,6 +119,12 @@ class Java2SwiftTests: XCTestCase {
     try assertTranslatedClass(
       ProcessBuilder.self,
       swiftTypeName: "ProcessBuilder",
+      translatedClasses: [
+        "java.lang.ProcessBuilder": ("ProcessBuilder", nil, true),
+        "java.lang.ProcessBuilder.Redirect": ("ProcessBuilder.Redirect", nil, true),
+        "java.lang.ProcessBuilder.Redirect.Type": ("ProcessBuilder.Redirect.Type", nil, true),
+        "java.lang.Enum.EnumDesc": ("Enum.EnumDesc", nil, true)
+      ],
       expectedChunks: [
         "import JavaKit",
         ""


### PR DESCRIPTION
Closes #19 

This adds support for nested classes. There are 2 parts here:
1. Recursively going through when translating classes
2. Using a stack to go through all classes to add to the classes to translate.

This also migrates some places where we were using `getCanonicalName` when we should be using `getName` (to make sure that we use the $)