### PR TITLE
get rid of some of the warnings in Java2Swift generated sources: generics

### DIFF
--- a/Sources/Java2SwiftLib/JavaClassTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaClassTranslator.swift
@@ -104,10 +104,23 @@ struct JavaClassTranslator {
     }
 
     let genericParameters = javaTypeParameters.map { param in
-      "\(param.getName()): AnyJavaObject"
+      let name = generateGenericParameterName(param.getName())
+      translator.usedGenericParameterNames.insert(param.getName())
+      return "\(name): AnyJavaObject"
     }
 
     return "<\(genericParameters.joined(separator: ", "))>"
+  }
+
+  /// If the name already exists, append a 1 to it.
+  /// For example, if name = "T" and it already exists, the result will be "T1".
+  private func generateGenericParameterName(_ baseName: String) -> String {
+    var name = baseName
+    let index = 1
+    if translator.usedGenericParameterNames.contains(name) {
+      name = "\(baseName)\(index)"
+    }
+    return name
   }
 
   /// Prepare translation for the given Java class (or interface).
@@ -392,7 +405,9 @@ extension JavaClassTranslator {
     let staticMemberWhereClause: String
     if !javaTypeParameters.isEmpty {
       let genericParameterNames = javaTypeParameters.compactMap { typeVar in
-        typeVar.getName()
+        let name = generateGenericParameterName(typeVar.getName())
+        translator.usedGenericParameterNames.insert(typeVar.getName())
+        return name
       }
 
       let genericArgumentClause = "<\(genericParameterNames.joined(separator: ", "))>"

--- a/Sources/Java2SwiftLib/JavaTranslator.swift
+++ b/Sources/Java2SwiftLib/JavaTranslator.swift
@@ -63,6 +63,9 @@ package class JavaTranslator {
   /// TODO: Make JavaClass Hashable so we can index by the object?
   package var nestedClasses: [String: [JavaClass<JavaObject>]] = [:]
 
+  /// The set of generic parameter names that have been used.
+  package var usedGenericParameterNames: Set<String> = []
+
   package init(
     swiftModuleName: String,
     environment: JNIEnvironment,
@@ -78,6 +81,7 @@ package class JavaTranslator {
   /// Clear out any per-file state when we want to start a new file.
   package func startNewFile() {
     importedSwiftModules = Self.defaultImportedSwiftModules
+    usedGenericParameterNames = []
   }
 
   /// Simplistic logging for all entities that couldn't be translated.

--- a/Sources/JavaKit/generated/JavaClass.swift
+++ b/Sources/JavaKit/generated/JavaClass.swift
@@ -52,13 +52,16 @@ open class JavaClass<T: AnyJavaObject>: JavaObject {
   open func isRecord() -> Bool
 
   @JavaMethod
+  open func isSealed() -> Bool
+
+  @JavaMethod
+  open func getInterfaces() -> [JavaClass<JavaObject>?]
+
+  @JavaMethod
   open func getClassLoader() -> JavaClassLoader!
 
   @JavaMethod
   open func newInstance() throws -> JavaObject!
-
-  @JavaMethod
-  open func getInterfaces() -> [JavaClass<JavaObject>?]
 
   @JavaMethod
   open func isMemberClass() -> Bool
@@ -128,17 +131,14 @@ open class JavaClass<T: AnyJavaObject>: JavaObject {
 
   @JavaMethod
   open func getNestMembers() -> [JavaClass<JavaObject>?]
-
-  @JavaMethod
-  open func isSealed() -> Bool
 }
 extension JavaClass {
   @JavaStaticMethod
-  public func forName<T: AnyJavaObject>(_ arg0: String, _ arg1: Bool, _ arg2: JavaClassLoader?) throws -> JavaClass<JavaObject>! where ObjectType == JavaClass<T>
+  public func forName<T1: AnyJavaObject>(_ arg0: String, _ arg1: Bool, _ arg2: JavaClassLoader?) throws -> JavaClass<JavaObject>! where ObjectType == JavaClass<T1>
 
   @JavaStaticMethod
-  public func forName<T: AnyJavaObject>(_ arg0: String) throws -> JavaClass<JavaObject>! where ObjectType == JavaClass<T>
+  public func forName<T1: AnyJavaObject>(_ arg0: String) throws -> JavaClass<JavaObject>! where ObjectType == JavaClass<T1>
 
   @JavaStaticMethod
-  public func forPrimitiveName<T: AnyJavaObject>(_ arg0: String) -> JavaClass<JavaObject>! where ObjectType == JavaClass<T>
+  public func forPrimitiveName<T1: AnyJavaObject>(_ arg0: String) -> JavaClass<JavaObject>! where ObjectType == JavaClass<T1>
 }

--- a/Sources/JavaKit/generated/JavaOptional.swift
+++ b/Sources/JavaKit/generated/JavaOptional.swift
@@ -29,23 +29,23 @@ open class JavaOptional<T: AnyJavaObject>: JavaObject {
 }
 extension JavaClass {
   @JavaStaticMethod
-  public func of<T: AnyJavaObject>(_ arg0: JavaObject?) -> JavaOptional<JavaObject>! where ObjectType == JavaOptional<T>
+  public func of<T1: AnyJavaObject>(_ arg0: JavaObject?) -> JavaOptional<JavaObject>! where ObjectType == JavaOptional<T1>
 
-  public func ofOptional<T: AnyJavaObject>(_ arg0: JavaObject?) -> JavaObject? where ObjectType == JavaOptional<T> {
+  public func ofOptional<T1: AnyJavaObject>(_ arg0: JavaObject?) -> JavaObject? where ObjectType == JavaOptional<T1> {
     Optional(javaOptional: of(arg0))
   }
 
   @JavaStaticMethod
-  public func empty<T: AnyJavaObject>() -> JavaOptional<JavaObject>! where ObjectType == JavaOptional<T>
+  public func empty<T1: AnyJavaObject>() -> JavaOptional<JavaObject>! where ObjectType == JavaOptional<T1>
 
-  public func emptyOptional<T: AnyJavaObject>() -> JavaObject? where ObjectType == JavaOptional<T> {
+  public func emptyOptional<T1: AnyJavaObject>() -> JavaObject? where ObjectType == JavaOptional<T1> {
     Optional(javaOptional: empty())
   }
 
   @JavaStaticMethod
-  public func ofNullable<T: AnyJavaObject>(_ arg0: JavaObject?) -> JavaOptional<JavaObject>! where ObjectType == JavaOptional<T>
+  public func ofNullable<T1: AnyJavaObject>(_ arg0: JavaObject?) -> JavaOptional<JavaObject>! where ObjectType == JavaOptional<T1>
 
-  public func ofNullableOptional<T: AnyJavaObject>(_ arg0: JavaObject?) -> JavaObject? where ObjectType == JavaOptional<T> {
+  public func ofNullableOptional<T1: AnyJavaObject>(_ arg0: JavaObject?) -> JavaObject? where ObjectType == JavaOptional<T1> {
     Optional(javaOptional: ofNullable(arg0))
   }
 }

--- a/Sources/JavaKit/generated/JavaString.swift
+++ b/Sources/JavaKit/generated/JavaString.swift
@@ -52,16 +52,16 @@ open class JavaString: JavaObject {
   open func getChars(_ arg0: Int32, _ arg1: Int32, _ arg2: [UInt16], _ arg3: Int32)
 
   @JavaMethod
-  open func compareTo(_ arg0: JavaObject?) -> Int32
-
-  @JavaMethod
   open func compareTo(_ arg0: String) -> Int32
 
   @JavaMethod
-  open func indexOf(_ arg0: String, _ arg1: Int32, _ arg2: Int32) -> Int32
+  open func compareTo(_ arg0: JavaObject?) -> Int32
 
   @JavaMethod
-  open func indexOf(_ arg0: String) -> Int32
+  open func indexOf(_ arg0: String, _ arg1: Int32) -> Int32
+
+  @JavaMethod
+  open func indexOf(_ arg0: String, _ arg1: Int32, _ arg2: Int32) -> Int32
 
   @JavaMethod
   open func indexOf(_ arg0: Int32) -> Int32
@@ -73,7 +73,7 @@ open class JavaString: JavaObject {
   open func indexOf(_ arg0: Int32, _ arg1: Int32, _ arg2: Int32) -> Int32
 
   @JavaMethod
-  open func indexOf(_ arg0: String, _ arg1: Int32) -> Int32
+  open func indexOf(_ arg0: String) -> Int32
 
   @JavaMethod
   open func charAt(_ arg0: Int32) -> UInt16
@@ -91,19 +91,19 @@ open class JavaString: JavaObject {
   open func offsetByCodePoints(_ arg0: Int32, _ arg1: Int32) -> Int32
 
   @JavaMethod
-  open func getBytes() -> [Int8]
-
-  @JavaMethod
   open func getBytes(_ arg0: String) throws -> [Int8]
 
   @JavaMethod
   open func getBytes(_ arg0: Int32, _ arg1: Int32, _ arg2: [Int8], _ arg3: Int32)
 
   @JavaMethod
-  open func regionMatches(_ arg0: Bool, _ arg1: Int32, _ arg2: String, _ arg3: Int32, _ arg4: Int32) -> Bool
+  open func getBytes() -> [Int8]
 
   @JavaMethod
   open func regionMatches(_ arg0: Int32, _ arg1: String, _ arg2: Int32, _ arg3: Int32) -> Bool
+
+  @JavaMethod
+  open func regionMatches(_ arg0: Bool, _ arg1: Int32, _ arg2: String, _ arg3: Int32, _ arg4: Int32) -> Bool
 
   @JavaMethod
   open func startsWith(_ arg0: String) -> Bool
@@ -112,22 +112,22 @@ open class JavaString: JavaObject {
   open func startsWith(_ arg0: String, _ arg1: Int32) -> Bool
 
   @JavaMethod
-  open func lastIndexOf(_ arg0: String) -> Int32
+  open func lastIndexOf(_ arg0: Int32) -> Int32
 
   @JavaMethod
-  open func lastIndexOf(_ arg0: Int32, _ arg1: Int32) -> Int32
+  open func lastIndexOf(_ arg0: String) -> Int32
 
   @JavaMethod
   open func lastIndexOf(_ arg0: String, _ arg1: Int32) -> Int32
 
   @JavaMethod
-  open func lastIndexOf(_ arg0: Int32) -> Int32
-
-  @JavaMethod
-  open func substring(_ arg0: Int32) -> String
+  open func lastIndexOf(_ arg0: Int32, _ arg1: Int32) -> Int32
 
   @JavaMethod
   open func substring(_ arg0: Int32, _ arg1: Int32) -> String
+
+  @JavaMethod
+  open func substring(_ arg0: Int32) -> String
 
   @JavaMethod
   open func isEmpty() -> Bool
@@ -216,38 +216,38 @@ open class JavaString: JavaObject {
 }
 extension JavaClass<JavaString> {
   @JavaStaticMethod
-  public func valueOf(_ arg0: Int64) -> String
-
-  @JavaStaticMethod
-  public func valueOf(_ arg0: [UInt16]) -> String
-
-  @JavaStaticMethod
   public func valueOf(_ arg0: JavaObject?) -> String
 
   @JavaStaticMethod
-  public func valueOf(_ arg0: [UInt16], _ arg1: Int32, _ arg2: Int32) -> String
-
-  @JavaStaticMethod
-  public func valueOf(_ arg0: Float) -> String
-
-  @JavaStaticMethod
-  public func valueOf(_ arg0: Double) -> String
-
-  @JavaStaticMethod
-  public func valueOf(_ arg0: UInt16) -> String
-
-  @JavaStaticMethod
-  public func valueOf(_ arg0: Bool) -> String
+  public func valueOf(_ arg0: Int64) -> String
 
   @JavaStaticMethod
   public func valueOf(_ arg0: Int32) -> String
 
   @JavaStaticMethod
+  public func valueOf(_ arg0: UInt16) -> String
+
+  @JavaStaticMethod
+  public func valueOf(_ arg0: [UInt16], _ arg1: Int32, _ arg2: Int32) -> String
+
+  @JavaStaticMethod
+  public func valueOf(_ arg0: Bool) -> String
+
+  @JavaStaticMethod
+  public func valueOf(_ arg0: Double) -> String
+
+  @JavaStaticMethod
+  public func valueOf(_ arg0: [UInt16]) -> String
+
+  @JavaStaticMethod
+  public func valueOf(_ arg0: Float) -> String
+
+  @JavaStaticMethod
   public func format(_ arg0: String, _ arg1: [JavaObject?]) -> String
 
   @JavaStaticMethod
-  public func copyValueOf(_ arg0: [UInt16]) -> String
+  public func copyValueOf(_ arg0: [UInt16], _ arg1: Int32, _ arg2: Int32) -> String
 
   @JavaStaticMethod
-  public func copyValueOf(_ arg0: [UInt16], _ arg1: Int32, _ arg2: Int32) -> String
+  public func copyValueOf(_ arg0: [UInt16]) -> String
 }

--- a/Sources/JavaKitCollection/generated/BitSet.swift
+++ b/Sources/JavaKitCollection/generated/BitSet.swift
@@ -5,37 +5,19 @@ import JavaRuntime
 @JavaClass("java.util.BitSet")
 open class BitSet: JavaObject {
   @JavaMethod
-  @_nonoverride public convenience init(environment: JNIEnvironment? = nil)
-
-  @JavaMethod
   @_nonoverride public convenience init(_ arg0: Int32, environment: JNIEnvironment? = nil)
 
   @JavaMethod
-  open func cardinality() -> Int32
-
-  @JavaMethod
-  open func nextSetBit(_ arg0: Int32) -> Int32
-
-  @JavaMethod
-  open func toLongArray() -> [Int64]
-
-  @JavaMethod
-  open func previousSetBit(_ arg0: Int32) -> Int32
-
-  @JavaMethod
-  open func previousClearBit(_ arg0: Int32) -> Int32
-
-  @JavaMethod
-  open func intersects(_ arg0: BitSet?) -> Bool
+  @_nonoverride public convenience init(environment: JNIEnvironment? = nil)
 
   @JavaMethod
   open func size() -> Int32
 
   @JavaMethod
-  open func get(_ arg0: Int32, _ arg1: Int32) -> BitSet!
+  open func get(_ arg0: Int32) -> Bool
 
   @JavaMethod
-  open func get(_ arg0: Int32) -> Bool
+  open func get(_ arg0: Int32, _ arg1: Int32) -> BitSet!
 
   @JavaMethod
   open override func equals(_ arg0: JavaObject?) -> Bool
@@ -53,28 +35,28 @@ open class BitSet: JavaObject {
   open override func clone() -> JavaObject!
 
   @JavaMethod
-  open func clear(_ arg0: Int32)
-
-  @JavaMethod
   open func clear(_ arg0: Int32, _ arg1: Int32)
 
   @JavaMethod
   open func clear()
 
   @JavaMethod
+  open func clear(_ arg0: Int32)
+
+  @JavaMethod
   open func isEmpty() -> Bool
 
   @JavaMethod
-  open func set(_ arg0: Int32, _ arg1: Int32, _ arg2: Bool)
-
-  @JavaMethod
-  open func set(_ arg0: Int32, _ arg1: Int32)
+  open func set(_ arg0: Int32, _ arg1: Bool)
 
   @JavaMethod
   open func set(_ arg0: Int32)
 
   @JavaMethod
-  open func set(_ arg0: Int32, _ arg1: Bool)
+  open func set(_ arg0: Int32, _ arg1: Int32)
+
+  @JavaMethod
+  open func set(_ arg0: Int32, _ arg1: Int32, _ arg2: Bool)
 
   @JavaMethod
   open func flip(_ arg0: Int32, _ arg1: Int32)
@@ -99,6 +81,24 @@ open class BitSet: JavaObject {
 
   @JavaMethod
   open func andNot(_ arg0: BitSet?)
+
+  @JavaMethod
+  open func cardinality() -> Int32
+
+  @JavaMethod
+  open func nextSetBit(_ arg0: Int32) -> Int32
+
+  @JavaMethod
+  open func toLongArray() -> [Int64]
+
+  @JavaMethod
+  open func previousSetBit(_ arg0: Int32) -> Int32
+
+  @JavaMethod
+  open func previousClearBit(_ arg0: Int32) -> Int32
+
+  @JavaMethod
+  open func intersects(_ arg0: BitSet?) -> Bool
 }
 extension JavaClass<BitSet> {
   @JavaStaticMethod

--- a/Sources/JavaKitCollection/generated/HashMap.swift
+++ b/Sources/JavaKitCollection/generated/HashMap.swift
@@ -61,57 +61,7 @@ open class HashMap<K: AnyJavaObject, V: AnyJavaObject>: JavaObject {
   @JavaMethod
   open func getOrDefault(_ arg0: JavaObject?, _ arg1: JavaObject?) -> JavaObject!
 }
-extension HashMap {
-  @JavaClass("java.util.AbstractMap$SimpleEntry")
-  open class SimpleEntry<K: AnyJavaObject, V: AnyJavaObject>: JavaObject {
-  @JavaMethod
-  @_nonoverride public convenience init(_ arg0: JavaObject?, _ arg1: JavaObject?, environment: JNIEnvironment? = nil)
-
-  @JavaMethod
-  open override func equals(_ arg0: JavaObject?) -> Bool
-
-  @JavaMethod
-  open override func toString() -> String
-
-  @JavaMethod
-  open override func hashCode() -> Int32
-
-  @JavaMethod
-  open func getValue() -> JavaObject!
-
-  @JavaMethod
-  open func getKey() -> JavaObject!
-
-  @JavaMethod
-  open func setValue(_ arg0: JavaObject?) -> JavaObject!
-  }
-}
-extension HashMap {
-  @JavaClass("java.util.AbstractMap$SimpleImmutableEntry")
-  open class SimpleImmutableEntry<K: AnyJavaObject, V: AnyJavaObject>: JavaObject {
-  @JavaMethod
-  @_nonoverride public convenience init(_ arg0: JavaObject?, _ arg1: JavaObject?, environment: JNIEnvironment? = nil)
-
-  @JavaMethod
-  open override func equals(_ arg0: JavaObject?) -> Bool
-
-  @JavaMethod
-  open override func toString() -> String
-
-  @JavaMethod
-  open override func hashCode() -> Int32
-
-  @JavaMethod
-  open func getValue() -> JavaObject!
-
-  @JavaMethod
-  open func getKey() -> JavaObject!
-
-  @JavaMethod
-  open func setValue(_ arg0: JavaObject?) -> JavaObject!
-  }
-}
 extension JavaClass {
   @JavaStaticMethod
-  public func newHashMap<K: AnyJavaObject, V: AnyJavaObject>(_ arg0: Int32) -> HashMap<JavaObject, JavaObject>! where ObjectType == HashMap<K, V>
+  public func newHashMap<K1: AnyJavaObject, V1: AnyJavaObject>(_ arg0: Int32) -> HashMap<JavaObject, JavaObject>! where ObjectType == HashMap<K1, V1>
 }

--- a/Sources/JavaKitCollection/generated/HashSet.swift
+++ b/Sources/JavaKitCollection/generated/HashSet.swift
@@ -48,5 +48,5 @@ open class HashSet<E: AnyJavaObject>: JavaObject {
 }
 extension JavaClass {
   @JavaStaticMethod
-  public func newHashSet<E: AnyJavaObject>(_ arg0: Int32) -> HashSet<JavaObject>! where ObjectType == HashSet<E>
+  public func newHashSet<E1: AnyJavaObject>(_ arg0: Int32) -> HashSet<JavaObject>! where ObjectType == HashSet<E1>
 }

--- a/Sources/JavaKitCollection/generated/JavaSet.swift
+++ b/Sources/JavaKitCollection/generated/JavaSet.swift
@@ -51,41 +51,41 @@ public struct JavaSet<E: AnyJavaObject> {
 }
 extension JavaClass {
   @JavaStaticMethod
-  public func copyOf<E: AnyJavaObject>(_ arg0: JavaCollection<JavaObject>?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func copyOf<E1: AnyJavaObject>(_ arg0: JavaCollection<JavaObject>?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>() -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>() -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?, _ arg9: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?, _ arg9: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: [JavaObject?]) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: [JavaObject?]) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?) -> JavaSet<JavaObject>! where ObjectType == JavaSet<E1>
 }

--- a/Sources/JavaKitCollection/generated/List.swift
+++ b/Sources/JavaKitCollection/generated/List.swift
@@ -102,41 +102,41 @@ public struct List<E: AnyJavaObject> {
 }
 extension JavaClass {
   @JavaStaticMethod
-  public func copyOf<E: AnyJavaObject>(_ arg0: JavaCollection<JavaObject>?) -> List<JavaObject>! where ObjectType == List<E>
+  public func copyOf<E1: AnyJavaObject>(_ arg0: JavaCollection<JavaObject>?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>() -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>() -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: [JavaObject?]) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: [JavaObject?]) -> List<JavaObject>! where ObjectType == List<E1>
 
   @JavaStaticMethod
-  public func of<E: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?, _ arg9: JavaObject?) -> List<JavaObject>! where ObjectType == List<E>
+  public func of<E1: AnyJavaObject>(_ arg0: JavaObject?, _ arg1: JavaObject?, _ arg2: JavaObject?, _ arg3: JavaObject?, _ arg4: JavaObject?, _ arg5: JavaObject?, _ arg6: JavaObject?, _ arg7: JavaObject?, _ arg8: JavaObject?, _ arg9: JavaObject?) -> List<JavaObject>! where ObjectType == List<E1>
 }

--- a/Sources/JavaKitCollection/generated/TreeMap.swift
+++ b/Sources/JavaKitCollection/generated/TreeMap.swift
@@ -70,3 +70,53 @@ open class TreeMap<K: AnyJavaObject, V: AnyJavaObject>: JavaObject {
   @JavaMethod
   open func lastKey() -> JavaObject!
 }
+extension TreeMap {
+  @JavaClass("java.util.AbstractMap$SimpleEntry")
+  open class SimpleEntry<K1: AnyJavaObject, V1: AnyJavaObject>: JavaObject {
+  @JavaMethod
+  @_nonoverride public convenience init(_ arg0: JavaObject?, _ arg1: JavaObject?, environment: JNIEnvironment? = nil)
+
+  @JavaMethod
+  open override func equals(_ arg0: JavaObject?) -> Bool
+
+  @JavaMethod
+  open override func toString() -> String
+
+  @JavaMethod
+  open override func hashCode() -> Int32
+
+  @JavaMethod
+  open func getValue() -> JavaObject!
+
+  @JavaMethod
+  open func getKey() -> JavaObject!
+
+  @JavaMethod
+  open func setValue(_ arg0: JavaObject?) -> JavaObject!
+  }
+}
+extension TreeMap {
+  @JavaClass("java.util.AbstractMap$SimpleImmutableEntry")
+  open class SimpleImmutableEntry<K1: AnyJavaObject, V1: AnyJavaObject>: JavaObject {
+  @JavaMethod
+  @_nonoverride public convenience init(_ arg0: JavaObject?, _ arg1: JavaObject?, environment: JNIEnvironment? = nil)
+
+  @JavaMethod
+  open override func equals(_ arg0: JavaObject?) -> Bool
+
+  @JavaMethod
+  open override func toString() -> String
+
+  @JavaMethod
+  open override func hashCode() -> Int32
+
+  @JavaMethod
+  open func getValue() -> JavaObject!
+
+  @JavaMethod
+  open func getKey() -> JavaObject!
+
+  @JavaMethod
+  open func setValue(_ arg0: JavaObject?) -> JavaObject!
+  }
+}

--- a/Sources/JavaKitNetwork/generated/URLClassLoader.swift
+++ b/Sources/JavaKitNetwork/generated/URLClassLoader.swift
@@ -4,18 +4,24 @@ import JavaKitCollection
 import JavaRuntime
 
 @JavaClass("java.net.URLClassLoader")
-open class URLClassLoader: JavaObject {
+open class URLClassLoader: JavaClassLoader {
+  @JavaMethod
+  @_nonoverride public convenience init(_ arg0: String, _ arg1: [URL?], _ arg2: JavaClassLoader?, environment: JNIEnvironment? = nil)
+
+  @JavaMethod
+  @_nonoverride public convenience init(_ arg0: [URL?], _ arg1: JavaClassLoader?, environment: JNIEnvironment? = nil)
+
   @JavaMethod
   @_nonoverride public convenience init(_ arg0: [URL?], environment: JNIEnvironment? = nil)
 
   @JavaMethod
-  open func findResource(_ arg0: String) -> URL!
+  open override func findResource(_ arg0: String) -> URL!
 
   @JavaMethod
-  open func findClass(_ arg0: String) throws -> JavaClass<JavaObject>!
+  open override func findClass(_ arg0: String) throws -> JavaClass<JavaObject>!
 
   @JavaMethod
-  open func findResources(_ arg0: String) throws -> Enumeration<URL>!
+  open override func findResources(_ arg0: String) throws -> Enumeration<URL>!
 
   @JavaMethod
   open func close() throws


### PR DESCRIPTION
Tries to solve #169

I got rid of some of the warning but I'm now stuck.

The following classes were translated appropriately
```
JavaOptional.swift
HashMap.swift
HashSet.swift
JavaSet.swift
List.swift
```

These classes were generated with a different order of methods and variables, I don't know why that happened.
```
JavaClass.swift
JavaString.swift
BitSet.swift
```
This class generates a bad translation which is not a valid class, I don't know why that happedned.
```
URLClassLoader.swift
```