### PR TITLE
[jextract] Misc improvements

### DIFF
--- a/Sources/JExtractSwift/Convenience/SwiftSyntax+Extensions.swift
+++ b/Sources/JExtractSwift/Convenience/SwiftSyntax+Extensions.swift
@@ -15,23 +15,7 @@
 import SwiftDiagnostics
 import SwiftSyntax
 
-extension DeclGroupSyntax {
-  internal var accessControlModifiers: DeclModifierListSyntax {
-    modifiers.filter { modifier in
-      modifier.isAccessControl
-    }
-  }
-}
-
-extension FunctionDeclSyntax {
-  internal var accessControlModifiers: DeclModifierListSyntax {
-    modifiers.filter { modifier in
-      modifier.isAccessControl
-    }
-  }
-}
-
-extension VariableDeclSyntax {
+extension WithModifiersSyntax {
   internal var accessControlModifiers: DeclModifierListSyntax {
     modifiers.filter { modifier in
       modifier.isAccessControl
@@ -89,7 +73,7 @@ extension DeclModifierSyntax {
   var isAccessControl: Bool {
     switch self.name.tokenKind {
     case .keyword(.private), .keyword(.fileprivate), .keyword(.internal), .keyword(.package),
-      .keyword(.public):
+        .keyword(.public), .keyword(.open):
       return true
     default:
       return false
@@ -105,7 +89,150 @@ extension DeclModifierSyntax {
     case .keyword(.internal): return false
     case .keyword(.package): return false
     case .keyword(.public): return true
+    case .keyword(.open): return true
     default: return false
+    }
+  }
+}
+
+extension WithModifiersSyntax {
+  var isPublic: Bool {
+    self.modifiers.contains { modifier in
+      modifier.isPublic
+    }
+  }
+}
+
+extension AttributeListSyntax.Element {
+  /// Whether this node has `JavaKit` attributes.
+  var isJava: Bool {
+    guard case let .attribute(attr) = self else {
+      // FIXME: Handle #if.
+      return false
+    }
+    let attrName = attr.attributeName.description
+    switch attrName {
+    case "JavaClass", "JavaInterface", "JavaField", "JavaStaticField", "JavaMethod", "JavaStaticMethod", "JavaImplementation":
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension DeclSyntaxProtocol {
+  /// Find inner most "decl" node in ancestors.
+  var ancestorDecl: DeclSyntax? {
+    var node: Syntax = Syntax(self)
+    while let parent = node.parent {
+      if let decl = parent.as(DeclSyntax.self) {
+        return decl
+      }
+      node = parent
+    }
+    return nil
+  }
+
+  /// Declaration name primarily for debugging.
+  var nameForDebug: String {
+    return switch DeclSyntax(self).as(DeclSyntaxEnum.self) {
+    case .accessorDecl(let node):
+      node.accessorSpecifier.text
+    case .actorDecl(let node):
+      node.name.text
+    case .associatedTypeDecl(let node):
+      node.name.text
+    case .classDecl(let node):
+      node.name.text
+    case .deinitializerDecl(_):
+      "deinit"
+    case .editorPlaceholderDecl:
+      ""
+    case .enumCaseDecl(let node):
+      // FIXME: Handle multiple elements.
+      if let element = node.elements.first {
+        element.name.text
+      } else {
+        "case"
+      }
+    case .enumDecl(let node):
+      node.name.text
+    case .extensionDecl(let node):
+      node.extendedType.description
+    case .functionDecl(let node):
+      node.name.text + "(" + node.signature.parameterClause.parameters.map({ $0.firstName.text + ":" }).joined()  + ")"
+    case .ifConfigDecl(_):
+      "#if"
+    case .importDecl(_):
+      "import"
+    case .initializerDecl(let node):
+      "init" + "(" + node.signature.parameterClause.parameters.map({ $0.firstName.text + ":" }).joined()  + ")"
+    case .macroDecl(let node):
+      node.name.text
+    case .macroExpansionDecl(let node):
+      "#" + node.macroName.trimmedDescription
+    case .missingDecl(_):
+      "(missing)"
+    case .operatorDecl(let node):
+      node.name.text
+    case .poundSourceLocation(_):
+      "#sourceLocation"
+    case .precedenceGroupDecl(let node):
+      node.name.text
+    case .protocolDecl(let node):
+      node.name.text
+    case .structDecl(let node):
+      node.name.text
+    case .subscriptDecl(let node):
+      "subscript" + "(" + node.parameterClause.parameters.map({ $0.firstName.text + ":" }).joined()  + ")"
+    case .typeAliasDecl(let node):
+      node.name.text
+    case .variableDecl(let node):
+      // FIXME: Handle multiple variables.
+      if let element = node.bindings.first {
+        element.pattern.trimmedDescription
+      } else {
+        "var"
+      }
+    }
+  }
+
+  /// Qualified declaration name primarily for debugging.
+  var qualifiedNameForDebug: String {
+    if let parent = ancestorDecl {
+      parent.qualifiedNameForDebug + "." + nameForDebug
+    } else {
+      nameForDebug
+    }
+  }
+
+  /// Signature part of the declaration. I.e. without body or member block.
+  var signatureString: String {
+    return switch DeclSyntax(self.detached).as(DeclSyntaxEnum.self) {
+    case .functionDecl(let node):
+      node.with(\.body, nil).trimmedDescription
+    case .initializerDecl(let node):
+      node.with(\.body, nil).trimmedDescription
+    case .classDecl(let node):
+      node.with(\.memberBlock, "").trimmedDescription
+    case .structDecl(let node):
+      node.with(\.memberBlock, "").trimmedDescription
+    case .protocolDecl(let node):
+      node.with(\.memberBlock, "").trimmedDescription
+    case .accessorDecl(let node):
+      node.with(\.body, nil).trimmedDescription
+    case .variableDecl(let node):
+      node
+        .with(\.bindings, PatternBindingListSyntax(
+          node.bindings.map {
+            $0.detached
+            .with(\.accessorBlock, nil)
+            .with(\.initializer, nil)
+          }
+        ))
+        .trimmedDescription
+    default:
+      fatalError("unimplemented \(self.kind)")
     }
   }
 }

--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -261,7 +261,7 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
   public var swiftDecl: any DeclSyntaxProtocol
 
   public var syntax: String? {
-    "\(self.swiftDecl)"
+    self.swiftDecl.signatureString
   }
 
   public var isInit: Bool = false

--- a/Sources/JExtractSwift/NominalTypeResolution.swift
+++ b/Sources/JExtractSwift/NominalTypeResolution.swift
@@ -38,7 +38,7 @@ public class NominalTypeResolution {
 
 /// A syntax node for a nominal type declaration.
 @_spi(Testing)
-public typealias NominalTypeDeclSyntaxNode = any DeclGroupSyntax & NamedDeclSyntax
+public typealias NominalTypeDeclSyntaxNode = any DeclGroupSyntax & NamedDeclSyntax & WithAttributesSyntax & WithModifiersSyntax
 
 // MARK: Nominal type name resolution.
 extension NominalTypeResolution {

--- a/Sources/JExtractSwift/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator.swift
@@ -159,7 +159,7 @@ extension Swift2JavaTranslator {
   /// Try to resolve the given nominal type node into its imported
   /// representation.
   func importedNominalType(
-    _ nominal: some DeclGroupSyntax & NamedDeclSyntax
+    _ nominal: some DeclGroupSyntax & NamedDeclSyntax & WithModifiersSyntax & WithAttributesSyntax
   ) -> ImportedNominalType? {
     if !nominal.shouldImport(log: log) {
       return nil

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -49,7 +49,7 @@ final class FunctionDescriptorTests {
       //  #MySwiftClass.counter!getter: (MySwiftClass) -> () -> Int32 : @$s14MySwiftLibrary0aB5ClassC7counters5Int32Vvg\t// MySwiftClass.counter.getter
       //  #MySwiftClass.counter!setter: (MySwiftClass) -> (Int32) -> () : @$s14MySwiftLibrary0aB5ClassC7counters5Int32Vvs\t// MySwiftClass.counter.setter
       //  #MySwiftClass.counter!modify: (MySwiftClass) -> () -> () : @$s14MySwiftLibrary0aB5ClassC7counters5Int32VvM\t// MySwiftClass.counter.modify
-      var counter: Int32
+      public var counter: Int32
     }
     """
 

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -483,7 +483,7 @@ final class MethodImportTests {
          * Create an instance of {@code MySwiftStruct}.
          *
          * {@snippet lang=swift :
-         * public init(len: Swift.Int, cap: Swift.Int) {}
+         * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
         public MySwiftStruct(long len, long cap) {
@@ -494,7 +494,7 @@ final class MethodImportTests {
          * This instance is managed by the passed in {@link SwiftArena} and may not outlive the arena's lifetime.
          *
          * {@snippet lang=swift :
-         * public init(len: Swift.Int, cap: Swift.Int) {}
+         * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
 


### PR DESCRIPTION
* Introduce `Swift2JavaVisitor.typeContext` to handle nested types
* Unify `shouldImport(log:)` method using `WithModifiersSyntax & WithAttributesSyntax`
* Unify `accessControlModifiers` as an extention to `WithModifiersSyntax`
* Import `open` declarations
* Don't import `JavaKit` declarations. e.g. `@JavaClass`
* Don't import non-public variable decls.
* Introduce `DeclSyntaxProtocol.qualifiedNameForDebug` and use it for log messages
* Introduce `DeclSyntaxProtocol.signatureString` and use it as the snippet in the exported `.java` files.