### PR TITLE
Add Support for Final Fields

### DIFF
--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -546,7 +546,7 @@ extension JavaTranslator {
     let fieldAttribute: AttributeSyntax = javaField.isStatic ? "@JavaStaticField" : "@JavaField";
     let swiftFieldName = javaField.getName().escapedSwiftName
     return """
-      \(fieldAttribute)
+      \(fieldAttribute)(isFinal: \(raw: javaField.isFinal))
       public var \(raw: swiftFieldName): \(raw: typeName)
       """
   }

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -92,7 +92,7 @@ public macro JavaInterface(_ fullClassName: String, extends: (any AnyJavaObject.
 /// }
 /// ```
 @attached(accessor)
-public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
+public macro JavaField(_ javaFieldName: String? = nil, isFinal: Bool = false) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
 
 
 /// Attached macro that turns a Swift property into one that accesses a Java static field on the underlying Java object.
@@ -106,7 +106,7 @@ public macro JavaField(_ javaFieldName: String? = nil) = #externalMacro(module: 
 /// }
 /// ```
 @attached(accessor)
-public macro JavaStaticField(_ javaFieldName: String? = nil) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
+public macro JavaStaticField(_ javaFieldName: String? = nil, isFinal: Bool = false) = #externalMacro(module: "JavaKitMacros", type: "JavaFieldMacro")
 
 /// Attached macro that turns a Swift method into one that wraps a Java method on the underlying Java object.
 ///

--- a/Sources/JavaKit/generated/JavaBoolean.swift
+++ b/Sources/JavaKit/generated/JavaBoolean.swift
@@ -46,13 +46,13 @@ public struct JavaBoolean {
   public func wait() throws
 }
 extension JavaClass<JavaBoolean> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TRUE: JavaBoolean?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var FALSE: JavaBoolean?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaBoolean>?
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaByte.swift
+++ b/Sources/JavaKit/generated/JavaByte.swift
@@ -61,19 +61,19 @@ public struct JavaByte {
   public func wait() throws
 }
 extension JavaClass<JavaByte> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaByte>?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaCharacter.swift
+++ b/Sources/JavaKit/generated/JavaCharacter.swift
@@ -43,214 +43,214 @@ public struct JavaCharacter {
   public func wait() throws
 }
 extension JavaClass<JavaCharacter> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_RADIX: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_RADIX: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaCharacter>?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var UNASSIGNED: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var UPPERCASE_LETTER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOWERCASE_LETTER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TITLECASE_LETTER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MODIFIER_LETTER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var OTHER_LETTER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var NON_SPACING_MARK: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENCLOSING_MARK: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var COMBINING_SPACING_MARK: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DECIMAL_DIGIT_NUMBER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LETTER_NUMBER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var OTHER_NUMBER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SPACE_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LINE_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PARAGRAPH_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CONTROL: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var FORMAT: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PRIVATE_USE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SURROGATE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DASH_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var START_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var END_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CONNECTOR_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var OTHER_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MATH_SYMBOL: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CURRENCY_SYMBOL: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MODIFIER_SYMBOL: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var OTHER_SYMBOL: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var INITIAL_QUOTE_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var FINAL_QUOTE_PUNCTUATION: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_UNDEFINED: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_LEFT_TO_RIGHT: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_RIGHT_TO_LEFT: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_EUROPEAN_NUMBER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_EUROPEAN_NUMBER_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_EUROPEAN_NUMBER_TERMINATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_ARABIC_NUMBER: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_COMMON_NUMBER_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_NONSPACING_MARK: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_BOUNDARY_NEUTRAL: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_PARAGRAPH_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_SEGMENT_SEPARATOR: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_WHITESPACE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_OTHER_NEUTRALS: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_LEFT_TO_RIGHT_EMBEDDING: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_RIGHT_TO_LEFT_EMBEDDING: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_POP_DIRECTIONAL_FORMAT: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_LEFT_TO_RIGHT_ISOLATE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_RIGHT_TO_LEFT_ISOLATE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_FIRST_STRONG_ISOLATE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DIRECTIONALITY_POP_DIRECTIONAL_ISOLATE: Int8
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_HIGH_SURROGATE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_HIGH_SURROGATE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_LOW_SURROGATE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_LOW_SURROGATE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_SURROGATE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_SURROGATE: UInt16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_SUPPLEMENTARY_CODE_POINT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_CODE_POINT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_CODE_POINT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaDouble.swift
+++ b/Sources/JavaKit/generated/JavaDouble.swift
@@ -67,40 +67,40 @@ public struct JavaDouble {
   public func wait() throws
 }
 extension JavaClass<JavaDouble> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var POSITIVE_INFINITY: Double
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var NEGATIVE_INFINITY: Double
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var NaN: Double
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: Double
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_NORMAL: Double
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: Double
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PRECISION: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_EXPONENT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_EXPONENT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaDouble>?
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaFloat.swift
+++ b/Sources/JavaKit/generated/JavaFloat.swift
@@ -70,40 +70,40 @@ public struct JavaFloat {
   public func wait() throws
 }
 extension JavaClass<JavaFloat> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var POSITIVE_INFINITY: Float
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var NEGATIVE_INFINITY: Float
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var NaN: Float
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: Float
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_NORMAL: Float
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: Float
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PRECISION: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_EXPONENT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_EXPONENT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaFloat>?
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaInteger.swift
+++ b/Sources/JavaKit/generated/JavaInteger.swift
@@ -61,19 +61,19 @@ public struct JavaInteger {
   public func wait() throws
 }
 extension JavaClass<JavaInteger> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaInteger>?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaLong.swift
+++ b/Sources/JavaKit/generated/JavaLong.swift
@@ -61,19 +61,19 @@ public struct JavaLong {
   public func wait() throws
 }
 extension JavaClass<JavaLong> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaLong>?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaShort.swift
+++ b/Sources/JavaKit/generated/JavaShort.swift
@@ -61,19 +61,19 @@ public struct JavaShort {
   public func wait() throws
 }
 extension JavaClass<JavaShort> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MIN_VALUE: Int16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAX_VALUE: Int16
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaShort>?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIZE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var BYTES: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKit/generated/JavaVoid.swift
+++ b/Sources/JavaKit/generated/JavaVoid.swift
@@ -31,6 +31,6 @@ public struct JavaVoid {
   public func wait() throws
 }
 extension JavaClass<JavaVoid> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var TYPE: JavaClass<JavaVoid>?
 }

--- a/Sources/JavaKitJar/generated/JarEntry.swift
+++ b/Sources/JavaKitJar/generated/JarEntry.swift
@@ -95,129 +95,129 @@ public struct JarEntry {
   public func wait() throws
 }
 extension JavaClass<JarEntry> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var STORED: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DEFLATED: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVEM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCOM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENDSK: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATX: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSUB: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDTOT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDCOM: Int32
 }

--- a/Sources/JavaKitJar/generated/JarFile.swift
+++ b/Sources/JavaKitJar/generated/JarFile.swift
@@ -63,132 +63,132 @@ public struct JarFile {
   public func wait() throws
 }
 extension JavaClass<JarFile> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MANIFEST_NAME: String
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var OPEN_READ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var OPEN_DELETE: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVEM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCOM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENDSK: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATX: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSUB: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDTOT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDCOM: Int32
 }

--- a/Sources/JavaKitJar/generated/JarInputStream.swift
+++ b/Sources/JavaKitJar/generated/JarInputStream.swift
@@ -80,123 +80,123 @@ public struct JarInputStream {
   public func wait() throws
 }
 extension JavaClass<JarInputStream> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVEM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCOM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENDSK: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATX: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSUB: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDTOT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDCOM: Int32
 }

--- a/Sources/JavaKitJar/generated/JarOutputStream.swift
+++ b/Sources/JavaKitJar/generated/JarOutputStream.swift
@@ -62,129 +62,129 @@ public struct JarOutputStream {
   public func wait() throws
 }
 extension JavaClass<JarOutputStream> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var STORED: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DEFLATED: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIG: Int64
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDHDR: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var LOCEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVEM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENVER: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENFLG: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENHOW: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENTIM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCRC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENLEN: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENNAM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENEXT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENCOM: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENDSK: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENATX: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CENOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSUB: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDTOT: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDSIZ: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDOFF: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var ENDCOM: Int32
 }

--- a/Sources/JavaKitReflection/Field+Utilities.swift
+++ b/Sources/JavaKitReflection/Field+Utilities.swift
@@ -17,4 +17,9 @@ extension Field {
     public var isStatic: Bool {
       return (getModifiers() & 0x08) != 0
     }
+
+  /// Whether this is a 'final' field.
+  public var isFinal: Bool {
+    return (getModifiers() & 16) != 0
+  }
 }

--- a/Sources/JavaKitReflection/generated/Constructor.swift
+++ b/Sources/JavaKitReflection/generated/Constructor.swift
@@ -123,10 +123,10 @@ public struct Constructor<T: AnyJavaObject> {
   public func wait() throws
 }
 extension JavaClass {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PUBLIC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DECLARED: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKitReflection/generated/Executable.swift
+++ b/Sources/JavaKitReflection/generated/Executable.swift
@@ -120,10 +120,10 @@ public struct Executable {
   public func wait() throws
 }
 extension JavaClass<Executable> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PUBLIC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DECLARED: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKitReflection/generated/Field.swift
+++ b/Sources/JavaKitReflection/generated/Field.swift
@@ -147,10 +147,10 @@ public struct Field {
   public func wait() throws
 }
 extension JavaClass<Field> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PUBLIC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DECLARED: Int32
 
   @JavaStaticMethod

--- a/Sources/JavaKitReflection/generated/Method.swift
+++ b/Sources/JavaKitReflection/generated/Method.swift
@@ -138,10 +138,10 @@ public struct Method {
   public func wait() throws
 }
 extension JavaClass<Method> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var PUBLIC: Int32
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var DECLARED: Int32
 
   @JavaStaticMethod

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -75,7 +75,7 @@ class Java2SwiftTests: XCTestCase {
                 }
         """,
         """
-          @JavaStaticField
+          @JavaStaticField(isFinal: true)
           public var APRIL: Month?
         """
       ])

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -41,6 +41,9 @@ class JavaKitMacroTests: XCTestCase {
 
           @JavaField
           public var myField: Int64
+      
+          @JavaField(isFinal: true)
+          public var myFinalField: Int64
         }
       """,
       expandedSource: """
@@ -71,6 +74,11 @@ class JavaKitMacroTests: XCTestCase {
               }
               nonmutating set {
                   self[javaFieldName: "myField", fieldType: Int64.self] = newValue
+              }
+          }
+          public var myFinalField: Int64 {
+              get {
+                  self[javaFieldName: "myFinalField", fieldType: Int64.self]
               }
           }
       


### PR DESCRIPTION
Closes #116 

This adds support for final fields (so they are only `get`).

2 parts:
1. New update to the macro which defaults to a non-final field
2. Updates translator to define whether a field is final or not