### PR TITLE
Fail Macro Expansion if JavaStaticField is used in non-class

### DIFF
--- a/Sources/JavaKitMacros/JavaFieldMacro.swift
+++ b/Sources/JavaKitMacros/JavaFieldMacro.swift
@@ -33,6 +33,11 @@ extension JavaFieldMacro: AccessorMacro {
       return []
     }
 
+    let isStatic = node.attributeName.trimmedDescription == "JavaStaticMethod"
+    guard !isStatic || isInStaticContext(context: context) else {
+      throw MacroExpansionErrorMessage("Cannot use @JavaStaticMethod outside of a JavaClass instance")
+    }
+
     // Dig out the Java field name, if provided. Otherwise, use the name as written.
     let fieldName =
       if case .argumentList(let arguments) = node.arguments,
@@ -78,5 +83,19 @@ extension JavaFieldMacro: AccessorMacro {
     }
 
     return accessors
+  }
+
+  private static func isInStaticContext(context: some MacroExpansionContext) -> Bool {
+    for lexicalContext in context.lexicalContext {
+      if let classSyntax = lexicalContext.as(StructDeclSyntax.self) {
+        if classSyntax.name.trimmedDescription.starts(with: "JavaClass") {
+          return true
+        } else {
+          return false
+        }
+      }
+    }
+
+    return false
   }
 }

--- a/Sources/JavaKitMacros/JavaFieldMacro.swift
+++ b/Sources/JavaKitMacros/JavaFieldMacro.swift
@@ -33,9 +33,9 @@ extension JavaFieldMacro: AccessorMacro {
       return []
     }
 
-    let isStatic = node.attributeName.trimmedDescription == "JavaStaticMethod"
+    let isStatic = node.attributeName.trimmedDescription == "JavaStaticField"
     guard !isStatic || isInStaticContext(context: context) else {
-      throw MacroExpansionErrorMessage("Cannot use @JavaStaticMethod outside of a JavaClass instance")
+      throw MacroExpansionErrorMessage("Cannot use @JavaStaticField outside of a JavaClass instance")
     }
 
     // Dig out the Java field name, if provided. Otherwise, use the name as written.
@@ -87,8 +87,8 @@ extension JavaFieldMacro: AccessorMacro {
 
   private static func isInStaticContext(context: some MacroExpansionContext) -> Bool {
     for lexicalContext in context.lexicalContext {
-      if let classSyntax = lexicalContext.as(StructDeclSyntax.self) {
-        if classSyntax.name.trimmedDescription.starts(with: "JavaClass") {
+      if let classSyntax = lexicalContext.as(ClassDeclSyntax.self) {
+        if classSyntax.name.trimmedDescription.starts(with: "JavaClass<") {
           return true
         } else {
           return false

--- a/Sources/JavaKitMacros/JavaFieldMacro.swift
+++ b/Sources/JavaKitMacros/JavaFieldMacro.swift
@@ -88,7 +88,7 @@ extension JavaFieldMacro: AccessorMacro {
   private static func isInJavaClassContext(context: some MacroExpansionContext) -> Bool {
     for lexicalContext in context.lexicalContext {
       if let classSyntax = lexicalContext.as(ExtensionDeclSyntax.self) {
-        return classSyntax.extendedType.trimmedDescription.starts(with: "JavaClass<")
+        return classSyntax.extendedType.trimmedDescription.starts(with: "JavaClass")
       }
     }
 

--- a/Sources/JavaKitMacros/JavaFieldMacro.swift
+++ b/Sources/JavaKitMacros/JavaFieldMacro.swift
@@ -34,7 +34,7 @@ extension JavaFieldMacro: AccessorMacro {
     }
 
     let isStatic = node.attributeName.trimmedDescription == "JavaStaticField"
-    guard !isStatic || isInStaticContext(context: context) else {
+    guard !isStatic || isInJavaClassContext(context: context) else {
       throw MacroExpansionErrorMessage("Cannot use @JavaStaticField outside of a JavaClass instance")
     }
 
@@ -85,14 +85,10 @@ extension JavaFieldMacro: AccessorMacro {
     return accessors
   }
 
-  private static func isInStaticContext(context: some MacroExpansionContext) -> Bool {
+  private static func isInJavaClassContext(context: some MacroExpansionContext) -> Bool {
     for lexicalContext in context.lexicalContext {
-      if let classSyntax = lexicalContext.as(ClassDeclSyntax.self) {
-        if classSyntax.name.trimmedDescription.starts(with: "JavaClass<") {
-          return true
-        } else {
-          return false
-        }
+      if let classSyntax = lexicalContext.as(ExtensionDeclSyntax.self) {
+        return classSyntax.extendedType.trimmedDescription.starts(with: "JavaClass<")
       }
     }
 

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -26,6 +26,25 @@ class JavaKitMacroTests: XCTestCase {
     "JavaField": JavaFieldMacro.self
   ]
 
+  func testJavaStaticMethodFailure() throws {
+    assertMacroExpansion(
+      """
+        @JavaClass("org.swift.example.HelloWorld")
+        public struct HelloWorld {
+          @JavaStaticMethod
+          public init(environment: JNIEnvironment? = nil)
+        }
+      """,
+      expandedSource: """
+
+        public struct HelloWorld {
+        }
+      """,
+      diagnostics: [DiagnosticSpec(message: "", line: 0, column: 0)],
+      macros: Self.javaKitMacros
+    )
+  }
+
   func testJavaClass() throws {
     assertMacroExpansion("""
         @JavaClass("org.swift.example.HelloWorld")

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -23,24 +23,35 @@ class JavaKitMacroTests: XCTestCase {
   static let javaKitMacros: [String: any Macro.Type] = [
     "JavaClass": JavaClassMacro.self,
     "JavaMethod": JavaMethodMacro.self,
-    "JavaField": JavaFieldMacro.self
+    "JavaField": JavaFieldMacro.self,
+    "JavaStaticField": JavaFieldMacro.self
   ]
 
   func testJavaStaticMethodFailure() throws {
     assertMacroExpansion(
       """
         @JavaClass("org.swift.example.HelloWorld")
-        public struct HelloWorld {
-          @JavaStaticMethod
-          public init(environment: JNIEnvironment? = nil)
+        public class HelloWorld {
+          @JavaStaticField
+          public var test: String
         }
       """,
       expandedSource: """
-
-        public struct HelloWorld {
+      
+        public class HelloWorld {
+          public var test: String
+      
+            /// The full Java class name for this Swift type.
+            open override class var fullJavaClassName: String {
+                "org.swift.example.HelloWorld"
+            }
+      
+            public required init(javaHolder: JavaObjectHolder) {
+                super.init(javaHolder: javaHolder)
+            }
         }
       """,
-      diagnostics: [DiagnosticSpec(message: "", line: 0, column: 0)],
+      diagnostics: [DiagnosticSpec(message: "Cannot use @JavaStaticField outside of a JavaClass instance", line: 3, column: 5)],
       macros: Self.javaKitMacros
     )
   }

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -56,6 +56,31 @@ class JavaKitMacroTests: XCTestCase {
     )
   }
 
+  func testJavaStaticMethodSuccess() throws {
+    assertMacroExpansion(
+      """
+        extension JavaClass<HelloWorld> {
+          @JavaStaticField
+          public var test: String
+        }
+      """,
+      expandedSource: """
+      
+        extension JavaClass<HelloWorld> {
+          public var test: String {
+              get {
+                  self[javaFieldName: "test", fieldType: String.self]
+              }
+              set {
+                  self[javaFieldName: "test", fieldType: String.self] = newValue
+              }
+          }
+        }
+      """,
+      macros: Self.javaKitMacros
+    )
+  }
+
   func testJavaClass() throws {
     assertMacroExpansion("""
         @JavaClass("org.swift.example.HelloWorld")


### PR DESCRIPTION
Closes #65 

This adds support for failing macro expansion if `JavaStaticField` is used in the incorrect context.

One thing I was thinking is we can add similar logic for the `JavaStaticMethod` to fail in that context. That will fail in compilation, but it could be nicer to fail expansion vs fail in an implementation detail (of a function not existing on the type)