### PR TITLE
build: remove package-benchmark from the dependencies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,8 @@ jobs:
       # FIXME: Something is off with the format task and it gets "stuck", need to investigate
       format_check_enabled: false
       license_header_check_project_name: Swift.org
+    env:
+      SWIFT_JAVA_ENABLE_BENCHMARKING: NO
 
   test-java:
     name: Java tests (swift:${{ matrix.swift_version }} jdk:${{matrix.jdk_vendor}} os:${{ matrix.os_version }})
@@ -86,6 +88,7 @@ jobs:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     env:
       JAVA_HOME: "/usr/lib/jvm/default-jdk"
+      SWIFT_JAVA_ENABLE_BENCHMARKING: NO
     steps:
       - uses: actions/checkout@v4
       - name: Install System Dependencies

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,17 @@ let javaIncludePath = "\(javaHome)/include"
   let javaPlatformIncludePath = "\(javaIncludePath)/win32"
 #endif
 
+func sjEnableBenchmarking() -> Bool {
+    if let value = ProcessInfo.processInfo.environment["SWIFT_JAVA_ENABLE_BENCHMARKING"] {
+        switch value {
+        case "TRUE", "YES", "1": return true
+        case "FALSE", "NO", "0": return false
+        default: break
+        }
+    }
+    fatalError("Please set 'SWIFT_JAVA_ENABLE_BENCHMARKING' to 'TRUE' or 'FALSE'")
+}
+
 let package = Package(
   name: "JavaKit",
   platforms: [
@@ -138,8 +149,10 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-    .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),
-  ],
+  ] + (sjEnableBenchmarking() ? [
+    .package(url: "https://github.com/ordo-one/package-benchmark",
+             .upToNextMajor(from: "1.4.0")),
+  ] : []),
   targets: [
     .macro(
       name: "JavaKitMacros",


### PR DESCRIPTION
This package is not very Windows friendly. A partial port was attempted but revealed further Unixisms that will be difficult to port. There are alternative packages for benchmarking, e.g. google/swift-benchmark which may be a better choice.