### PR TITLE
[jextract] Prepare all inputs before analyze()

### DIFF
--- a/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
@@ -22,7 +22,7 @@ func assertLoweredFunction(
   _ inputDecl: DeclSyntax,
   javaPackage: String = "org.swift.mypackage",
   swiftModuleName: String = "MyModule",
-  sourceFile: SourceFileSyntax? = nil,
+  sourceFile: String? = nil,
   enclosingType: TypeSyntax? = nil,
   expectedCDecl: DeclSyntax,
   expectedCFunction: String,
@@ -37,7 +37,7 @@ func assertLoweredFunction(
   )
 
   if let sourceFile {
-    translator.addSourceFile(sourceFile)
+    translator.add(filePath: "Fake.swift", text: sourceFile)
   }
 
   translator.prepareForTranslation()


### PR DESCRIPTION
Register all the files to `Swift2JavaTranslator` (and `NominalTypeResolution`) and `analye()` all the files at once.

`Swift2JavaVisitor.visit(_: ExtentionDeclSyntax)` requires all the nominal types are prepared in the `nominalResolution`. Otherwise it's just ignored.

Also previously, writing files was performed for each file iteration but actually, it is not a per-source file operation. Instead, it only writes the current state of the translator, so multiple calls were redundant.