### PR TITLE
Fix how we spell "classpath" consistently

### DIFF
--- a/Samples/JavaSieve/Sources/JavaSieve/main.swift
+++ b/Samples/JavaSieve/Sources/JavaSieve/main.swift
@@ -15,7 +15,7 @@
 import JavaKit
 import JavaMath
 
-let jvm = try JavaVirtualMachine.shared(classPath: ["QuadraticSieve-1.0.jar"])
+let jvm = try JavaVirtualMachine.shared(classpath: ["QuadraticSieve-1.0.jar"])
 do {
   let sieveClass = try JavaClass<SieveOfEratosthenes>(environment: jvm.environment())
   for prime in sieveClass.findPrimes(100)! {

--- a/Samples/JavaSieve/Sources/JavaSieve/swift-java.config
+++ b/Samples/JavaSieve/Sources/JavaSieve/swift-java.config
@@ -1,5 +1,5 @@
 {
-  "classPath" : "QuadraticSieve-1.0.jar",
+  "classpath" : "QuadraticSieve-1.0.jar",
   "classes" : {
     "com.gazman.quadratic_sieve.QuadraticSieve" : "QuadraticSieve",
     "com.gazman.quadratic_sieve.core.BaseFact" : "BaseFact",

--- a/Sources/Java2Swift/JavaToSwift.swift
+++ b/Sources/Java2Swift/JavaToSwift.swift
@@ -136,38 +136,38 @@ struct JavaToSwift: ParsableCommand {
 
     // Form a class path from all of our input sources:
     //   * Command-line option --classpath
-    var classPathPieces: [String] = classpath
+    var classpathPieces: [String] = classpath
     switch generationMode {
     case .configuration(jarFile: let jarFile):
       //   * Jar file (in `-jar` mode)
-      classPathPieces.append(jarFile)
+      classpathPieces.append(jarFile)
     case .classWrappers(let config):
       //   * Class path specified in the configuration file (if any)
-      config.classPath.map { classPathPieces.append($0) }
+      config.classpath.map { classpathPieces.append($0) }
     }
 
     //   * Classes paths from all dependent configuration files
     for (_, config) in dependentConfigs {
-      config.classPath.map { classPathPieces.append($0) }
+      config.classpath.map { classpathPieces.append($0) }
     }
 
     // Bring up the Java VM.
-    let jvm = try JavaVirtualMachine.shared(classPath: classPathPieces)
+    let jvm = try JavaVirtualMachine.shared(classpath: classpathPieces)
 
     // Run the generation step.
-    let classPath = classPathPieces.joined(separator: ":")
+    let classpath = classpathPieces.joined(separator: ":")
     switch generationMode {
     case .configuration(jarFile: let jarFile):
       try emitConfiguration(
         forJarFile: jarFile,
-        classPath: classPath,
+        classpath: classpath,
         environment: jvm.environment()
       )
 
     case .classWrappers(let config):
       try generateWrappers(
         config: config,
-        classPath: classPath,
+        classpath: classpath,
         dependentConfigs: dependentConfigs,
         environment: jvm.environment()
       )
@@ -177,7 +177,7 @@ struct JavaToSwift: ParsableCommand {
   /// Generate wrapper
   mutating func generateWrappers(
     config: Configuration,
-    classPath: String,
+    classpath: String,
     dependentConfigs: [(String, Configuration)],
     environment: JNIEnvironment
   ) throws {
@@ -340,10 +340,10 @@ struct JavaToSwift: ParsableCommand {
 
   mutating func emitConfiguration(
     forJarFile jarFileName: String,
-    classPath: String,
+    classpath: String,
     environment: JNIEnvironment
   ) throws {
-    var configuration = Configuration(classPath: classPath)
+    var configuration = Configuration(classpath: classpath)
 
     let jarFile = try JarFile(jarFileName, false, environment: environment)
     for entry in jarFile.entries()! {

--- a/Sources/Java2SwiftLib/Configuration.swift
+++ b/Sources/Java2SwiftLib/Configuration.swift
@@ -21,7 +21,7 @@ package typealias JavaVersion = Int
 /// must be kept in sync.
 package struct Configuration: Codable {
   /// The Java class path that should be passed along to the Java2Swift tool.
-  package var classPath: String? = nil
+  package var classpath: String? = nil
 
   /// The Java classes that should be translated to Swift. The keys are
   /// canonical Java class names (e.g., java.util.Vector) and the values are
@@ -32,12 +32,12 @@ package struct Configuration: Codable {
   package var targetCompatibility: JavaVersion?
 
   package init(
-    classPath: String? = nil,
+    classpath: String? = nil,
     classes: [String : String] = [:],
     sourceCompatibility: JavaVersion? = nil,
     targetCompatibility: JavaVersion? = nil
   ) {
-    self.classPath = classPath
+    self.classpath = classpath
     self.classes = classes
     self.sourceCompatibility = sourceCompatibility
     self.targetCompatibility = targetCompatibility

--- a/Sources/JavaKit/JavaKitVM/JavaVirtualMachine.swift
+++ b/Sources/JavaKit/JavaKitVM/JavaVirtualMachine.swift
@@ -44,7 +44,7 @@ public final class JavaVirtualMachine: @unchecked Sendable {
   /// Initialize a new Java virtual machine instance.
   ///
   /// - Parameters:
-  ///   - classPath: The directories, JAR files, and ZIP files in which the JVM
+  ///   - classpath: The directories, JAR files, and ZIP files in which the JVM
   ///     should look to find classes. This maps to the VM option
   ///     `-Djava.class.path=`.
   ///   - vmOptions: Options that should be passed along to the JVM, which will
@@ -52,7 +52,7 @@ public final class JavaVirtualMachine: @unchecked Sendable {
   ///   - ignoreUnrecognized: Whether the JVM should ignore any VM options it
   ///     does not recognize.
   private init(
-    classPath: [String] = [],
+    classpath: [String] = [],
     vmOptions: [String] = [],
     ignoreUnrecognized: Bool = false
   ) throws {
@@ -64,14 +64,14 @@ public final class JavaVirtualMachine: @unchecked Sendable {
 
     // Construct the complete list of VM options.
     var allVMOptions: [String] = []
-    if !classPath.isEmpty {
+    if !classpath.isEmpty {
       let fileManager = FileManager.default
-      for path in classPath {
+      for path in classpath {
         if !fileManager.fileExists(atPath: path) {
-          throw JavaKitError.classPathEntryNotFound(entry: path, classPath: classPath)
+          throw JavaKitError.classpathEntryNotFound(entry: path, classpath: classpath)
         }
       }
-      let colonSeparatedClassPath = classPath.joined(separator: ":")
+      let colonSeparatedClassPath = classpath.joined(separator: ":")
       allVMOptions.append("-Djava.class.path=\(colonSeparatedClassPath)")
     }
     allVMOptions.append(contentsOf: vmOptions)
@@ -183,7 +183,7 @@ extension JavaVirtualMachine {
   /// calls.
   ///
   /// - Parameters:
-  ///   - classPath: The directories, JAR files, and ZIP files in which the JVM
+  ///   - classpath: The directories, JAR files, and ZIP files in which the JVM
   ///     should look to find classes. This maps to the VM option
   ///     `-Djava.class.path=`.
   ///   - vmOptions: Options that should be passed along to the JVM, which will
@@ -191,7 +191,7 @@ extension JavaVirtualMachine {
   ///   - ignoreUnrecognized: Whether the JVM should ignore any VM options it
   ///     does not recognize.
   public static func shared(
-    classPath: [String] = [],
+    classpath: [String] = [],
     vmOptions: [String] = [],
     ignoreUnrecognized: Bool = false
   ) throws -> JavaVirtualMachine {
@@ -225,7 +225,7 @@ extension JavaVirtualMachine {
           let javaVirtualMachine: JavaVirtualMachine
           do {
             javaVirtualMachine = try JavaVirtualMachine(
-              classPath: classPath,
+              classpath: classpath,
               vmOptions: vmOptions,
               ignoreUnrecognized: ignoreUnrecognized
             )
@@ -289,6 +289,6 @@ extension JavaVirtualMachine {
   }
 
   enum JavaKitError: Error {
-    case classPathEntryNotFound(entry: String, classPath: [String])
+    case classpathEntryNotFound(entry: String, classpath: [String])
   }
 }

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -111,7 +111,7 @@ The resulting configuration file will look something like this:
 
 ```json
 {
-  "classPath" : "QuadraticSieve-1.0.jar",
+  "classpath" : "QuadraticSieve-1.0.jar",
   "classes" : {
     "com.gazman.quadratic_sieve.QuadraticSieve" : "QuadraticSieve",
     "com.gazman.quadratic_sieve.core.BaseFact" : "BaseFact",
@@ -206,7 +206,7 @@ Putting it all together, we can define a main program in `Sources/JavaSieve/main
 ```swift
 import JavaKit
 
-let jvm = try JavaVirtualMachine.shared(classPath: ["QuadraticSieve-1.0.jar"])
+let jvm = try JavaVirtualMachine.shared(classpath: ["QuadraticSieve-1.0.jar"])
 do {
   let sieveClass = try JavaClass<SieveOfEratosthenes>(environment: jvm.environment())
   for prime in sieveClass.findPrimes(100)! {
@@ -217,7 +217,7 @@ do {
 }
 ```
 
-Note that we are passing the Jar file in the `classPath` argument when initializing the `JavaVirtualMachine` instance. Otherwise, the program will fail with an error because it cannot find the Java class `com.gazman.quadratic_sieve.primes.SieveOfEratosthenes`.
+Note that we are passing the Jar file in the `classpath` argument when initializing the `JavaVirtualMachine` instance. Otherwise, the program will fail with an error because it cannot find the Java class `com.gazman.quadratic_sieve.primes.SieveOfEratosthenes`.
 
 ### Downcasting
 


### PR DESCRIPTION
Otherwise it gets too confusing when mixing java and swift tools, the common way to spell the word is "classpath" without the uppercased P, even though in prose the words are "class path" and the shorthand "cp".