### PR TITLE
JavaClass macro: stop generating javaThis and javaEnvironment members

### DIFF
--- a/Sources/JavaKit/AnyJavaObject.swift
+++ b/Sources/JavaKit/AnyJavaObject.swift
@@ -50,15 +50,19 @@ public protocol AnyJavaObject {
 
   /// The Swift instance that keeps the Java holder alive.
   var javaHolder: JavaObjectHolder { get }
-
-  /// Retrieve the underlying Java object.
-  var javaThis: jobject { get }
-
-  /// Retrieve the environment in which this Java object resides.
-  var javaEnvironment: JNIEnvironment { get }
 }
 
 extension AnyJavaObject {
+  /// Retrieve the underlying Java object.
+  public var javaThis: jobject {
+    javaHolder.object!
+  }
+
+  /// Retrieve the environment in which this Java object resides.
+  public var javaEnvironment: JNIEnvironment {
+    javaHolder.environment
+  }
+
   /// The full Java class name, where each component is separated by a "/".
   static var fullJavaClassNameWithSlashes: String {
     let seq = fullJavaClassName.map { $0 == "." ? "/" as Character : $0 }

--- a/Sources/JavaKit/Macros.swift
+++ b/Sources/JavaKit/Macros.swift
@@ -34,8 +34,6 @@
   member,
   names: named(fullJavaClassName),
   named(javaHolder),
-  named(javaThis),
-  named(javaEnvironment),
   named(init(javaHolder:)),
   named(JavaSuperclass),
   named(`as`)
@@ -70,8 +68,6 @@ public macro JavaClass(
   member,
   names: named(fullJavaClassName),
   named(javaHolder),
-  named(javaThis),
-  named(javaEnvironment),
   named(init(javaHolder:)),
   named(JavaSuperclass),
   named(`as`)

--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -69,18 +69,6 @@ extension JavaClassMacro: MemberMacro {
       public var javaHolder: JavaObjectHolder
       """
 
-    let javaThisMember: DeclSyntax = """
-      public var javaThis: jobject {
-        javaHolder.object!
-      }
-      """
-
-    let javaEnvironmentMember: DeclSyntax = """
-      public var javaEnvironment: JNIEnvironment {
-        javaHolder.environment
-      }
-      """
-
     let initMember: DeclSyntax = """
       public init(javaHolder: JavaObjectHolder) {
           self.javaHolder = javaHolder
@@ -98,8 +86,6 @@ extension JavaClassMacro: MemberMacro {
       fullJavaClassNameMember,
       superclassTypealias,
       javaHolderMember,
-      javaThisMember,
-      javaEnvironmentMember,
       initMember,
       nonOptionalAs,
     ]

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -102,14 +102,6 @@ class JavaKitMacroTests: XCTestCase {
 
             public var javaHolder: JavaObjectHolder
 
-            public var javaThis: jobject {
-              javaHolder.object!
-            }
-
-            public var javaEnvironment: JNIEnvironment {
-              javaHolder.environment
-            }
-
             public init(javaHolder: JavaObjectHolder) {
                 self.javaHolder = javaHolder
             }


### PR DESCRIPTION
Provide these properties via an extension to AnyJavaObject, accessing the holder values, rather than splatting that same code into every @JavaClass.