### PR TITLE
Drop dependency on swift-collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -139,7 +139,6 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-    .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.1.0")),
     .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),
   ],
   targets: [
@@ -309,7 +308,6 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "Collections", package: "swift-collections"),
         "JavaTypes",
       ],
       swiftSettings: [

--- a/Sources/JExtractSwift/ImportedDecls+Printing.swift
+++ b/Sources/JExtractSwift/ImportedDecls+Printing.swift
@@ -15,7 +15,6 @@
 import Foundation
 import JavaTypes
 import SwiftSyntax
-import OrderedCollections
 
 extension ImportedFunc {
   /// Render a `@{@snippet ... }` comment section that can be put inside a JavaDoc comment

--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -15,7 +15,6 @@
 import Foundation
 import JavaTypes
 import SwiftSyntax
-import OrderedCollections
 
 /// Any imported (Swift) declaration
 protocol ImportedDecl {
@@ -254,7 +253,7 @@ public struct ImportedVariable: ImportedDecl, CustomStringConvertible {
   /// Usually this will be all the accessors the variable declares,
   /// however if the getter is async or throwing we may not be able to import it
   /// (yet), and therefore would skip it from the supported set.
-  public var supportedAccessorKinds: OrderedSet<VariableAccessorKind> = [.get, .set]
+  public var supportedAccessorKinds: [VariableAccessorKind] = [.get, .set]
 
   /// This is the base identifier for the function, e.g., "init" for an
   /// initializer or "f" for "f(a:b:)".


### PR DESCRIPTION
We only used it in one place where we don't really need it.