### PR TITLE
Make nested classes explicitly-specifiable and work through some integration issues

### DIFF
--- a/Plugins/Java2SwiftPlugin/Java2SwiftPlugin.swift
+++ b/Plugins/Java2SwiftPlugin/Java2SwiftPlugin.swift
@@ -90,7 +90,8 @@ struct Java2SwiftBuildToolPlugin: BuildToolPlugin {
     /// Determine the set of Swift files that will be emitted by the Java2Swift
     /// tool.
     let outputSwiftFiles = config.classes.map { (javaClassName, swiftName) in
-      outputDirectory.appending(path: "\(swiftName).swift")
+      let swiftNestedName = swiftName.replacingOccurrences(of: ".", with: "+")
+      return outputDirectory.appending(path: "\(swiftNestedName).swift")
     }
 
     // Find the Java .class files generated from prior plugins.

--- a/Samples/JavaSieve/Sources/JavaSieve/Java2Swift.config
+++ b/Samples/JavaSieve/Sources/JavaSieve/Java2Swift.config
@@ -20,6 +20,7 @@
     "com.gazman.quadratic_sieve.data.VectorWorkData" : "VectorWorkData",
     "com.gazman.quadratic_sieve.debug.Analytics" : "Analytics",
     "com.gazman.quadratic_sieve.debug.AssertUtils" : "AssertUtils",
+    "com.gazman.quadratic_sieve.debug.AssertUtils$Tester" : "AssertUtils.Tester",
     "com.gazman.quadratic_sieve.debug.Logger" : "Logger",
     "com.gazman.quadratic_sieve.fact.TrivialDivision" : "TrivialDivision",
     "com.gazman.quadratic_sieve.primes.BigPrimes" : "BigPrimes",

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -202,17 +202,8 @@ struct JavaToSwift: ParsableCommand {
     translator.addConfiguration(config, forSwiftModule: moduleName)
 
     // Load all of the requested classes.
-    #if false
-    let classLoader = URLClassLoader(
-      [
-        try URL("file://\(classPath)", environment: environment)
-      ],
-      environment: environment
-    )
-    #else
     let classLoader = try JavaClass<ClassLoader>(environment: environment)
       .getSystemClassLoader()!
-    #endif
     var javaClasses: [JavaClass<JavaObject>] = []
     for (javaClassName, swiftName) in config.classes {
       guard let javaClass = try classLoader.loadClass(javaClassName) else {

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -224,9 +224,14 @@ struct JavaToSwift: ParsableCommand {
         currentClassIndex += 1
       }
 
+      // The current class we're in.
+      let currentClass = allClassesToVisit[currentClassIndex]
+      guard let currentSwiftName = translator.translatedClasses[currentClass.getName()]?.swiftType else {
+        continue
+      }
+
       // Find all of the nested classes that weren't explicitly translated
       // already.
-      let currentClass = allClassesToVisit[currentClassIndex]
       let nestedClasses: [JavaClass<JavaObject>] = currentClass.getClasses().compactMap { nestedClass in
         guard let nestedClass else { return nil }
 
@@ -242,7 +247,9 @@ struct JavaToSwift: ParsableCommand {
         }
 
         // Record this as a translated class.
-        let swiftName = javaClassName.defaultSwiftNameForJavaClass
+        let swiftUnqualifiedName = javaClassName.javaClassNameToCanonicalName
+          .defaultSwiftNameForJavaClass
+        let swiftName = "\(currentSwiftName).\(swiftUnqualifiedName)"
         translator.translatedClasses[javaClassName] = (swiftName, nil, true)
         return nestedClass
       }

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -249,6 +249,8 @@ struct JavaToSwift: ParsableCommand {
         // Record this as a translated class.
         let swiftUnqualifiedName = javaClassName.javaClassNameToCanonicalName
           .defaultSwiftNameForJavaClass
+
+
         let swiftName = "\(currentSwiftName).\(swiftUnqualifiedName)"
         translator.translatedClasses[javaClassName] = (swiftName, nil, true)
         return nestedClass
@@ -390,10 +392,10 @@ extension String {
   fileprivate var defaultSwiftNameForJavaClass: String {
     if let dotLoc = lastIndex(of: ".") {
       let afterDot = index(after: dotLoc)
-      return String(self[afterDot...]).javaClassNameToCanonicalName
+      return String(self[afterDot...]).javaClassNameToCanonicalName.adjustedSwiftTypeName
     }
 
-    return javaClassNameToCanonicalName
+    return javaClassNameToCanonicalName.adjustedSwiftTypeName
   }
 }
 
@@ -424,5 +426,13 @@ extension String {
     }
 
     return false
+  }
+
+  /// Adjust type name for "bad" type names that don't work well in Swift.
+  fileprivate var adjustedSwiftTypeName: String {
+    switch self {
+    case "Type": return "JavaType"
+    default: return self
+    }
   }
 }

--- a/Sources/JavaKit/Optional+JavaObject.swift
+++ b/Sources/JavaKit/Optional+JavaObject.swift
@@ -37,7 +37,7 @@ extension Optional: JavaValue where Wrapped: AnyJavaObject {
   }
 
   public static var javaType: JavaType {
-    JavaType(canonicalClassName: Wrapped.fullJavaClassName)
+    JavaType(className: Wrapped.fullJavaClassName)
   }
 
   public static func jniMethodCall(

--- a/Sources/JavaKitJar/generated/Attributes.swift
+++ b/Sources/JavaKitJar/generated/Attributes.swift
@@ -133,57 +133,57 @@ extension Attributes {
   }
 }
 extension JavaClass<Attributes.Name> {
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MANIFEST_VERSION: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SIGNATURE_VERSION: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CONTENT_TYPE: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var CLASS_PATH: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MAIN_CLASS: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SEALED: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTENSION_LIST: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTENSION_NAME: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var EXTENSION_INSTALLATION: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var IMPLEMENTATION_TITLE: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var IMPLEMENTATION_VERSION: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var IMPLEMENTATION_VENDOR: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var IMPLEMENTATION_VENDOR_ID: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var IMPLEMENTATION_URL: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SPECIFICATION_TITLE: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SPECIFICATION_VERSION: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var SPECIFICATION_VENDOR: Attributes.Name?
 
-  @JavaStaticField
+  @JavaStaticField(isFinal: true)
   public var MULTI_RELEASE: Attributes.Name?
 }

--- a/Sources/JavaTypes/JavaType+JavaSource.swift
+++ b/Sources/JavaTypes/JavaType+JavaSource.swift
@@ -32,7 +32,7 @@ extension JavaType {
       self = try JavaType(mangledName: name)
 
     case let className:
-      self = JavaType(canonicalClassName: className)
+      self = JavaType(className: className)
     }
   }
 }

--- a/Sources/JavaTypes/JavaType.swift
+++ b/Sources/JavaTypes/JavaType.swift
@@ -31,9 +31,9 @@ public enum JavaType: Equatable, Hashable {
   /// A Java array.
   indirect case array(JavaType)
 
-  /// Given a canonical class name such as "java.lang.Object", split it into
+  /// Given a class name such as "java.lang.Object", split it into
   /// its package and class name to form a class instance.
-  public init(canonicalClassName name: some StringProtocol) {
+  public init(className name: some StringProtocol) {
     if let lastDot = name.lastIndex(of: ".") {
       self = .class(
         package: String(name[..<lastDot]),

--- a/Sources/JavaTypes/Mangling.swift
+++ b/Sources/JavaTypes/Mangling.swift
@@ -125,7 +125,7 @@ extension JavaType {
       string = string[string.index(after: semicolonIndex)...]
 
       return JavaType(
-        canonicalClassName: canonicalNameWithSlashes.replacingSlashesWithPeriods()
+        className: canonicalNameWithSlashes.replacingSlashesWithPeriods()
       )
 
     default:

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -176,6 +176,10 @@ class Java2SwiftTests: XCTestCase {
           @JavaClass("java.lang.ProcessBuilder$Redirect$Type")
           public struct Type {
         """,
+        """
+          @JavaMethod
+          public func type() -> ProcessBuilder.Redirect.`Type`?
+        """,
       ]
     )
   }

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -169,9 +169,52 @@ class Java2SwiftTests: XCTestCase {
           public struct Redirect {
         """,
         """
+        public func redirectError() -> ProcessBuilder.Redirect?
+        """,
+        """
         extension ProcessBuilder.Redirect {
           @JavaClass("java.lang.ProcessBuilder$Redirect$Type")
           public struct Type {
+        """,
+      ]
+    )
+  }
+
+  func testNestedRenamedSubclasses() throws {
+    try assertTranslatedClass(
+      ProcessBuilder.self,
+      swiftTypeName: "ProcessBuilder",
+      translatedClasses: [
+        "java.lang.ProcessBuilder": ("ProcessBuilder", nil, true),
+        "java.lang.ProcessBuilder$Redirect": ("ProcessBuilder.PBRedirect", nil, true),
+        "java.lang.ProcessBuilder$Redirect$Type": ("ProcessBuilder.PBRedirect.JavaType", nil, true),
+      ],
+      nestedClasses: [
+        "java.lang.ProcessBuilder": [JavaClass<ProcessBuilder.Redirect>().as(JavaClass<JavaObject>.self)!],
+        "java.lang.ProcessBuilder$Redirect": [JavaClass<ProcessBuilder.Redirect.JavaType>().as(JavaClass<JavaObject>.self)!],
+      ],
+      expectedChunks: [
+        "import JavaKit",
+        """
+          @JavaMethod
+          public func redirectInput() -> ProcessBuilder.PBRedirect?
+        """,
+        """
+        extension ProcessBuilder {
+          @JavaClass("java.lang.ProcessBuilder$Redirect")
+          public struct PBRedirect {
+        """,
+        """
+        public func redirectError() -> ProcessBuilder.PBRedirect?
+        """,
+        """
+        extension ProcessBuilder.PBRedirect {
+          @JavaClass("java.lang.ProcessBuilder$Redirect$Type")
+          public struct JavaType {
+        """,
+        """
+          @JavaMethod
+          public func type() -> ProcessBuilder.PBRedirect.JavaType?
         """
       ]
     )

--- a/Tests/Java2SwiftTests/Java2SwiftTests.swift
+++ b/Tests/Java2SwiftTests/Java2SwiftTests.swift
@@ -51,6 +51,28 @@ class Java2SwiftTests: XCTestCase {
     )
   }
 
+  func testJavaLangClassMapping() throws {
+    try assertTranslatedClass(
+      JavaClass<JavaObject>.self,
+      swiftTypeName: "MyJavaClass",
+      translatedClasses: [
+        "java.lang.Object": ("JavaObject", nil, true),
+        "java.lang.String": ("JavaString", nil, true),
+      ],
+      expectedChunks: [
+        "import JavaKit",
+        """
+        @JavaClass("java.lang.Class")
+        public struct MyJavaClass<T: AnyJavaObject> {
+        """,
+        """
+          @JavaStaticMethod
+          public func forName<T: AnyJavaObject>(_ arg0: JavaString) throws -> MyJavaClass<JavaObject>? where ObjectType == MyJavaClass<T>
+        """,
+      ]
+    )
+  }
+
   func testEnum() throws {
     try assertTranslatedClass(
       JavaMonth.self,


### PR DESCRIPTION
Implement a follow-on to https://github.com/swiftlang/swift-java/pull/115 that improves things in a few ways:
* Allow `Java2Swift.config` to explicitly specify nested classes, or omit them to get them autogenerated. This "moved" the recursion to make it computed by the outer Java2Swift rather than always walking through all nested classes.
* Get the JavaSieve example working again, now with nested types being listed by the Jar file reader
* More tests!
* Deal with an annoying problem when importing Java nested classes named "Type"; it doesn't work well in Swift because `X.Type` already has a meaning.