### PR TITLE
SwiftArena.ofAuto() which uses GC to manage swift instances (and destroy them)

### DIFF
--- a/SwiftKit/src/main/java/org/swift/swiftkit/AutoSwiftMemorySession.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/AutoSwiftMemorySession.java
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 package org.swift.swiftkit;
 
 import java.lang.foreign.MemorySegment;

--- a/SwiftKit/src/main/java/org/swift/swiftkit/AutoSwiftMemorySession.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/AutoSwiftMemorySession.java
@@ -1,0 +1,56 @@
+package org.swift.swiftkit;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.ref.Cleaner;
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A memory session which manages registered objects via the Garbage Collector.
+ *
+ * <p> When registered Java wrapper classes around native Swift instances {@link SwiftInstance},
+ * are eligible for collection, this will trigger the cleanup of the native resources as well.
+ *
+ * <p> This memory session is LESS reliable than using a {@link ConfinedSwiftMemorySession} because
+ * the timing of when the native resources are cleaned up is somewhat undefined, and rely on the
+ * system GC. Meaning, that if an object nas been promoted to an old generation, there may be a
+ * long time between the resource no longer being referenced "in Java" and its native memory being released,
+ * and also the deinit of the Swift type being run.
+ *
+ * <p> This can be problematic for Swift applications which rely on quick release of resources, and may expect
+ * the deinits to run in expected and "quick" succession.
+ *
+ * <p> Whenever possible, prefer using an explicitly managed {@link SwiftArena}, such as {@link SwiftArena#ofConfined()}.
+ */
+final class AutoSwiftMemorySession implements SwiftArena {
+
+    private final Cleaner cleaner;
+
+    public AutoSwiftMemorySession(ThreadFactory cleanerThreadFactory) {
+        this.cleaner = Cleaner.create(cleanerThreadFactory);
+    }
+
+    @Override
+    public void register(SwiftHeapObject object) {
+        SwiftHeapObjectCleanup cleanupAction = new SwiftHeapObjectCleanup(object.$memorySegment(), object.$swiftType());
+        register(object, cleanupAction);
+    }
+
+    // visible for testing
+    void register(SwiftHeapObject object, SwiftHeapObjectCleanup cleanupAction) {
+        Objects.requireNonNull(object, "obj");
+        Objects.requireNonNull(cleanupAction, "cleanupAction");
+
+
+        cleaner.register(object, cleanupAction);
+    }
+
+    @Override
+    public void register(SwiftValue value) {
+        Objects.requireNonNull(value, "value");
+        MemorySegment resource = value.$memorySegment();
+        var cleanupAction = new SwiftValueCleanup(resource);
+        cleaner.register(value, cleanupAction);
+    }
+
+}

--- a/SwiftKit/src/main/java/org/swift/swiftkit/ClosableSwiftArena.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/ClosableSwiftArena.java
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package org.swift.swiftkit;
+
+/**
+ * Auto-closable version of {@link SwiftArena}.
+ */
+public interface ClosableSwiftArena extends SwiftArena, AutoCloseable {
+
+    /**
+     * Close the arena and make sure all objects it managed are released.
+     * Throws if unable to verify all resources have been release (e.g. over retained Swift classes)
+     */
+    void close();
+
+}

--- a/SwiftKit/src/main/java/org/swift/swiftkit/ConfinedSwiftMemorySession.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/ConfinedSwiftMemorySession.java
@@ -1,0 +1,72 @@
+package org.swift.swiftkit;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class ConfinedSwiftMemorySession implements ClosableSwiftArena {
+
+    final static int CLOSED = 0;
+    final static int ACTIVE = 1;
+
+    final Thread owner;
+    final AtomicInteger state;
+
+    final ConfinedResourceList resources;
+
+    public ConfinedSwiftMemorySession(Thread owner) {
+        this.owner = owner;
+        this.state = new AtomicInteger(ACTIVE);
+        this.resources = new ConfinedResourceList();
+    }
+
+    public void checkValid() throws RuntimeException {
+        if (this.owner != null && this.owner != Thread.currentThread()) {
+            throw new WrongThreadException("ConfinedSwift arena is confined to %s but was closed from %s!".formatted(this.owner, Thread.currentThread()));
+        } else if (this.state.get() < ACTIVE) {
+            throw new RuntimeException("SwiftArena is already closed!");
+        }
+    }
+
+    @Override
+    public void close() {
+        checkValid();
+
+        // Cleanup all resources
+        if (this.state.compareAndExchange(ACTIVE, CLOSED) == ACTIVE) {
+            this.resources.runCleanup();
+        } // else, was already closed; do nothing
+    }
+
+    @Override
+    public void register(SwiftHeapObject object) {
+        checkValid();
+
+        var cleanup = new SwiftHeapObjectCleanup(object.$memorySegment(), object.$swiftType());
+        this.resources.add(cleanup);
+    }
+
+    @Override
+    public void register(SwiftValue value) {
+        checkValid();
+
+        var cleanup = new SwiftValueCleanup(value.$memorySegment());
+        this.resources.add(cleanup);
+    }
+
+    static final class ConfinedResourceList implements SwiftResourceList {
+        // TODO: Could use intrusive linked list to avoid one indirection here
+        final List<SwiftInstanceCleanup> resourceCleanups = new LinkedList<>();
+
+        void add(SwiftInstanceCleanup cleanup) {
+            resourceCleanups.add(cleanup);
+        }
+
+        @Override
+        public void runCleanup() {
+            for (SwiftInstanceCleanup cleanup : resourceCleanups) {
+                cleanup.run();
+            }
+        }
+    }
+}

--- a/SwiftKit/src/main/java/org/swift/swiftkit/ConfinedSwiftMemorySession.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/ConfinedSwiftMemorySession.java
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 package org.swift.swiftkit;
 
 import java.util.LinkedList;

--- a/SwiftKit/src/test/java/org/swift/swiftkit/AutoArenaTest.java
+++ b/SwiftKit/src/test/java/org/swift/swiftkit/AutoArenaTest.java
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package org.swift.swiftkit;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.ref.Cleaner;
+import java.util.concurrent.CountDownLatch;
+
+public class AutoArenaTest {
+
+
+    @Test
+    @SuppressWarnings("removal") // System.runFinalization() will be removed
+    public void cleaner_releases_native_resource() {
+        SwiftHeapObject object = new FakeSwiftHeapObject();
+
+        // Latch waiting for the cleanup of the object
+        var cleanupLatch = new CountDownLatch(1);
+
+        // we're retaining the `object`, register it with the arena:
+        AutoSwiftMemorySession arena = (AutoSwiftMemorySession) SwiftArena.ofAuto();
+        arena.register(object, new SwiftHeapObjectCleanup(object.$memorySegment(), object.$swiftType()) {
+            @Override
+            public void run() throws UnexpectedRetainCountException {
+                cleanupLatch.countDown();
+            }
+        });
+
+        // Release the object and hope it gets GC-ed soon
+
+        //noinspection UnusedAssignment
+        object = null;
+
+        var i = 1_000;
+        while (cleanupLatch.getCount() != 0) {
+            System.runFinalization();
+            System.gc();
+
+            if (i-- < 1) {
+                throw new RuntimeException("Reference was not cleaned up! Did Cleaner not pick up the release?");
+            }
+        }
+
+    }
+
+    private static class FakeSwiftHeapObject implements SwiftHeapObject {
+        public FakeSwiftHeapObject() {
+        }
+
+        @Override
+        public MemorySegment $memorySegment() {
+            return MemorySegment.NULL;
+        }
+
+        @Override
+        public GroupLayout $layout() {
+            return null;
+        }
+
+        @Override
+        public SwiftAnyType $swiftType() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This implements `SwiftArena.ofAuto()` which uses phantom references (and a `Cleaner`) to manage java swift wrapper classes on the java side.

Usage is something like this:

```
new SwiftClass(SwiftArena.ofAuto())
```

When the JVM no longer has references to such object, it will initiate the clean of the object. Currently this is going to destroy() the object, however in this mode we should perhaps just decrement the reference count of the underlying object for swift classes, unlike in the Confined case.