### PR TITLE
Introduce staged lowering of Swift to `@_cdecl` Swift to C

### DIFF
--- a/Sources/JExtractSwift/CDeclLowering/CDeclConversions.swift
+++ b/Sources/JExtractSwift/CDeclLowering/CDeclConversions.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension ConversionStep {
+  /// Produce a conversion that takes in a value (or set of values) that
+  /// would be available in a @_cdecl function to represent the given Swift
+  /// type, and convert that to an instance of the Swift type.
+  init(cdeclToSwift swiftType: SwiftType) throws {
+    switch swiftType {
+    case .function, .optional:
+      throw LoweringError.unhandledType(swiftType)
+
+    case .metatype(let instanceType):
+      self = .unsafeCastPointer(
+        .placeholder,
+        swiftType: instanceType
+      )
+
+    case .nominal(let nominal):
+      if let knownType = nominal.nominalTypeDecl.knownStandardLibraryType {
+        // Swift types that map to primitive types in C. These can be passed
+        // through directly.
+        if knownType.primitiveCType != nil {
+          self = .placeholder
+          return
+        }
+
+        // Typed pointers
+        if let firstGenericArgument = nominal.genericArguments?.first {
+          switch knownType {
+          case .unsafePointer, .unsafeMutablePointer:
+            self = .typedPointer(
+              .explodedComponent(.placeholder, component: "pointer"),
+              swiftType: firstGenericArgument
+            )
+            return
+
+          case .unsafeBufferPointer, .unsafeMutableBufferPointer:
+            self = .initialize(
+              swiftType,
+              arguments: [
+                LabeledArgument(
+                  label: "start",
+                  argument: .typedPointer(
+                    .explodedComponent(.placeholder, component: "pointer"),
+                    swiftType: firstGenericArgument)
+                ),
+                LabeledArgument(
+                  label: "count",
+                  argument: .explodedComponent(.placeholder, component: "count")
+                )
+              ]
+            )
+            return
+
+          default:
+            break
+          }
+        }
+      }
+
+      // Arbitrary nominal types.
+      switch nominal.nominalTypeDecl.kind {
+      case .actor, .class:
+        // For actor and class, we pass around the pointer directly.
+        self = .unsafeCastPointer(.placeholder, swiftType: swiftType)
+      case .enum, .struct, .protocol:
+        // For enums, structs, and protocol types, we pass around the
+        // values indirectly.
+        self = .passIndirectly(
+          .pointee(.typedPointer(.placeholder, swiftType: swiftType))
+        )
+      }
+
+    case .tuple(let elements):
+      self = .tuplify(try elements.map { try ConversionStep(cdeclToSwift: $0) })
+    }
+  }
+}

--- a/Sources/JExtractSwift/CDeclLowering/CDeclConversions.swift
+++ b/Sources/JExtractSwift/CDeclLowering/CDeclConversions.swift
@@ -17,6 +17,14 @@ extension ConversionStep {
   /// would be available in a @_cdecl function to represent the given Swift
   /// type, and convert that to an instance of the Swift type.
   init(cdeclToSwift swiftType: SwiftType) throws {
+    // If there is a 1:1 mapping between this Swift type and a C type, then
+    // there is no translation to do.
+    if let cType = try? CType(cdeclType: swiftType) {
+      _ = cType
+      self = .placeholder
+      return
+    }
+
     switch swiftType {
     case .function, .optional:
       throw LoweringError.unhandledType(swiftType)
@@ -29,13 +37,6 @@ extension ConversionStep {
 
     case .nominal(let nominal):
       if let knownType = nominal.nominalTypeDecl.knownStandardLibraryType {
-        // Swift types that map to primitive types in C. These can be passed
-        // through directly.
-        if knownType.primitiveCType != nil {
-          self = .placeholder
-          return
-        }
-
         // Typed pointers
         if let firstGenericArgument = nominal.genericArguments?.first {
           switch knownType {
@@ -100,6 +101,14 @@ extension ConversionStep {
     swiftToCDecl swiftType: SwiftType,
     stdlibTypes: SwiftStandardLibraryTypes
   ) throws {
+    // If there is a 1:1 mapping between this Swift type and a C type, then
+    // there is no translation to do.
+    if let cType = try? CType(cdeclType: swiftType) {
+      _ = cType
+      self = .placeholder
+      return
+    }
+
     switch swiftType {
     case .function, .optional:
       throw LoweringError.unhandledType(swiftType)
@@ -117,13 +126,6 @@ extension ConversionStep {
 
     case .nominal(let nominal):
       if let knownType = nominal.nominalTypeDecl.knownStandardLibraryType {
-        // Swift types that map to primitive types in C. These can be passed
-        // through directly.
-        if knownType.primitiveCType != nil {
-          self = .placeholder
-          return
-        }
-
         // Typed pointers
         if nominal.genericArguments?.first != nil {
           switch knownType {

--- a/Sources/JExtractSwift/CDeclLowering/CRepresentation.swift
+++ b/Sources/JExtractSwift/CDeclLowering/CRepresentation.swift
@@ -16,8 +16,11 @@ extension CType {
   /// Lower the given Swift type down to a its corresponding C type.
   ///
   /// This operation only supports the subset of Swift types that are
-  /// representable in a Swift `@_cdecl` function. If lowering an arbitrary
-  /// Swift function, first go through Swift -> cdecl lowering.
+  /// representable in a Swift `@_cdecl` function, which means that they are
+  /// also directly representable in C. If lowering an arbitrary Swift
+  /// function, first go through Swift -> cdecl lowering. This function
+  /// will throw an error if it encounters a type that is not expressible in
+  /// C.
   init(cdeclType: SwiftType) throws {
     switch cdeclType {
     case .nominal(let nominalType):

--- a/Sources/JExtractSwift/CDeclLowering/Swift2JavaTranslator+FunctionLowering.swift
+++ b/Sources/JExtractSwift/CDeclLowering/Swift2JavaTranslator+FunctionLowering.swift
@@ -49,6 +49,7 @@ extension Swift2JavaTranslator {
 
     return try lowerFunctionSignature(signature)
   }
+
   /// Lower the given Swift function signature to a Swift @_cdecl function signature,
   /// which is C compatible, and the corresponding Java method signature.
   ///
@@ -332,6 +333,11 @@ extension LoweredFunctionSignature {
     // Add the @_cdecl attribute.
     let cdeclAttribute: AttributeSyntax = "@_cdecl(\(literal: cName))\n"
     loweredCDecl.attributes.append(.attribute(cdeclAttribute))
+
+    // Make it public.
+    loweredCDecl.modifiers.append(
+      DeclModifierSyntax(name: .keyword(.public), trailingTrivia: .space)
+    )
 
     // Create the body.
 

--- a/Sources/JExtractSwift/CDeclLowering/Swift2JavaTranslator+FunctionLowering.swift
+++ b/Sources/JExtractSwift/CDeclLowering/Swift2JavaTranslator+FunctionLowering.swift
@@ -113,6 +113,13 @@ extension Swift2JavaTranslator {
       contentsOf: loweredParameters.flatMap { $0.cdeclParameters }
     )
 
+    // Lower self.
+    if let loweredSelf {
+      allLoweredParameters.append(loweredSelf)
+      cdeclLoweredParameters.append(contentsOf: loweredSelf.cdeclParameters)
+    }
+
+    // Lower indirect results.
     let cdeclResult: SwiftResult
     if indirectResult {
       cdeclLoweredParameters.append(
@@ -126,11 +133,6 @@ extension Swift2JavaTranslator {
       cdeclResult = .init(convention: .direct, type: .tuple([]))
     } else {
       fatalError("Improper lowering of result for \(signature)")
-    }
-
-    if let loweredSelf {
-      allLoweredParameters.append(loweredSelf)
-      cdeclLoweredParameters.append(contentsOf: loweredSelf.cdeclParameters)
     }
 
     let cdeclSignature = SwiftFunctionSignature(

--- a/Sources/JExtractSwift/CTypes/CEnum.swift
+++ b/Sources/JExtractSwift/CTypes/CEnum.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a C enum type.
+public class CEnum {
+  public var name: String
+  public init(name: String) {
+    self.name = name
+  }
+}

--- a/Sources/JExtractSwift/CTypes/CFunction.swift
+++ b/Sources/JExtractSwift/CTypes/CFunction.swift
@@ -48,10 +48,9 @@ extension CFunction: CustomStringConvertible {
   public var description: String {
     var result = ""
 
-    resultType.printBefore(result: &result)
+    var hasEmptyPlaceholder = false
+    resultType.printBefore(hasEmptyPlaceholder: &hasEmptyPlaceholder, result: &result)
 
-    // FIXME: parentheses when needed.
-    result += " "
     result += name
 
     // Function parameters.
@@ -64,7 +63,10 @@ extension CFunction: CustomStringConvertible {
     )
     result += ")"
 
-    resultType.printAfter(result: &result)
+    resultType.printAfter(
+      hasEmptyPlaceholder: &hasEmptyPlaceholder,
+      result: &result
+    )
 
     result += ""
     return result

--- a/Sources/JExtractSwift/CTypes/CFunction.swift
+++ b/Sources/JExtractSwift/CTypes/CFunction.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a C function.
+public struct CFunction {
+  /// The result type of the function.
+  public var resultType: CType
+
+  /// The name of the function.
+  public var name: String
+
+  /// The parameters of the function.
+  public var parameters: [CParameter]
+
+  /// Whether the function is variadic.
+  public var isVariadic: Bool
+
+  public init(resultType: CType, name: String, parameters: [CParameter], isVariadic: Bool) {
+    self.resultType = resultType
+    self.name = name
+    self.parameters = parameters
+    self.isVariadic = isVariadic
+  }
+
+  /// Produces the type of the function.
+  public var functionType: CType {
+    .function(
+      resultType: resultType,
+      parameters: parameters.map { $0.type },
+      variadic: isVariadic
+    )
+  }
+}
+
+extension CFunction: CustomStringConvertible {
+  /// Print the declaration of this C function
+  public var description: String {
+    var result = ""
+
+    resultType.printBefore(result: &result)
+
+    // FIXME: parentheses when needed.
+    result += " "
+    result += name
+
+    // Function parameters.
+    result += "("
+    result += parameters.map { $0.description }.joined(separator: ", ")
+    CType.printFunctionParametersSuffix(
+      isVariadic: isVariadic,
+      hasZeroParameters: parameters.isEmpty,
+      to: &result
+    )
+    result += ")"
+
+    resultType.printAfter(result: &result)
+
+    result += ""
+    return result
+  }
+}

--- a/Sources/JExtractSwift/CTypes/CParameter.swift
+++ b/Sources/JExtractSwift/CTypes/CParameter.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a parameter to a C function.
+public struct CParameter {
+  /// The name of the parameter, if provided.
+  public var name: String?
+
+  /// The type of the parameter.
+  public var type: CType
+
+  public init(name: String? = nil, type: CType) {
+    self.name = name
+    self.type = type
+  }
+}
+
+extension CParameter: CustomStringConvertible {
+  public var description: String {
+    type.print(placeholder: name ?? "")
+  }
+}

--- a/Sources/JExtractSwift/CTypes/CStruct.swift
+++ b/Sources/JExtractSwift/CTypes/CStruct.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a C struct type.
+public class CStruct {
+  public var name: String
+
+  public init(name: String) {
+    self.name = name
+  }
+}

--- a/Sources/JExtractSwift/CTypes/CTag.swift
+++ b/Sources/JExtractSwift/CTypes/CTag.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a tag type in C, which is either a struct or an enum.
+public enum CTag {
+  case `struct`(CStruct)
+  case `enum`(CEnum)
+  case `union`(CUnion)
+
+  public var name: String {
+    switch self {
+      case .struct(let cStruct): return cStruct.name
+      case .enum(let cEnum): return cEnum.name
+      case .union(let cUnion): return cUnion.name
+    }
+  }
+}
+

--- a/Sources/JExtractSwift/CTypes/CType.swift
+++ b/Sources/JExtractSwift/CTypes/CType.swift
@@ -195,3 +195,16 @@ extension CType: CustomStringConvertible {
     print(placeholder: nil)
   }
 }
+
+extension CType {
+  /// Apply the rules for function parameter decay to produce the resulting
+  /// decayed type. For example, this will adjust a function type to a
+  /// pointer-to-function type.
+  var parameterDecay: CType {
+    switch self {
+    case .floating, .integral, .pointer, .qualified, .tag, .void: self
+
+    case .function: .pointer(self)
+    }
+  }
+}

--- a/Sources/JExtractSwift/CTypes/CType.swift
+++ b/Sources/JExtractSwift/CTypes/CType.swift
@@ -1,0 +1,197 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a type in the C type system as it is used for lowering of Swift
+/// declarations to C.
+///
+/// This description of the C type system only has to account for the types
+/// that are used when providing C-compatible thunks from Swift code. It is
+/// not a complete representation of the C type system, and leaves some
+/// target-specific types (like the actual type that ptrdiff_t and size_t
+/// map to) unresolved.
+public enum CType {
+  /// A tag type, such as a struct or enum.
+  case tag(CTag)
+
+  /// An integral type.
+  case integral(IntegralType)
+
+  /// A floating-point type.
+  case floating(FloatingType)
+
+  case void
+
+  /// A qualiied type, such as 'const T'.
+  indirect case qualified(const: Bool, volatile: Bool, type: CType)
+
+  /// A pointer to the given type.
+  indirect case pointer(CType)
+
+  /// A function type.
+  indirect case function(resultType: CType, parameters: [CType], variadic: Bool)
+
+  /// An integral type in C, described mostly in terms of the bit-sized
+  /// typedefs rather than actual C types (like int or long), because Swift
+  /// deals in bit-widths.
+  public enum IntegralType {
+    case bool
+
+    /// A signed integer type stored with the given number of bits. This
+    /// corresponds to the intNNN_t types from <stdint.h>.
+    case signed(bits: Int)
+
+    /// An unsigned integer type stored with the given number of bits. This
+    /// corresponds to the uintNNN_t types from <stdint.h>.
+    case unsigned(bits: Int)
+
+    /// The ptrdiff_t type, which in C is a typedef for the signed integer
+    /// type that is the same size as a pointer.
+    case ptrdiff_t
+
+    /// The size_t type, which in C is a typedef for the unsigned integer
+    /// type that is the same size as a pointer.
+    case size_t
+  }
+
+  /// A floating point type in C.
+  public enum FloatingType {
+    case float
+    case double
+  }
+}
+
+extension CType: CustomStringConvertible {
+  /// Print the part of this type that comes before the declarator, appending
+  /// it to the provided `result` string.
+  func printBefore(result: inout String) {
+    switch self {
+    case .floating(let floating):
+      switch floating {
+      case .float: result += "float"
+      case .double: result += "double"
+      }
+
+    case .function(resultType: let resultType, parameters: _, variadic: _):
+      resultType.printBefore(result: &result)
+
+      // FIXME: Clang inserts a parentheses in here if there's a non-empty
+      // placeholder, which is Very Stateful. How should I model that?
+
+    case .integral(let integral):
+      switch integral {
+      case .bool: result += "_Bool"
+      case .signed(let bits): result += "int\(bits)_t"
+      case .unsigned(let bits): result += "uint\(bits)_t"
+      case .ptrdiff_t: result += "ptrdiff_t"
+      case .size_t: result += "size_t"
+      }
+
+    case .pointer(let pointee):
+      pointee.printBefore(result: &result)
+      result += "*"
+
+    case .qualified(const: let isConst, volatile: let isVolatile, type: let underlying):
+      underlying.printBefore(result: &result)
+
+      // FIXME: "east const" is easier to print correctly, so do that. We could
+      // follow Clang and decide when it's correct to print "west const" by
+      // splitting the qualifiers before we get here.
+      if isConst {
+        result += " const"
+      }
+      if isVolatile {
+        result += " volatile"
+      }
+
+    case .tag(let tag):
+      switch tag {
+      case .enum(let cEnum): result += "enum \(cEnum.name)"
+      case .struct(let cStruct): result += "struct \(cStruct.name)"
+      case .union(let cUnion): result += "union \(cUnion.name)"
+      }
+
+    case .void: result += "void"
+    }
+  }
+
+  /// Render an appropriate "suffix" to the parameter list of a function,
+  /// which goes just before the closing ")" of that function, appending
+  /// it to the string. This includes whether the function is variadic and
+  /// whether is had zero parameters.
+  static func printFunctionParametersSuffix(
+    isVariadic: Bool,
+    hasZeroParameters: Bool,
+    to result: inout String
+  ) {
+    // Take care of variadic parameters and empty parameter lists together,
+    // because the formatter of the former depends on the latter.
+    switch (isVariadic, hasZeroParameters) {
+    case (true, false): result += ", ..."
+    case (true, true): result += "..."
+    case (false, true): result += "void"
+    case (false, false): break
+    }
+  }
+
+  /// Print the part of the type that comes after the declarator, appending
+  /// it to the provided `result` string.
+  func printAfter(result: inout String) {
+    switch self {
+    case .floating, .integral, .tag, .void: break
+
+    case .function(resultType: let resultType, parameters: let parameters, variadic: let variadic):
+      // FIXME: Clang inserts a parentheses in here if there's a non-empty
+      // placeholder, which is Very Stateful. How should I model that?
+
+      result += "("
+
+      // Render the parameter types.
+      result += parameters.map { $0.description }.joined(separator: ", ")
+
+      CType.printFunctionParametersSuffix(
+        isVariadic: variadic,
+        hasZeroParameters: parameters.isEmpty,
+        to: &result
+      )
+
+      result += ")"
+
+      resultType.printAfter(result: &result)
+
+    case .pointer(let pointee):
+      pointee.printAfter(result: &result)
+
+    case .qualified(const: _, volatile: _, type: let underlying):
+      underlying.printAfter(result: &result)
+    }
+  }
+
+  /// Print this type into a string, with the given placeholder as the name
+  /// of the entity being declared.
+  public func print(placeholder: String?) -> String {
+    var result = ""
+    printBefore(result: &result)
+    if let placeholder {
+      result += " "
+      result += placeholder
+    }
+    printAfter(result: &result)
+    return result
+  }
+
+  /// Render the C type into a string that represents the type in C.
+  public var description: String {
+    print(placeholder: nil)
+  }
+}

--- a/Sources/JExtractSwift/CTypes/CUnion.swift
+++ b/Sources/JExtractSwift/CTypes/CUnion.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a C union type.
+public class CUnion {
+  public var name: String
+  public init(name: String) {
+    self.name = name
+  }
+}

--- a/Sources/JExtractSwift/ConversionStep.swift
+++ b/Sources/JExtractSwift/ConversionStep.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Describes the transformation needed to take the parameters of a thunk
+/// and map them to the corresponding parameter (or result value) of the
+/// original function.
+enum ConversionStep: Equatable {
+  /// The value being lowered.
+  case placeholder
+
+  /// A reference to a component in a value that has been exploded, such as
+  /// a tuple element or part of a buffer pointer.
+  indirect case explodedComponent(ConversionStep, component: String)
+
+  /// Cast the pointer described by the lowering step to the given
+  /// Swift type using `unsafeBitCast(_:to:)`.
+  indirect case unsafeCastPointer(ConversionStep, swiftType: SwiftType)
+
+  /// Assume at the untyped pointer described by the lowering step to the
+  /// given type, using `assumingMemoryBound(to:).`
+  indirect case typedPointer(ConversionStep, swiftType: SwiftType)
+
+  /// The thing to which the pointer typed, which is the `pointee` property
+  /// of the `Unsafe(Mutable)Pointer` types in Swift.
+  indirect case pointee(ConversionStep)
+
+  /// Pass this value indirectly, via & for explicit `inout` parameters.
+  indirect case passIndirectly(ConversionStep)
+
+  /// Initialize a value of the given Swift type with the set of labeled
+  /// arguments.
+  case initialize(SwiftType, arguments: [LabeledArgument<ConversionStep>])
+
+  /// Produce a tuple with the given elements.
+  ///
+  /// This is used for exploding Swift tuple arguments into multiple
+  /// elements, recursively. Note that this always produces unlabeled
+  /// tuples, which Swift will convert to the labeled tuple form.
+  case tuplify([ConversionStep])
+
+  /// Convert the conversion step into an expression with the given
+  /// value as the placeholder value in the expression.
+  func asExprSyntax(isSelf: Bool, placeholder: String) -> ExprSyntax {
+    switch self {
+    case .placeholder:
+      return "\(raw: placeholder)"
+
+    case .explodedComponent(let step, component: let component):
+      return step.asExprSyntax(isSelf: false, placeholder: "\(placeholder)_\(component)")
+
+    case .unsafeCastPointer(let step, swiftType: let swiftType):
+      let untypedExpr = step.asExprSyntax(isSelf: false, placeholder: placeholder)
+      return "unsafeBitCast(\(untypedExpr), to: \(swiftType.metatypeReferenceExprSyntax))"
+
+    case .typedPointer(let step, swiftType: let type):
+      let untypedExpr = step.asExprSyntax(isSelf: isSelf, placeholder: placeholder)
+      return "\(untypedExpr).assumingMemoryBound(to: \(type.metatypeReferenceExprSyntax))"
+
+    case .pointee(let step):
+      let untypedExpr = step.asExprSyntax(isSelf: isSelf, placeholder: placeholder)
+      return "\(untypedExpr).pointee"
+
+    case .passIndirectly(let step):
+      let innerExpr = step.asExprSyntax(isSelf: false, placeholder: placeholder)
+      return isSelf ? innerExpr : "&\(innerExpr)"
+
+    case .initialize(let type, arguments: let arguments):
+      let renderedArguments: [String] = arguments.map { labeledArgument in
+        let renderedArg = labeledArgument.argument.asExprSyntax(isSelf: false, placeholder: placeholder)
+        if let argmentLabel = labeledArgument.label {
+          return "\(argmentLabel): \(renderedArg.description)"
+        } else {
+          return renderedArg.description
+        }
+      }
+
+      // FIXME: Should be able to use structured initializers here instead
+      // of splatting out text.
+      let renderedArgumentList = renderedArguments.joined(separator: ", ")
+      return "\(raw: type.description)(\(raw: renderedArgumentList))"
+
+    case .tuplify(let elements):
+      let renderedElements: [String] = elements.enumerated().map { (index, element) in
+        element.asExprSyntax(isSelf: false, placeholder: "\(placeholder)_\(index)").description
+      }
+
+      // FIXME: Should be able to use structured initializers here instead
+      // of splatting out text.
+      let renderedElementList = renderedElements.joined(separator: ", ")
+      return "(\(raw: renderedElementList))"
+    }
+  }
+}

--- a/Sources/JExtractSwift/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator.swift
@@ -39,7 +39,7 @@ public final class Swift2JavaTranslator {
   /// type representation.
   package var importedTypes: [String: ImportedNominalType] = [:]
 
-  var swiftStdlibTypes: SwiftStandardLibraryTypes
+  public var swiftStdlibTypes: SwiftStandardLibraryTypes
 
   let symbolTable: SwiftSymbolTable
   let nominalResolution: NominalTypeResolution = NominalTypeResolution()

--- a/Sources/JExtractSwift/SwiftTypes/SwiftFunctionType.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftFunctionType.swift
@@ -27,7 +27,12 @@ struct SwiftFunctionType: Equatable {
 
 extension SwiftFunctionType: CustomStringConvertible {
   var description: String {
-    return  "(\(parameters.map { $0.descriptionInType } )) -> \(resultType.description)"
+    let parameterString = parameters.map { $0.descriptionInType }.joined(separator: ", ")
+    let conventionPrefix = switch convention {
+    case .c: "@convention(c) "
+    case .swift: ""
+    }
+    return  "\(conventionPrefix)(\(parameterString)) -> \(resultType.description)"
   }
 }
 

--- a/Sources/JExtractSwift/SwiftTypes/SwiftNominalTypeDeclaration.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftNominalTypeDeclaration.swift
@@ -42,6 +42,12 @@ class SwiftNominalTypeDeclaration {
 
   // TODO: Generic parameters.
 
+  /// Identify this nominal declaration as one of the known standard library
+  /// types, like 'Swift.Int[.
+  lazy var knownStandardLibraryType: KnownStandardLibraryType? = {
+    self.computeKnownStandardLibraryType()
+  }()
+
   /// Create a nominal type declaration from the syntax node for a nominal type
   /// declaration.
   init(
@@ -62,6 +68,16 @@ class SwiftNominalTypeDeclaration {
     case .structDecl: self.kind = .struct
     default: fatalError("Not a nominal type declaration")
     }
+  }
+
+  /// Determine the known standard library type for this nominal type
+  /// declaration.
+  private func computeKnownStandardLibraryType() -> KnownStandardLibraryType? {
+    if parent != nil || moduleName != "Swift" {
+      return nil
+    }
+
+    return KnownStandardLibraryType(typeNameInSwiftModule: name)
   }
 }
 

--- a/Sources/JExtractSwift/SwiftTypes/SwiftParameter.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftParameter.swift
@@ -19,6 +19,7 @@ struct SwiftParameter: Equatable {
   var argumentLabel: String?
   var parameterName: String?
   var type: SwiftType
+  var isPrimitive = false
 }
 
 extension SwiftParameter: CustomStringConvertible {

--- a/Sources/JExtractSwift/SwiftTypes/SwiftParameter.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftParameter.swift
@@ -19,7 +19,7 @@ struct SwiftParameter: Equatable {
   var argumentLabel: String?
   var parameterName: String?
   var type: SwiftType
-  var isPrimitive = false
+  var canBeDirectReturn = false
 }
 
 extension SwiftParameter: CustomStringConvertible {

--- a/Sources/JExtractSwift/SwiftTypes/SwiftParameter.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftParameter.swift
@@ -64,8 +64,10 @@ extension SwiftParameter {
     var type = node.type
     var convention = SwiftParameterConvention.byValue
     if let attributedType = type.as(AttributedTypeSyntax.self) {
+      var sawUnknownSpecifier = false
       for specifier in attributedType.specifiers {
         guard case .simpleTypeSpecifier(let simple) = specifier else {
+          sawUnknownSpecifier = true
           continue
         }
 
@@ -75,13 +77,15 @@ extension SwiftParameter {
         case .keyword(.inout):
           convention = .inout
         default:
+          sawUnknownSpecifier = true
           break
         }
       }
 
       // Ignore anything else in the attributed type.
-      // FIXME: We might want to check for these and ignore them.
-      type = attributedType.baseType
+      if !sawUnknownSpecifier && attributedType.attributes.isEmpty {
+        type = attributedType.baseType
+      }
     }
     self.convention = convention
 

--- a/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes+CLowering.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes+CLowering.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension SwiftStandardLibraryTypes {
+  /// Lower the given Swift type down to a its corresponding C type.
+  ///
+  /// This operation only supports the subset of Swift types that are
+  /// representable in a Swift `@_cdecl` function. If lowering an arbitrary
+  /// Swift function, first go through Swift -> cdecl lowering.
+  func cdeclToCLowering(_ swiftType: SwiftType) throws -> CType {
+    switch swiftType {
+    case .nominal(let nominalType):
+      if let knownType = self[nominalType.nominalTypeDecl] {
+        return try knownType.loweredCType()
+      }
+
+      throw CDeclToCLoweringError.invalidNominalType(nominalType.nominalTypeDecl)
+
+    case .function(let functionType):
+      switch functionType.convention {
+      case .swift:
+        throw CDeclToCLoweringError.invalidFunctionConvention(functionType)
+
+      case .c:
+        let resultType = try cdeclToCLowering(functionType.resultType)
+        let parameterTypes = try functionType.parameters.map { param in
+          try cdeclToCLowering(param.type)
+        }
+
+        return .function(
+          resultType: resultType,
+          parameters: parameterTypes,
+          variadic: false
+        )
+      }
+
+    case .tuple([]):
+      return .void
+
+    case .metatype, .optional, .tuple:
+      throw CDeclToCLoweringError.invalidCDeclType(swiftType)
+    }
+  }
+}
+
+extension KnownStandardLibraryType {
+  func loweredCType() throws -> CType {
+    switch self {
+    case .bool: .integral(.bool)
+    case .int: .integral(.ptrdiff_t)
+    case .uint: .integral(.size_t)
+    case .int8: .integral(.signed(bits: 8))
+    case .uint8: .integral(.unsigned(bits: 8))
+    case .int16: .integral(.signed(bits: 16))
+    case .uint16: .integral(.unsigned(bits: 16))
+    case .int32: .integral(.signed(bits: 32))
+    case .uint32: .integral(.unsigned(bits: 32))
+    case .int64: .integral(.signed(bits: 64))
+    case .uint64: .integral(.unsigned(bits: 64))
+    case .float: .floating(.float)
+    case .double: .floating(.double)
+    case .unsafeMutableRawPointer: .pointer(.void)
+    case .unsafeRawPointer: .pointer(
+      .qualified(const: true, volatile: false, type: .void)
+    )
+    }
+  }
+}
+enum CDeclToCLoweringError: Error {
+  case invalidCDeclType(SwiftType)
+  case invalidNominalType(SwiftNominalTypeDeclaration)
+  case invalidFunctionConvention(SwiftFunctionType)
+}
+

--- a/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes.swift
@@ -14,45 +14,45 @@
 
 import SwiftSyntax
 
-enum KnownStandardLibraryType: Int, Hashable, CaseIterable {
-  case bool = 0
-  case int
-  case uint
-  case int8
-  case uint8
-  case int16
-  case uint16
-  case int32
-  case uint32
-  case int64
-  case uint64
-  case float
-  case double
-  case unsafeRawPointer
-  case unsafeMutableRawPointer
+enum KnownStandardLibraryType: String, Hashable, CaseIterable {
+  case bool = "Bool"
+  case int = "Int"
+  case uint = "UInt"
+  case int8 = "Int8"
+  case uint8 = "UInt8"
+  case int16 = "Int16"
+  case uint16 = "UInt16"
+  case int32 = "Int32"
+  case uint32 = "UInt32"
+  case int64 = "Int64"
+  case uint64 = "UInt64"
+  case float = "Float"
+  case double = "Double"
+  case unsafeRawPointer = "UnsafeRawPointer"
+  case unsafeMutableRawPointer = "UnsafeMutableRawPointer"
+  case unsafePointer = "UnsafePointer"
+  case unsafeMutablePointer = "UnsafeMutablePointer"
+  case unsafeBufferPointer = "UnsafeBufferPointer"
+  case unsafeMutableBufferPointer = "UnsafeMutableBufferPointer"
 
-  var typeName: String {
-    switch self {
-      case .bool: return "Bool"
-      case .int: return "Int"
-      case .uint: return "UInt"
-      case .int8: return "Int8"
-      case .uint8: return "UInt8"
-      case .int16: return "Int16"
-      case .uint16: return "UInt16"
-      case .int32: return "Int32"
-      case .uint32: return "UInt32"
-      case .int64: return "Int64"
-      case .uint64: return "UInt64"
-      case .float: return "Float"
-      case .double: return "Double"
-      case .unsafeRawPointer: return "UnsafeRawPointer"
-      case .unsafeMutableRawPointer: return "UnsafeMutableRawPointer"
-    }
+  var typeName: String { rawValue }
+
+  init?(typeNameInSwiftModule: String) {
+    self.init(rawValue: typeNameInSwiftModule)
   }
 
+  /// Whether this declaration is generic.
   var isGeneric: Bool {
-    false
+    switch self {
+    case .bool, .double, .float, .int, .int8, .int16, .int32, .int64,
+        .uint, .uint8, .uint16, .uint32, .uint64, .unsafeRawPointer,
+        .unsafeMutableRawPointer:
+      false
+
+    case .unsafePointer, .unsafeMutablePointer, .unsafeBufferPointer,
+        .unsafeMutableBufferPointer:
+      true
+    }
   }
 }
 

--- a/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes.swift
@@ -14,75 +14,101 @@
 
 import SwiftSyntax
 
+enum KnownStandardLibraryType: Int, Hashable, CaseIterable {
+  case bool = 0
+  case int
+  case uint
+  case int8
+  case uint8
+  case int16
+  case uint16
+  case int32
+  case uint32
+  case int64
+  case uint64
+  case float
+  case double
+  case unsafeRawPointer
+  case unsafeMutableRawPointer
+
+  var typeName: String {
+    switch self {
+      case .bool: return "Bool"
+      case .int: return "Int"
+      case .uint: return "UInt"
+      case .int8: return "Int8"
+      case .uint8: return "UInt8"
+      case .int16: return "Int16"
+      case .uint16: return "UInt16"
+      case .int32: return "Int32"
+      case .uint32: return "UInt32"
+      case .int64: return "Int64"
+      case .uint64: return "UInt64"
+      case .float: return "Float"
+      case .double: return "Double"
+      case .unsafeRawPointer: return "UnsafeRawPointer"
+      case .unsafeMutableRawPointer: return "UnsafeMutableRawPointer"
+    }
+  }
+
+  var isGeneric: Bool {
+    false
+  }
+}
+
 /// Captures many types from the Swift standard library in their most basic
 /// forms, so that the translator can reason about them in source code.
 struct SwiftStandardLibraryTypes {
-  /// Swift.UnsafeRawPointer
-  var unsafeRawPointerDecl: SwiftNominalTypeDeclaration
-
-  /// Swift.UnsafeMutableRawPointer
-  var unsafeMutableRawPointerDecl: SwiftNominalTypeDeclaration
-
   // Swift.UnsafePointer<Element>
-  var unsafePointerDecl: SwiftNominalTypeDeclaration
+  let unsafePointerDecl: SwiftNominalTypeDeclaration
 
   // Swift.UnsafeMutablePointer<Element>
-  var unsafeMutablePointerDecl: SwiftNominalTypeDeclaration
+  let unsafeMutablePointerDecl: SwiftNominalTypeDeclaration
 
   // Swift.UnsafeBufferPointer<Element>
-  var unsafeBufferPointerDecl: SwiftNominalTypeDeclaration
+  let unsafeBufferPointerDecl: SwiftNominalTypeDeclaration
 
   // Swift.UnsafeMutableBufferPointer<Element>
-  var unsafeMutableBufferPointerDecl: SwiftNominalTypeDeclaration
+  let unsafeMutableBufferPointerDecl: SwiftNominalTypeDeclaration
 
-  /// Swift.Bool
-  var boolDecl: SwiftNominalTypeDeclaration
+  /// Mapping from known standard library types to their nominal type declaration.
+  let knownTypeToNominal: [KnownStandardLibraryType: SwiftNominalTypeDeclaration]
 
-  /// Swift.Int8
-  var int8Decl: SwiftNominalTypeDeclaration
+  /// Mapping from nominal type declarations to known types.
+  let nominalTypeDeclToKnownType: [SwiftNominalTypeDeclaration: KnownStandardLibraryType]
 
-  /// Swift.Int16
-  var int16Decl: SwiftNominalTypeDeclaration
+  private static func recordKnownType(
+    _ type: KnownStandardLibraryType,
+    _ syntax: NominalTypeDeclSyntaxNode,
+    knownTypeToNominal: inout [KnownStandardLibraryType: SwiftNominalTypeDeclaration],
+    nominalTypeDeclToKnownType: inout [SwiftNominalTypeDeclaration: KnownStandardLibraryType],
+    parsedModule: inout SwiftParsedModuleSymbolTable
+  ) {
+    let nominalDecl = parsedModule.addNominalTypeDeclaration(syntax, parent: nil)
+    knownTypeToNominal[type] = nominalDecl
+    nominalTypeDeclToKnownType[nominalDecl] = type
+  }
 
-  /// Swift.UInt16
-  var uint16Decl: SwiftNominalTypeDeclaration
-
-  /// Swift.Int32
-  var int32Decl: SwiftNominalTypeDeclaration
-
-  /// Swift.Int64
-  var int64Decl: SwiftNominalTypeDeclaration
-
-  /// Swift.Int
-  var intDecl: SwiftNominalTypeDeclaration
-
-  /// Swift.Float
-  var floatDecl: SwiftNominalTypeDeclaration
-
-  /// Swift.Double
-  var doubleDecl: SwiftNominalTypeDeclaration
-
-  /// Swift.String
-  var stringDecl: SwiftNominalTypeDeclaration
+  private static func recordKnownNonGenericStruct(
+    _ type: KnownStandardLibraryType,
+    knownTypeToNominal: inout [KnownStandardLibraryType: SwiftNominalTypeDeclaration],
+    nominalTypeDeclToKnownType: inout [SwiftNominalTypeDeclaration: KnownStandardLibraryType],
+    parsedModule: inout SwiftParsedModuleSymbolTable
+  ) {
+    recordKnownType(
+      type,
+      StructDeclSyntax(
+        name: .identifier(type.typeName),
+        memberBlock: .init(members: [])
+      ),
+      knownTypeToNominal: &knownTypeToNominal,
+      nominalTypeDeclToKnownType: &nominalTypeDeclToKnownType,
+      parsedModule: &parsedModule
+    )
+  }
 
   init(into parsedModule: inout SwiftParsedModuleSymbolTable) {
     // Pointer types
-    self.unsafeRawPointerDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("UnsafeRawPointer"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-
-    self.unsafeMutableRawPointerDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("UnsafeMutableRawPointer"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-
     self.unsafePointerDecl = parsedModule.addNominalTypeDeclaration(
       StructDeclSyntax(
         name: .identifier("UnsafePointer"),
@@ -127,82 +153,32 @@ struct SwiftStandardLibraryTypes {
       parent: nil
     )
 
-    self.boolDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Bool"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.intDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Int"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.int8Decl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Int8"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.int16Decl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Int16"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.uint16Decl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("UInt16"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.int32Decl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Int32"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.int64Decl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Int64"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.floatDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Float"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.doubleDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Double"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.intDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("Int"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
-    self.stringDecl = parsedModule.addNominalTypeDeclaration(
-      StructDeclSyntax(
-        name: .identifier("String"),
-        memberBlock: .init(members: [])
-      ),
-      parent: nil
-    )
+    var knownTypeToNominal: [KnownStandardLibraryType: SwiftNominalTypeDeclaration] = [:]
+    var nominalTypeDeclToKnownType: [SwiftNominalTypeDeclaration: KnownStandardLibraryType] = [:]
+
+    // Handle all of the non-generic types at once.
+    for knownType in KnownStandardLibraryType.allCases {
+      guard !knownType.isGeneric else {
+        continue
+      }
+
+      Self.recordKnownNonGenericStruct(
+        knownType,
+        knownTypeToNominal: &knownTypeToNominal,
+        nominalTypeDeclToKnownType: &nominalTypeDeclToKnownType,
+        parsedModule: &parsedModule
+      )
+    }
+
+    self.knownTypeToNominal = knownTypeToNominal
+    self.nominalTypeDeclToKnownType = nominalTypeDeclToKnownType
+  }
+
+  subscript(knownType: KnownStandardLibraryType) -> SwiftNominalTypeDeclaration {
+    knownTypeToNominal[knownType]!
+  }
+
+  subscript(nominalType: SwiftNominalTypeDeclaration) -> KnownStandardLibraryType? {
+    nominalTypeDeclToKnownType[nominalType]
   }
 }

--- a/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftStandardLibraryTypes.swift
@@ -58,7 +58,7 @@ enum KnownStandardLibraryType: String, Hashable, CaseIterable {
 
 /// Captures many types from the Swift standard library in their most basic
 /// forms, so that the translator can reason about them in source code.
-struct SwiftStandardLibraryTypes {
+public struct SwiftStandardLibraryTypes {
   // Swift.UnsafePointer<Element>
   let unsafePointerDecl: SwiftNominalTypeDeclaration
 

--- a/Sources/JExtractSwift/SwiftTypes/SwiftType.swift
+++ b/Sources/JExtractSwift/SwiftTypes/SwiftType.swift
@@ -129,12 +129,12 @@ extension SwiftType {
       // Only recognize the "@convention(c)" and "@convention(swift)" attributes, and
       // then only on function types.
       // FIXME: This string matching is a horrible hack.
-      switch attributedType.trimmedDescription {
+      switch attributedType.attributes.trimmedDescription {
       case "@convention(c)", "@convention(swift)":
         let innerType = try SwiftType(attributedType.baseType, symbolTable: symbolTable)
         switch innerType {
         case .function(var functionType):
-          let isConventionC = attributedType.trimmedDescription == "@convention(c)"
+          let isConventionC = attributedType.attributes.trimmedDescription == "@convention(c)"
           let convention: SwiftFunctionType.Convention = isConventionC ? .c : .swift
           functionType.convention = convention
           self = .function(functionType)

--- a/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
@@ -47,7 +47,11 @@ func assertLoweredFunction(
     inputFunction,
     enclosingType: enclosingType
   )
-  let loweredCDecl = loweredFunction.cdeclThunk(cName: "c_\(inputFunction.name.text)", inputFunction: inputFunction)
+  let loweredCDecl = loweredFunction.cdeclThunk(
+    cName: "c_\(inputFunction.name.text)",
+    inputFunction: inputFunction,
+    stdlibTypes: translator.swiftStdlibTypes
+  )
 
   #expect(
     loweredCDecl.description == expectedCDecl.description,

--- a/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
@@ -25,6 +25,7 @@ func assertLoweredFunction(
   sourceFile: SourceFileSyntax? = nil,
   enclosingType: TypeSyntax? = nil,
   expectedCDecl: DeclSyntax,
+  expectedCFunction: String,
   fileID: String = #fileID,
   filePath: String = #filePath,
   line: Int = #line,
@@ -50,6 +51,20 @@ func assertLoweredFunction(
 
   #expect(
     loweredCDecl.description == expectedCDecl.description,
+    sourceLocation: Testing.SourceLocation(
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  )
+
+  let cFunction = translator.cdeclToCFunctionLowering(
+    loweredFunction.cdecl,
+    cName: "c_\(inputFunction.name.text)"
+  )
+  #expect(
+    cFunction.description == expectedCFunction,
     sourceLocation: Testing.SourceLocation(
       fileID: fileID,
       filePath: filePath,

--- a/Tests/JExtractSwiftTests/CTypeTests.swift
+++ b/Tests/JExtractSwiftTests/CTypeTests.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import JExtractSwift
+import Testing
+
+@Suite("C type system tests")
+struct CTypeTests {
+  @Test("Function declaration printing")
+  func testFunctionDeclarationPrint() {
+    let malloc = CFunction(
+      resultType: .pointer(.void),
+      name: "malloc",
+      parameters: [
+        CParameter(name: "size", type: .integral(.size_t))
+      ],
+      isVariadic: false
+    )
+    #expect(malloc.description == "void* malloc(size_t size)")
+
+    let free = CFunction(
+      resultType: .void,
+      name: "free",
+      parameters: [
+        CParameter(name: "ptr", type: .pointer(.void))
+      ],
+      isVariadic: false
+    )
+    #expect(free.description == "void free(void* ptr)")
+
+    let snprintf = CFunction(
+      resultType: .integral(.signed(bits: 32)),
+      name: "snprintf",
+      parameters: [
+        CParameter(name: "str", type: .pointer(.integral(.signed(bits: 8)))),
+        CParameter(name: "size", type: .integral(.size_t)),
+        CParameter(
+          name: "format",
+          type: .pointer(
+            .qualified(
+              const: true,
+              volatile: false,
+              type: .integral(.signed(bits: 8))
+            )
+          )
+        )
+      ],
+      isVariadic: true
+    )
+    #expect(snprintf.description == "int32_t snprintf(int8_t* str, size_t size, int8_t const* format, ...)")
+    #expect(snprintf.functionType.description == "int32_t(int8_t*, size_t, int8_t const*, ...)")
+
+    let rand = CFunction(
+      resultType: .integral(.signed(bits: 32)),
+      name: "rand",
+      parameters: [],
+      isVariadic: false
+    )
+    #expect(rand.description == "int32_t rand(void)")
+    #expect(rand.functionType.description == "int32_t(void)")
+  }
+}

--- a/Tests/JExtractSwiftTests/CTypeTests.swift
+++ b/Tests/JExtractSwiftTests/CTypeTests.swift
@@ -17,7 +17,7 @@ import Testing
 
 @Suite("C type system tests")
 struct CTypeTests {
-  @Test("Function declaration printing")
+  @Test("C function declaration printing")
   func testFunctionDeclarationPrint() {
     let malloc = CFunction(
       resultType: .pointer(.void),
@@ -27,7 +27,7 @@ struct CTypeTests {
       ],
       isVariadic: false
     )
-    #expect(malloc.description == "void* malloc(size_t size)")
+    #expect(malloc.description == "void *malloc(size_t size)")
 
     let free = CFunction(
       resultType: .void,
@@ -37,7 +37,7 @@ struct CTypeTests {
       ],
       isVariadic: false
     )
-    #expect(free.description == "void free(void* ptr)")
+    #expect(free.description == "void free(void *ptr)")
 
     let snprintf = CFunction(
       resultType: .integral(.signed(bits: 32)),
@@ -58,8 +58,8 @@ struct CTypeTests {
       ],
       isVariadic: true
     )
-    #expect(snprintf.description == "int32_t snprintf(int8_t* str, size_t size, int8_t const* format, ...)")
-    #expect(snprintf.functionType.description == "int32_t(int8_t*, size_t, int8_t const*, ...)")
+    #expect(snprintf.description == "int32_t snprintf(int8_t *str, size_t size, int8_t const *format, ...)")
+    #expect(snprintf.functionType.description == "int32_t (int8_t *, size_t, int8_t const *, ...)")
 
     let rand = CFunction(
       resultType: .integral(.signed(bits: 32)),
@@ -68,6 +68,28 @@ struct CTypeTests {
       isVariadic: false
     )
     #expect(rand.description == "int32_t rand(void)")
-    #expect(rand.functionType.description == "int32_t(void)")
+    #expect(rand.functionType.description == "int32_t (void)")
+  }
+
+  @Test("C pointer declarator printing")
+  func testPointerDeclaratorPrinting() {
+    let doit = CFunction(
+      resultType: .void,
+      name: "doit",
+      parameters: [
+        .init(
+          name: "body",
+          type: .pointer(
+            .function(
+              resultType: .void,
+              parameters: [.integral(.bool)],
+              variadic: false
+            )
+          )
+        )
+      ],
+      isVariadic: false
+    )
+    #expect(doit.description == "void doit(void (*body)(_Bool))")
   }
 }

--- a/Tests/JExtractSwiftTests/CTypeTests.swift
+++ b/Tests/JExtractSwiftTests/CTypeTests.swift
@@ -58,8 +58,8 @@ struct CTypeTests {
       ],
       isVariadic: true
     )
-    #expect(snprintf.description == "int32_t snprintf(int8_t *str, size_t size, int8_t const *format, ...)")
-    #expect(snprintf.functionType.description == "int32_t (int8_t *, size_t, int8_t const *, ...)")
+    #expect(snprintf.description == "int32_t snprintf(int8_t *str, size_t size, const int8_t *format, ...)")
+    #expect(snprintf.functionType.description == "int32_t (int8_t *, size_t, const int8_t *, ...)")
 
     let rand = CFunction(
       resultType: .integral(.signed(bits: 32)),
@@ -91,5 +91,16 @@ struct CTypeTests {
       isVariadic: false
     )
     #expect(doit.description == "void doit(void (*body)(_Bool))")
+
+    let ptrptr = CType.pointer(
+      .qualified(
+        const: true,
+        volatile: false,
+        type: .pointer(
+          .qualified(const: false, volatile: true, type: .void)
+        )
+      )
+    ) 
+    #expect(ptrptr.description == "volatile void *const *")
   }
 }

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -26,7 +26,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_f")
-      func c_f(_ x: Int, _ y: Float, _ z_pointer: UnsafeRawPointer, _ z_count: Int) {
+      public func c_f(_ x: Int, _ y: Float, _ z_pointer: UnsafeRawPointer, _ z_count: Int) {
         f(x: x, y: y, z: UnsafeBufferPointer<Bool>(start: z_pointer.assumingMemoryBound(to: Bool.self), count: z_count))
       }
       """,
@@ -41,7 +41,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_f")
-      func c_f(_ t_0: Int, _ t_1_0: Float, _ t_1_1: Double, _ z_pointer: UnsafeRawPointer) -> Int {
+      public func c_f(_ t_0: Int, _ t_1_0: Float, _ t_1_1: Double, _ z_pointer: UnsafeRawPointer) -> Int {
         return f(t: (t_0, (t_1_0, t_1_1)), z: z_pointer.assumingMemoryBound(to: Int.self))
       }
       """,
@@ -59,7 +59,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_shift")
-      func c_shift(_ point: UnsafeMutableRawPointer, _ delta_0: Double, _ delta_1: Double) {
+      public func c_shift(_ point: UnsafeMutableRawPointer, _ delta_0: Double, _ delta_1: Double) {
         shift(point: &point.assumingMemoryBound(to: Point.self).pointee, by: (delta_0, delta_1))
       }
       """,
@@ -78,7 +78,7 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shifted")
-      func c_shifted(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer, _ _result: UnsafeMutableRawPointer) {
+      public func c_shifted(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer, _ _result: UnsafeMutableRawPointer) {
         _result.assumingMemoryBound(to: Point.self).initialize(to: self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1)))
       }
       """,
@@ -97,7 +97,7 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shift")
-      func c_shift(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeMutableRawPointer) {
+      public func c_shift(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeMutableRawPointer) {
         self.assumingMemoryBound(to: Point.self).pointee.shift(by: (delta_0, delta_1))
       }
       """,
@@ -116,7 +116,7 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shift")
-      func c_shift(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer) {
+      public func c_shift(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer) {
         unsafeBitCast(self, to: Point.self).shift(by: (delta_0, delta_1))
       }
       """,
@@ -135,7 +135,7 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_scaledUnit")
-      func c_scaledUnit(_ value: Double, _ _result: UnsafeMutableRawPointer) {
+      public func c_scaledUnit(_ value: Double, _ _result: UnsafeMutableRawPointer) {
         _result.assumingMemoryBound(to: Point.self).initialize(to: Point.scaledUnit(by: value))
       }
       """,
@@ -151,7 +151,7 @@ final class FunctionLoweringTests {
       enclosingType: "Person",
       expectedCDecl: """
       @_cdecl("c_randomPerson")
-      func c_randomPerson(_ seed: Double) -> UnsafeRawPointer {
+      public func c_randomPerson(_ seed: Double) -> UnsafeRawPointer {
         return unsafeBitCast(Person.randomPerson(seed: seed), to: UnsafeRawPointer.self)
       }
       """,
@@ -170,7 +170,7 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_init")
-      func c_init(_ value: Double, _ _result: UnsafeMutableRawPointer) {
+      public func c_init(_ value: Double, _ _result: UnsafeMutableRawPointer) {
         _result.assumingMemoryBound(to: Point.self).initialize(to: Point(scaledBy: value))
       }
       """,
@@ -186,7 +186,7 @@ final class FunctionLoweringTests {
       enclosingType: "Person",
       expectedCDecl: """
       @_cdecl("c_init")
-      func c_init(_ seed: Double) -> UnsafeRawPointer {
+      public func c_init(_ seed: Double) -> UnsafeRawPointer {
         return unsafeBitCast(Person(seed: seed), to: UnsafeRawPointer.self)
       }
       """,
@@ -201,7 +201,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_f")
-      func c_f(_ t: UnsafeRawPointer) {
+      public func c_f(_ t: UnsafeRawPointer) {
         f(t: unsafeBitCast(t, to: Int.self))
       }
       """,
@@ -213,7 +213,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_f")
-      func c_f() -> UnsafeRawPointer {
+      public func c_f() -> UnsafeRawPointer {
         return unsafeBitCast(f(), to: UnsafeRawPointer.self)
       }
       """,
@@ -232,7 +232,7 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shifted")
-      func c_shifted(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer) -> UnsafeRawPointer {
+      public func c_shifted(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer) -> UnsafeRawPointer {
         return unsafeBitCast(unsafeBitCast(self, to: Point.self).shifted(by: (delta_0, delta_1)), to: UnsafeRawPointer.self)
       }
       """,
@@ -250,7 +250,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_getPointer")
-      func c_getPointer() -> UnsafeRawPointer {
+      public func c_getPointer() -> UnsafeRawPointer {
         return UnsafeRawPointer(getPointer())
       }
       """,
@@ -268,7 +268,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_getTuple")
-      func c_getTuple(_ _result_0: UnsafeMutableRawPointer, _ _result_1_0: UnsafeMutableRawPointer, _ _result_1_1: UnsafeMutableRawPointer) {
+      public func c_getTuple(_ _result_0: UnsafeMutableRawPointer, _ _result_1_0: UnsafeMutableRawPointer, _ _result_1_1: UnsafeMutableRawPointer) {
         let __swift_result = getTuple()
         _result_0 = __swift_result_0
         _result_1_0 = __swift_result_1_0
@@ -289,7 +289,7 @@ final class FunctionLoweringTests {
       """,
       expectedCDecl: """
       @_cdecl("c_getBufferPointer")
-      func c_getBufferPointer(_result_pointer: UnsafeMutableRawPointer, _result_count: UnsafeMutableRawPointer) {
+      public func c_getBufferPointer(_result_pointer: UnsafeMutableRawPointer, _result_count: UnsafeMutableRawPointer) {
         return UnsafeRawPointer(getPointer())
       }
       """,

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -29,7 +29,8 @@ final class FunctionLoweringTests {
       func c_f(_ x: Int, _ y: Float, _ z_pointer: UnsafeRawPointer, _ z_count: Int) {
         f(x: x, y: y, z: UnsafeBufferPointer<Bool>(start: z_pointer.assumingMemoryBound(to: Bool.self), count: z_count))
       }
-      """
+      """,
+      expectedCFunction: "void c_f(ptrdiff_t x, float y, void const* z_pointer, ptrdiff_t z_count)"
     )
   }
 
@@ -43,7 +44,8 @@ final class FunctionLoweringTests {
       func c_f(_ t_0: Int, _ t_1_0: Float, _ t_1_1: Double, _ z_pointer: UnsafeRawPointer) -> Int {
         return f(t: (t_0, (t_1_0, t_1_1)), z: z_pointer.assumingMemoryBound(to: Int.self))
       }
-      """
+      """,
+      expectedCFunction: "ptrdiff_t c_f(ptrdiff_t t_0, float t_1_0, double t_1_1, void const* z_pointer)"
     )
   }
 
@@ -60,9 +62,11 @@ final class FunctionLoweringTests {
       func c_shift(_ point: UnsafeMutableRawPointer, _ delta_0: Double, _ delta_1: Double) {
         shift(point: &point.assumingMemoryBound(to: Point.self).pointee, by: (delta_0, delta_1))
       }
-      """
+      """,
+      expectedCFunction: "void c_shift(void* point, double delta_0, double delta_1)"
     )
   }
+
   @Test("Lowering methods")
   func loweringMethods() throws {
     try assertLoweredFunction("""
@@ -77,7 +81,8 @@ final class FunctionLoweringTests {
       func c_shifted(_ self: UnsafeRawPointer, _ delta_0: Double, _ delta_1: Double, _ _result: UnsafeMutableRawPointer) {
         _result.assumingMemoryBound(to: Point.self).pointee = self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1))
       }
-      """
+      """,
+      expectedCFunction: "void c_shifted(void const* self, double delta_0, double delta_1, void* _result)"
     )
   }
 
@@ -95,7 +100,8 @@ final class FunctionLoweringTests {
       func c_shift(_ self: UnsafeMutableRawPointer, _ delta_0: Double, _ delta_1: Double) {
         self.assumingMemoryBound(to: Point.self).pointee.shift(by: (delta_0, delta_1))
       }
-      """
+      """,
+      expectedCFunction: "void c_shift(void* self, double delta_0, double delta_1)"
     )
   }
 
@@ -113,7 +119,8 @@ final class FunctionLoweringTests {
       func c_shift(_ self: UnsafeRawPointer, _ delta_0: Double, _ delta_1: Double) {
         unsafeBitCast(self, to: Point.self).shift(by: (delta_0, delta_1))
       }
-      """
+      """,
+      expectedCFunction: "void c_shift(void const* self, double delta_0, double delta_1)"
     )
   }
 
@@ -127,7 +134,8 @@ final class FunctionLoweringTests {
       func c_f(_ t: UnsafeRawPointer) {
         f(t: unsafeBitCast(t, to: Int.self))
       }
-      """
+      """,
+      expectedCFunction: "void c_f(void const* t)"
      )
   }
 }

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -30,7 +30,7 @@ final class FunctionLoweringTests {
         f(x: x, y: y, z: UnsafeBufferPointer<Bool>(start: z_pointer.assumingMemoryBound(to: Bool.self), count: z_count))
       }
       """,
-      expectedCFunction: "void c_f(ptrdiff_t x, float y, void const* z_pointer, ptrdiff_t z_count)"
+      expectedCFunction: "void c_f(ptrdiff_t x, float y, void const *z_pointer, ptrdiff_t z_count)"
     )
   }
 
@@ -45,7 +45,7 @@ final class FunctionLoweringTests {
         return f(t: (t_0, (t_1_0, t_1_1)), z: z_pointer.assumingMemoryBound(to: Int.self))
       }
       """,
-      expectedCFunction: "ptrdiff_t c_f(ptrdiff_t t_0, float t_1_0, double t_1_1, void const* z_pointer)"
+      expectedCFunction: "ptrdiff_t c_f(ptrdiff_t t_0, float t_1_0, double t_1_1, void const *z_pointer)"
     )
   }
 
@@ -63,7 +63,7 @@ final class FunctionLoweringTests {
         shift(point: &point.assumingMemoryBound(to: Point.self).pointee, by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shift(void* point, double delta_0, double delta_1)"
+      expectedCFunction: "void c_shift(void *point, double delta_0, double delta_1)"
     )
   }
 
@@ -82,7 +82,7 @@ final class FunctionLoweringTests {
         _result.assumingMemoryBound(to: Point.self).initialize(to: self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1)))
       }
       """,
-      expectedCFunction: "void c_shifted(double delta_0, double delta_1, void const* self, void* _result)"
+      expectedCFunction: "void c_shifted(double delta_0, double delta_1, void const *self, void *_result)"
     )
   }
 
@@ -101,7 +101,7 @@ final class FunctionLoweringTests {
         self.assumingMemoryBound(to: Point.self).pointee.shift(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shift(double delta_0, double delta_1, void* self)"
+      expectedCFunction: "void c_shift(double delta_0, double delta_1, void *self)"
     )
   }
 
@@ -120,7 +120,7 @@ final class FunctionLoweringTests {
         unsafeBitCast(self, to: Point.self).shift(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shift(double delta_0, double delta_1, void const* self)"
+      expectedCFunction: "void c_shift(double delta_0, double delta_1, void const *self)"
     )
   }
 
@@ -139,7 +139,7 @@ final class FunctionLoweringTests {
         _result.assumingMemoryBound(to: Point.self).initialize(to: Point.scaledUnit(by: value))
       }
       """,
-      expectedCFunction: "void c_scaledUnit(double value, void* _result)"
+      expectedCFunction: "void c_scaledUnit(double value, void *_result)"
     )
 
     try assertLoweredFunction("""
@@ -155,7 +155,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(Person.randomPerson(seed: seed), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const* c_randomPerson(double seed)"
+      expectedCFunction: "void const *c_randomPerson(double seed)"
     )
   }
 
@@ -174,7 +174,7 @@ final class FunctionLoweringTests {
         _result.assumingMemoryBound(to: Point.self).initialize(to: Point(scaledBy: value))
       }
       """,
-      expectedCFunction: "void c_init(double value, void* _result)"
+      expectedCFunction: "void c_init(double value, void *_result)"
     )
 
     try assertLoweredFunction("""
@@ -190,7 +190,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(Person(seed: seed), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const* c_init(double seed)"
+      expectedCFunction: "void const *c_init(double seed)"
     )
   }
 
@@ -205,7 +205,7 @@ final class FunctionLoweringTests {
         f(t: unsafeBitCast(t, to: Int.self))
       }
       """,
-      expectedCFunction: "void c_f(void const* t)"
+      expectedCFunction: "void c_f(void const *t)"
     )
 
     try assertLoweredFunction("""
@@ -217,7 +217,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(f(), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const* c_f(void)"
+      expectedCFunction: "void const *c_f(void)"
     )
   }
 
@@ -236,7 +236,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(unsafeBitCast(self, to: Point.self).shifted(by: (delta_0, delta_1)), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const* c_shifted(double delta_0, double delta_1, void const* self)"
+      expectedCFunction: "void const *c_shifted(double delta_0, double delta_1, void const *self)"
     )
   }
 
@@ -254,7 +254,7 @@ final class FunctionLoweringTests {
         return UnsafeRawPointer(getPointer())
       }
       """,
-      expectedCFunction: "void const* c_getPointer(void)"
+      expectedCFunction: "void const *c_getPointer(void)"
     )
   }
 
@@ -275,7 +275,7 @@ final class FunctionLoweringTests {
         _result_1_1.assumingMemoryBound(to: Point.self).initialize(to: __swift_result_1_1)
       }
       """,
-      expectedCFunction: "void c_getTuple(void* _result_0, void* _result_1_0, void* _result_1_1)"
+      expectedCFunction: "void c_getTuple(void *_result_0, void *_result_1_0, void *_result_1_1)"
     )
   }
 
@@ -310,7 +310,7 @@ final class FunctionLoweringTests {
         doSomething(body: body)
       }
       """,
-      expectedCFunction: "void c_doSomething(double* body(int32_t))"
+      expectedCFunction: "void c_doSomething(double (*body)(int32_t))"
     )
   }
 }

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -296,4 +296,21 @@ final class FunctionLoweringTests {
       expectedCFunction: "c_getBufferPointer(void* _result_pointer, void* _result_count)"
     )
   }
+
+  @Test("Lowering C function types")
+  func lowerFunctionTypes() throws {
+    // FIXME: C pretty printing isn't handling parameters of function pointer
+    // type yet.
+    try assertLoweredFunction("""
+      func doSomething(body: @convention(c) (Int32) -> Double) { }
+      """,
+      expectedCDecl: """
+      @_cdecl("c_doSomething")
+      public func c_doSomething(_ body: @convention(c) (Int32) -> Double) {
+        doSomething(body: body)
+      }
+      """,
+      expectedCFunction: "void c_doSomething(double* body(int32_t))"
+    )
+  }
 }

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -79,7 +79,7 @@ final class FunctionLoweringTests {
       expectedCDecl: """
       @_cdecl("c_shifted")
       func c_shifted(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer, _ _result: UnsafeMutableRawPointer) {
-        _result.assumingMemoryBound(to: Point.self).pointee = self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1))
+        _result.assumingMemoryBound(to: Point.self).initialize(to: self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1)))
       }
       """,
       expectedCFunction: "void c_shifted(double delta_0, double delta_1, void const* self, void* _result)"
@@ -136,7 +136,7 @@ final class FunctionLoweringTests {
       expectedCDecl: """
       @_cdecl("c_scaledUnit")
       func c_scaledUnit(_ value: Double, _ _result: UnsafeMutableRawPointer) {
-        _result.assumingMemoryBound(to: Point.self).pointee = Point.scaledUnit(by: value)
+        _result.assumingMemoryBound(to: Point.self).initialize(to: Point.scaledUnit(by: value))
       }
       """,
       expectedCFunction: "void c_scaledUnit(double value, void* _result)"
@@ -171,7 +171,7 @@ final class FunctionLoweringTests {
       expectedCDecl: """
       @_cdecl("c_init")
       func c_init(_ value: Double, _ _result: UnsafeMutableRawPointer) {
-        _result.assumingMemoryBound(to: Point.self).pointee = Point(scaledBy: value)
+        _result.assumingMemoryBound(to: Point.self).initialize(to: Point(scaledBy: value))
       }
       """,
       expectedCFunction: "void c_init(double value, void* _result)"
@@ -261,13 +261,18 @@ final class FunctionLoweringTests {
   @Test("Lowering tuple returns")
   func lowerTupleReturns() throws {
     try assertLoweredFunction("""
-      func getTuple() -> (Int, (Float, Double)) { }
+      func getTuple() -> (Int, (Float, Point)) { }
+      """,
+      sourceFile: """
+      struct Point { }
       """,
       expectedCDecl: """
       @_cdecl("c_getTuple")
       func c_getTuple(_ _result_0: UnsafeMutableRawPointer, _ _result_1_0: UnsafeMutableRawPointer, _ _result_1_1: UnsafeMutableRawPointer) {
         let __swift_result = getTuple()
-        (_result_0, (_result_1_0, _result_1_1)) = (__swift_result_0, (__swift_result_1_0, __swift_result_1_1))
+        _result_0 = __swift_result_0
+        _result_1_0 = __swift_result_1_0
+        _result_1_1.assumingMemoryBound(to: Point.self).initialize(to: __swift_result_1_1)
       }
       """,
       expectedCFunction: "void c_getTuple(void* _result_0, void* _result_1_0, void* _result_1_1)"

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -30,7 +30,7 @@ final class FunctionLoweringTests {
         f(x: x, y: y, z: UnsafeBufferPointer<Bool>(start: z_pointer.assumingMemoryBound(to: Bool.self), count: z_count))
       }
       """,
-      expectedCFunction: "void c_f(ptrdiff_t x, float y, void const *z_pointer, ptrdiff_t z_count)"
+      expectedCFunction: "void c_f(ptrdiff_t x, float y, const void *z_pointer, ptrdiff_t z_count)"
     )
   }
 
@@ -45,7 +45,7 @@ final class FunctionLoweringTests {
         return f(t: (t_0, (t_1_0, t_1_1)), z: z_pointer.assumingMemoryBound(to: Int.self))
       }
       """,
-      expectedCFunction: "ptrdiff_t c_f(ptrdiff_t t_0, float t_1_0, double t_1_1, void const *z_pointer)"
+      expectedCFunction: "ptrdiff_t c_f(ptrdiff_t t_0, float t_1_0, double t_1_1, const void *z_pointer)"
     )
   }
 
@@ -82,7 +82,7 @@ final class FunctionLoweringTests {
         _result.assumingMemoryBound(to: Point.self).initialize(to: self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1)))
       }
       """,
-      expectedCFunction: "void c_shifted(double delta_0, double delta_1, void const *self, void *_result)"
+      expectedCFunction: "void c_shifted(double delta_0, double delta_1, const void *self, void *_result)"
     )
   }
 
@@ -120,7 +120,7 @@ final class FunctionLoweringTests {
         unsafeBitCast(self, to: Point.self).shift(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shift(double delta_0, double delta_1, void const *self)"
+      expectedCFunction: "void c_shift(double delta_0, double delta_1, const void *self)"
     )
   }
 
@@ -155,7 +155,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(Person.randomPerson(seed: seed), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const *c_randomPerson(double seed)"
+      expectedCFunction: "const void *c_randomPerson(double seed)"
     )
   }
 
@@ -190,7 +190,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(Person(seed: seed), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const *c_init(double seed)"
+      expectedCFunction: "const void *c_init(double seed)"
     )
   }
 
@@ -205,7 +205,7 @@ final class FunctionLoweringTests {
         f(t: unsafeBitCast(t, to: Int.self))
       }
       """,
-      expectedCFunction: "void c_f(void const *t)"
+      expectedCFunction: "void c_f(const void *t)"
     )
 
     try assertLoweredFunction("""
@@ -217,7 +217,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(f(), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const *c_f(void)"
+      expectedCFunction: "const void *c_f(void)"
     )
   }
 
@@ -236,7 +236,7 @@ final class FunctionLoweringTests {
         return unsafeBitCast(unsafeBitCast(self, to: Point.self).shifted(by: (delta_0, delta_1)), to: UnsafeRawPointer.self)
       }
       """,
-      expectedCFunction: "void const *c_shifted(double delta_0, double delta_1, void const *self)"
+      expectedCFunction: "const void *c_shifted(double delta_0, double delta_1, const void *self)"
     )
   }
 
@@ -254,7 +254,7 @@ final class FunctionLoweringTests {
         return UnsafeRawPointer(getPointer())
       }
       """,
-      expectedCFunction: "void const *c_getPointer(void)"
+      expectedCFunction: "const void *c_getPointer(void)"
     )
   }
 

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -78,11 +78,11 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shifted")
-      func c_shifted(_ self: UnsafeRawPointer, _ delta_0: Double, _ delta_1: Double, _ _result: UnsafeMutableRawPointer) {
+      func c_shifted(_ delta_0: Double, _ delta_1: Double, _ _result: UnsafeMutableRawPointer, _ self: UnsafeRawPointer) {
         _result.assumingMemoryBound(to: Point.self).pointee = self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shifted(void const* self, double delta_0, double delta_1, void* _result)"
+      expectedCFunction: "void c_shifted(double delta_0, double delta_1, void* _result, void const* self)"
     )
   }
 
@@ -97,11 +97,11 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shift")
-      func c_shift(_ self: UnsafeMutableRawPointer, _ delta_0: Double, _ delta_1: Double) {
+      func c_shift(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeMutableRawPointer) {
         self.assumingMemoryBound(to: Point.self).pointee.shift(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shift(void* self, double delta_0, double delta_1)"
+      expectedCFunction: "void c_shift(double delta_0, double delta_1, void* self)"
     )
   }
 
@@ -116,11 +116,11 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shift")
-      func c_shift(_ self: UnsafeRawPointer, _ delta_0: Double, _ delta_1: Double) {
+      func c_shift(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer) {
         unsafeBitCast(self, to: Point.self).shift(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shift(void const* self, double delta_0, double delta_1)"
+      expectedCFunction: "void c_shift(double delta_0, double delta_1, void const* self)"
     )
   }
 

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -78,11 +78,11 @@ final class FunctionLoweringTests {
       enclosingType: "Point",
       expectedCDecl: """
       @_cdecl("c_shifted")
-      func c_shifted(_ delta_0: Double, _ delta_1: Double, _ _result: UnsafeMutableRawPointer, _ self: UnsafeRawPointer) {
+      func c_shifted(_ delta_0: Double, _ delta_1: Double, _ self: UnsafeRawPointer, _ _result: UnsafeMutableRawPointer) {
         _result.assumingMemoryBound(to: Point.self).pointee = self.assumingMemoryBound(to: Point.self).pointee.shifted(by: (delta_0, delta_1))
       }
       """,
-      expectedCFunction: "void c_shifted(double delta_0, double delta_1, void* _result, void const* self)"
+      expectedCFunction: "void c_shifted(double delta_0, double delta_1, void const* self, void* _result)"
     )
   }
 


### PR DESCRIPTION
Introduce a different approach to creating `@_cdecl` thunks that looks a lot more like what the compiler does, breaking down Swift abstractions (things like tuples) to create new function signatures and patterns to follow to convert between the Swift-native values and the `@_cdecl`-compatible ones.

This approach also comes with a model of the C type system so we can take a `@_cdecl` function and produce the corresponding C declaration (e.g, similar to a generated header). At present, this is used mostly for testing that the C lowering looks like it should, but it's also potentially a handy reference when (e.g.) figuring out how to encode the function signature in Java's Foreign Function & Memory Interface.

This is not quite ready to wire into the main parts of jextract-swift yet. It still needs to handle optionals and function conversions.