### PR TITLE
build: elide the JavaKitMacroTests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -343,6 +343,7 @@ let package = Package(
       ]
     ),
 
+/*
     .testTarget(
       name: "JavaKitMacroTests",
       dependencies: [
@@ -353,6 +354,7 @@ let package = Package(
         .swiftLanguageMode(.v5)
       ]
     ),
+*/
 
     .testTarget(
       name: "Java2SwiftTests",


### PR DESCRIPTION
The way that SPM builds executable tests is not supportable on Windows. We end up with duplicate definitions of `main` which is a hard error on Windows. Disable this test suite to allow us to build.