### PR TITLE
JavaKit: make JavaVirtualMachine(adoptingJVM:) public

### DIFF
--- a/Sources/JavaKit/JavaKitVM/JavaVirtualMachine.swift
+++ b/Sources/JavaKit/JavaKitVM/JavaVirtualMachine.swift
@@ -18,7 +18,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-typealias JavaVMPointer = UnsafeMutablePointer<JavaVM?>
+public typealias JavaVMPointer = UnsafeMutablePointer<JavaVM?>
 
 public final class JavaVirtualMachine: @unchecked Sendable {
   /// The JNI version that we depend on.
@@ -31,7 +31,7 @@ public final class JavaVirtualMachine: @unchecked Sendable {
   private let destroyOnDeinit: Bool
 
   /// Adopt an existing JVM pointer.
-  private init(adoptingJVM jvm: JavaVMPointer) {
+  public init(adoptingJVM jvm: JavaVMPointer) {
     self.jvm = jvm
     self.destroyOnDeinit = false
   }


### PR DESCRIPTION
This is useful for a shared object to wrap a VM passed in JNI_OnLoad()