### PR TITLE
JavaKit: check each classPath element exists before starting VM

### DIFF
--- a/Sources/JavaKit/JavaKitVM/JavaVirtualMachine.swift
+++ b/Sources/JavaKit/JavaKitVM/JavaVirtualMachine.swift
@@ -12,6 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 typealias JavaVMPointer = UnsafeMutablePointer<JavaVM?>
 
 public final class JavaVirtualMachine: @unchecked Sendable {
@@ -54,6 +60,12 @@ public final class JavaVirtualMachine: @unchecked Sendable {
     // Construct the complete list of VM options.
     var allVMOptions: [String] = []
     if !classPath.isEmpty {
+      let fileManager = FileManager.default
+      for path in classPath {
+        if !fileManager.fileExists(atPath: path) {
+          throw JavaKitError.classPathEntryNotFound(entry: path, classPath: classPath)
+        }
+      }
       let colonSeparatedClassPath = classPath.joined(separator: ":")
       allVMOptions.append("-Djava.class.path=\(colonSeparatedClassPath)")
     }
@@ -267,5 +279,9 @@ extension JavaVirtualMachine {
       default: self = .unknown(error)
       }
     }
+  }
+
+  enum JavaKitError: Error {
+    case classPathEntryNotFound(entry: String, classPath: [String])
   }
 }


### PR DESCRIPTION
Partial fix for #136: validate each classPath element by attempting to open it before starting VM. It would be more efficient to stat() it but SystemPackage lacks an abstraction for checking if a file exists, and we don't want to import Foundation.