### PR TITLE
[jextract] CodePrinter indentation improvements

### DIFF
--- a/Sources/JExtractSwift/ImportedDecls+Printing.swift
+++ b/Sources/JExtractSwift/ImportedDecls+Printing.swift
@@ -22,9 +22,9 @@ extension ImportedFunc {
   var renderCommentSnippet: String? {
     if let syntax {
       """
-      * {@snippet lang=swift :
-      * \(syntax)
-      * }
+       * {@snippet lang=swift :
+       * \(syntax)
+       * }
       """
     } else {
       nil

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -510,7 +510,7 @@ extension Swift2JavaTranslator {
       /**
        * Create an instance of {@code \(parentName.unqualifiedJavaTypeName)}.
        *
-       \(decl.renderCommentSnippet ?? " *")
+      \(decl.renderCommentSnippet ?? " *")
        */
       public \(parentName.unqualifiedJavaTypeName)(\(renderJavaParamDecls(decl, paramPassingStyle: .wrapper))) {
         this(/*arena=*/null, \(renderForwardJavaParams(decl, paramPassingStyle: .wrapper)));
@@ -543,7 +543,7 @@ extension Swift2JavaTranslator {
        * Create an instance of {@code \(parentName.unqualifiedJavaTypeName)}.
        * This instance is managed by the passed in {@link SwiftArena} and may not outlive the arena's lifetime.
        *
-       \(decl.renderCommentSnippet ?? " *")
+      \(decl.renderCommentSnippet ?? " *")
        */
       public \(parentName.unqualifiedJavaTypeName)(SwiftArena arena, \(renderJavaParamDecls(decl, paramPassingStyle: .wrapper))) {
         var mh$ = \(descClassIdentifier).HANDLE;
@@ -601,7 +601,7 @@ extension Swift2JavaTranslator {
       """
       /**
        * Address for:
-       \(snippet)
+      \(snippet)
        */
       public static MemorySegment \(decl.baseIdentifier)\(methodNameSegment)$address() {
           return \(decl.baseIdentifier).\(addrName);
@@ -623,7 +623,7 @@ extension Swift2JavaTranslator {
       """
       /**
        * Downcall method handle for:
-       \(snippet)
+      \(snippet)
        */
       public static MethodHandle \(decl.baseIdentifier)\(methodNameSegment)$handle() {
           return \(decl.baseIdentifier).\(handleName);
@@ -645,7 +645,7 @@ extension Swift2JavaTranslator {
       """
       /**
        * Function descriptor for:
-       \(snippet)
+      \(snippet)
        */
       public static FunctionDescriptor \(decl.baseIdentifier)\(methodNameSegment)$descriptor() {
           return \(decl.baseIdentifier).\(descName);
@@ -744,7 +744,7 @@ extension Swift2JavaTranslator {
       """
       /**
        * Downcall to Swift:
-       \(decl.renderCommentSnippet ?? "* ")
+      \(decl.renderCommentSnippet ?? "* ")
        */
       """
 
@@ -1065,7 +1065,6 @@ extension Swift2JavaTranslator {
     } else {
       printer.print("FunctionDescriptor.of(")
       printer.indent()
-      printer.print("", .continue)
 
       // Write return type
       let returnTyIsLastTy = decl.parameters.isEmpty && !decl.hasParent

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -47,7 +47,7 @@ final class VariableImportTests {
       expectedChunks: [
         """
         private static class counterInt {
-          public static final FunctionDescriptor DESC_GET =     FunctionDescriptor.of(
+          public static final FunctionDescriptor DESC_GET = FunctionDescriptor.of(
               /* -> */SWIFT_INT,
               /*self$*/SWIFT_POINTER
           );
@@ -55,7 +55,7 @@ final class VariableImportTests {
           FakeModule.findOrThrow("swiftjava_FakeModule_MySwiftClass_counterInt");
 
           public static final MethodHandle HANDLE_GET = Linker.nativeLinker().downcallHandle(ADDR_GET, DESC_GET);
-          public static final FunctionDescriptor DESC_SET =     FunctionDescriptor.ofVoid(
+          public static final FunctionDescriptor DESC_SET = FunctionDescriptor.ofVoid(
               /*newValue*/SWIFT_INT,
               /*self$*/SWIFT_POINTER
           );


### PR DESCRIPTION
Improve indentations.

Introduce `atNewline` property in the printer, to indicate if the next `print()` should print the indentation on the first line. Stop handling single line `print()` specially.

before:
<img width="982" alt="Screenshot 2025-04-15 at 11 26 54 PM" src="https://github.com/user-attachments/assets/56b7f2c7-37c4-4fc5-8e06-c243cec01146" />

after:
<img width="982" alt="Screenshot 2025-04-15 at 11 26 20 PM" src="https://github.com/user-attachments/assets/50336226-db85-4d13-889c-af78db77f044" />
