### PR TITLE
Update Class Layout to use Runtime Metadata

### DIFF
--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -388,7 +388,7 @@ extension Swift2JavaTranslator {
   private func printClassMemoryLayout(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
     printer.print(
       """
-      private static final GroupLayout $LAYOUT = (GroupLayout)SwiftValueWitnessTable.layoutOfSwiftType(TYPE_METADATA.$memorySegment());
+      private static final GroupLayout $LAYOUT = (GroupLayout) SwiftValueWitnessTable.layoutOfSwiftType(TYPE_METADATA.$memorySegment());
 
       public final GroupLayout $layout() {
           return $LAYOUT;

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -208,7 +208,7 @@ extension Swift2JavaTranslator {
       // Layout of the class
       printClassMemoryLayout(&printer, decl)
 
-      printer.printParts("")
+      printer.print("")
 
       // Initializers
       for initDecl in decl.initializers {

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -205,6 +205,11 @@ extension Swift2JavaTranslator {
       )
       printer.print("")
 
+      // Layout of the class
+      printClassMemoryLayout(&printer, decl)
+
+      printer.printParts("")
+
       // Initializers
       for initDecl in decl.initializers {
         printClassConstructors(&printer, initDecl)
@@ -263,9 +268,6 @@ extension Swift2JavaTranslator {
       // Constants
       printClassConstants(printer: &printer)
       printTypeMappingDecls(&printer)
-
-      // Layout of the class
-      printClassMemoryLayout(&printer, decl)
 
       body(&printer)
     }
@@ -384,12 +386,9 @@ extension Swift2JavaTranslator {
   }
 
   private func printClassMemoryLayout(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
-    // TODO: make use of the swift runtime to get the layout
     printer.print(
       """
-      private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        SWIFT_POINTER
-      ).withName("\(decl.swiftTypeName)");
+      private static final GroupLayout $LAYOUT = (GroupLayout)SwiftValueWitnessTable.layoutOfSwiftType(TYPE_METADATA.$memorySegment());
 
       public final GroupLayout $layout() {
           return $LAYOUT;

--- a/Tests/JExtractSwiftTests/ClassPrintingTests.swift
+++ b/Tests/JExtractSwiftTests/ClassPrintingTests.swift
@@ -29,10 +29,8 @@ struct ClassPrintingTests {
     import _SwiftConcurrencyShims
 
     public class MySwiftClass {
-      // MANGLED NAME: $s14MySwiftLibrary0aB5ClassC3len3capACSi_SitcfC
       public init(len: Swift.Int, cap: Swift.Int)
 
-      // MANGLED NAME: $s14MySwiftLibrary0aB5ClassC19helloMemberFunctionyyF
       public func helloMemberFunction()
 
       public func makeInt() -> Int

--- a/Tests/JExtractSwiftTests/ClassPrintingTests.swift
+++ b/Tests/JExtractSwiftTests/ClassPrintingTests.swift
@@ -57,7 +57,7 @@ struct ClassPrintingTests {
       }
 
         
-      private static final GroupLayout $LAYOUT = (GroupLayout)SwiftValueWitnessTable.layoutOfSwiftType(TYPE_METADATA.$memorySegment());
+      private static final GroupLayout $LAYOUT = (GroupLayout) SwiftValueWitnessTable.layoutOfSwiftType(TYPE_METADATA.$memorySegment());
       public final GroupLayout $layout() {
           return $LAYOUT;
       }

--- a/Tests/JExtractSwiftTests/ClassPrintingTests.swift
+++ b/Tests/JExtractSwiftTests/ClassPrintingTests.swift
@@ -28,7 +28,6 @@ struct ClassPrintingTests {
     import _StringProcessing
     import _SwiftConcurrencyShims
 
-    // MANGLED NAME: $s14MySwiftLibrary0aB5ClassCMa
     public class MySwiftClass {
       // MANGLED NAME: $s14MySwiftLibrary0aB5ClassC3len3capACSi_SitcfC
       public init(len: Swift.Int, cap: Swift.Int)

--- a/Tests/JExtractSwiftTests/ClassPrintingTests.swift
+++ b/Tests/JExtractSwiftTests/ClassPrintingTests.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import JExtractSwift
+import Testing
+
+struct ClassPrintingTests {
+  let class_interfaceFile =
+    """
+    // swift-interface-format-version: 1.0
+    // swift-compiler-version: Apple Swift version 6.0 effective-5.10 (swiftlang-6.0.0.7.6 clang-1600.0.24.1)
+    // swift-module-flags: -target arm64-apple-macosx15.0 -enable-objc-interop -enable-library-evolution -module-name MySwiftLibrary
+    import Darwin.C
+    import Darwin
+    import Swift
+    import _Concurrency
+    import _StringProcessing
+    import _SwiftConcurrencyShims
+
+    // MANGLED NAME: $s14MySwiftLibrary0aB5ClassCMa
+    public class MySwiftClass {
+      // MANGLED NAME: $s14MySwiftLibrary0aB5ClassC3len3capACSi_SitcfC
+      public init(len: Swift.Int, cap: Swift.Int)
+
+      // MANGLED NAME: $s14MySwiftLibrary0aB5ClassC19helloMemberFunctionyyF
+      public func helloMemberFunction()
+
+      public func makeInt() -> Int
+
+      @objc deinit
+    }
+    """
+
+  @Test("Import: class layout")
+  func class_layout() throws {
+    let st = Swift2JavaTranslator(
+      javaPackage: "com.example.swift",
+      swiftModuleName: "__FakeModule"
+    )
+
+    try assertOutput(st, input: class_interfaceFile, .java, expectedChunks: [
+      """
+      public static final SwiftAnyType TYPE_METADATA =
+          new SwiftAnyType(SwiftKit.swiftjava.getType("__FakeModule", "MySwiftClass"));
+      public final SwiftAnyType $swiftType() {
+          return TYPE_METADATA;
+      }
+
+        
+      private static final GroupLayout $LAYOUT = (GroupLayout)SwiftValueWitnessTable.layoutOfSwiftType(TYPE_METADATA.$memorySegment());
+      public final GroupLayout $layout() {
+          return $LAYOUT;
+      }
+      """
+    ])
+  }
+}


### PR DESCRIPTION
Closes #63 

This moves the class layout to use the `SwiftValueWitnessTable` method instead of doing it manually. This also adds a test for the translation.