### PR TITLE
JavaKit: clear exception before initializing Throwable

### DIFF
--- a/Sources/JavaKit/Exceptions/ExceptionHandling.swift
+++ b/Sources/JavaKit/Exceptions/ExceptionHandling.swift
@@ -20,9 +20,8 @@ extension JNIEnvironment {
 
     // Check whether a Java exception occurred.
     if let exception = interface.ExceptionOccurred(self) {
-      let throwable = Throwable(javaThis: exception, environment: self)
       interface.ExceptionClear(self)
-      throw throwable
+      throw Throwable(javaThis: exception, environment: self)
     }
 
     return result


### PR DESCRIPTION
Initializing Throwable with an exception calls the JNI method NewGlobalRef, which on Android cannot be called while an exception is pending. [1] Clear the exception first before initializing the Throwable.

[1] https://developer.android.com/training/articles/perf-jni.html#exceptions_1