### PR TITLE
Add Support for Threadsafe and NotThreadSafe annotations

### DIFF
--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/JavaKitExample.swift
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/JavaKitExample.swift
@@ -76,6 +76,9 @@ extension HelloSwift: HelloSwiftNativeMethods {
       print("Caught Java error: \(error)")
     }
 
+    // Make sure that the thread safe class is sendable
+    let threadSafe: Sendable = ThreadSafeHelperClass(environment: javaEnvironment)
+
     return i * j
   }
 

--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/ThreadSafe.java
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/ThreadSafe.java
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package com.example.swift;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ThreadSafe {
+}

--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/ThreadSafeHelperClass.java
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/ThreadSafeHelperClass.java
@@ -1,0 +1,6 @@
+package com.example.swift;
+
+@ThreadSafe
+public class ThreadSafeHelperClass {
+    public ThreadSafeHelperClass() { }
+}

--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/ThreadSafeHelperClass.java
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/ThreadSafeHelperClass.java
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 package com.example.swift;
 
 @ThreadSafe

--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/swift-java.config
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/swift-java.config
@@ -2,6 +2,7 @@
   "classes" : {
     "com.example.swift.HelloSwift" : "HelloSwift",
     "com.example.swift.HelloSubclass" : "HelloSubclass",
-    "com.example.swift.JavaKitSampleMain" : "JavaKitSampleMain"
+    "com.example.swift.JavaKitSampleMain" : "JavaKitSampleMain",
+    "com.example.swift.ThreadSafeHelperClass" : "ThreadSafeHelperClass"
   }
 }

--- a/Sources/JavaKitReflection/JavaClass+Reflection.swift
+++ b/Sources/JavaKitReflection/JavaClass+Reflection.swift
@@ -43,4 +43,7 @@ extension JavaClass {
 
   @JavaMethod
   public func getGenericInterfaces() -> [Type?]
+
+  @JavaMethod
+  public func getAnnotations() -> [Annotation?]
 }


### PR DESCRIPTION
Closes #129 

This adds support for threadsafe, immutable, and notthreadsafe annotations. I was able to test this locally making jars, which I can attach if needed, but couldn't do any automated testing due to the fact that these types are not built in to Java, so I couldn't use the normal translator tests. I'm open to hearing if there are any good ways of doing automated testing for this (we could possibly build a jar in CI with the given dependencies and use that, but it's probably not great to be doing that during unit tests, especially since I think we will need to download dependencies if we want to use the real annotations in the ticket)