### PR TITLE
Move layout constants from generated code to SwiftKit

### DIFF
--- a/Sources/JExtractSwift/JavaConstants/ForeignValueLayouts.swift
+++ b/Sources/JExtractSwift/JavaConstants/ForeignValueLayouts.swift
@@ -57,7 +57,7 @@ public struct ForeignValueLayout: CustomStringConvertible, Equatable {
       result.append("/*\(inlineComment)*/")
     }
 
-    result.append("\(value)")
+    result.append("SwiftValueLayout.\(value)")
 
     // When the type is some custom type, e.g. another Swift struct that we imported,
     // we need to import its layout. We do this by calling $layout() on it.

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -298,7 +298,6 @@ extension Swift2JavaTranslator {
 
       // Constants
       printClassConstants(printer: &printer)
-      printTypeMappingDecls(&printer)
 
       body(&printer)
     }
@@ -310,7 +309,6 @@ extension Swift2JavaTranslator {
 
       // Constants
       printClassConstants(printer: &printer)
-      printTypeMappingDecls(&printer)
 
       printer.print(
         """
@@ -439,45 +437,6 @@ extension Swift2JavaTranslator {
       public final GroupLayout $layout() {
           return $LAYOUT;
       }
-      """
-    )
-  }
-
-  public func printTypeMappingDecls(_ printer: inout CodePrinter) {
-    // TODO: use some dictionary for those
-    printer.print(
-      """
-      // TODO: rather than the C ones offer the Swift mappings
-      public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
-      public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
-      public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
-      public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
-      public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
-      public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
-      public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
-      public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
-              .withTargetLayout(MemoryLayout.sequenceLayout(java.lang.Long.MAX_VALUE, ValueLayout.JAVA_BYTE));
-      public static final ValueLayout.OfLong C_LONG = ValueLayout.JAVA_LONG;
-      """
-    )
-    printer.print("")
-    printer.print(
-      """
-      public static final ValueLayout.OfBoolean SWIFT_BOOL = ValueLayout.JAVA_BOOLEAN;
-      public static final ValueLayout.OfByte SWIFT_INT8 = ValueLayout.JAVA_BYTE;
-      public static final ValueLayout.OfChar SWIFT_UINT16 = ValueLayout.JAVA_CHAR;
-      public static final ValueLayout.OfShort SWIFT_INT16 = ValueLayout.JAVA_SHORT;
-      public static final ValueLayout.OfInt SWIFT_INT32 = ValueLayout.JAVA_INT;
-      public static final ValueLayout.OfLong SWIFT_INT64 = ValueLayout.JAVA_LONG;
-      public static final ValueLayout.OfFloat SWIFT_FLOAT = ValueLayout.JAVA_FLOAT;
-      public static final ValueLayout.OfDouble SWIFT_DOUBLE = ValueLayout.JAVA_DOUBLE;
-      public static final AddressLayout SWIFT_POINTER = ValueLayout.ADDRESS;
-      // On the platform this was generated on, Int was Int64
-      public static final SequenceLayout SWIFT_BYTE_ARRAY = MemoryLayout.sequenceLayout(8, ValueLayout.JAVA_BYTE);
-      public static final ValueLayout.OfLong SWIFT_INT = SWIFT_INT64;
-      public static final ValueLayout.OfLong SWIFT_UINT = SWIFT_INT64;
-
-      public static final AddressLayout SWIFT_SELF = SWIFT_POINTER;
       """
     )
   }
@@ -1054,7 +1013,7 @@ extension Swift2JavaTranslator {
 
     let isIndirectReturn = decl.isIndirectReturn
 
-    var parameterLayoutDescriptors: [ForeignValueLayout] = javaMemoryLayoutDescriptors(
+    let parameterLayoutDescriptors: [ForeignValueLayout] = javaMemoryLayoutDescriptors(
       forParametersOf: decl,
       paramPassingStyle: .pointer
     )

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueLayout.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueLayout.java
@@ -32,13 +32,24 @@ public class SwiftValueLayout {
         return ValueLayout.ADDRESS.byteSize();
     }
 
+    public static final ValueLayout.OfBoolean SWIFT_BOOL = ValueLayout.JAVA_BOOLEAN;
+    public static final ValueLayout.OfByte SWIFT_INT8 = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfChar SWIFT_UINT16 = ValueLayout.JAVA_CHAR;
+    public static final ValueLayout.OfShort SWIFT_INT16 = ValueLayout.JAVA_SHORT;
+    public static final ValueLayout.OfInt SWIFT_INT32 = ValueLayout.JAVA_INT;
+    public static final ValueLayout.OfLong SWIFT_INT64 = ValueLayout.JAVA_LONG;
+    public static final ValueLayout.OfFloat SWIFT_FLOAT = ValueLayout.JAVA_FLOAT;
+    public static final ValueLayout.OfDouble SWIFT_DOUBLE = ValueLayout.JAVA_DOUBLE;
+    public static final AddressLayout SWIFT_POINTER = ValueLayout.ADDRESS
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE));
+    public static final SequenceLayout SWIFT_BYTE_ARRAY = MemoryLayout.sequenceLayout(8, ValueLayout.JAVA_BYTE);
+
     /**
      * The value layout for Swift's {@code Int} type, which is a signed type that follows
      * the size of a pointer (aka C's {@code ptrdiff_t}).
      */
     public static ValueLayout SWIFT_INT = (ValueLayout.ADDRESS.byteSize() == 4) ?
-            ValueLayout.JAVA_INT : ValueLayout.JAVA_LONG;
-
+            SWIFT_INT32 : SWIFT_INT64;
 
     /**
      * The value layout for Swift's {@code UInt} type, which is an unsigned type that follows
@@ -47,9 +58,4 @@ public class SwiftValueLayout {
      * Java does not have unsigned integer types, so we use the layout for Swift's {@code Int}.
      */
     public static ValueLayout SWIFT_UINT = SWIFT_INT;
-
-
-    public static final AddressLayout SWIFT_POINTER = ValueLayout.ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE));
-
 }

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueLayout.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueLayout.java
@@ -16,6 +16,7 @@ package org.swift.swiftkit;
 
 import java.lang.foreign.AddressLayout;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.ValueLayout;
 
 import static java.lang.foreign.ValueLayout.*;

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -61,7 +61,7 @@ final class FunctionDescriptorTests {
         expected:
           """
           public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /*i*/SWIFT_INT
+            /*i*/SwiftValueLayout.SWIFT_INT
           );
           """
       )
@@ -76,8 +76,8 @@ final class FunctionDescriptorTests {
         expected:
           """
           public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /*l*/SWIFT_INT64,
-            /*i32*/SWIFT_INT32
+            /*l*/SwiftValueLayout.SWIFT_INT64,
+            /*i32*/SwiftValueLayout.SWIFT_INT32
           );
           """
       )
@@ -92,8 +92,8 @@ final class FunctionDescriptorTests {
         expected:
           """
           public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            /* -> */SWIFT_INT,
-            /*i*/SWIFT_INT
+            /* -> */SwiftValueLayout.SWIFT_INT,
+            /*i*/SwiftValueLayout.SWIFT_INT
           );
           """
       )
@@ -108,8 +108,8 @@ final class FunctionDescriptorTests {
         expected:
           """
           public static final FunctionDescriptor DESC_GET = FunctionDescriptor.of(
-            /* -> */SWIFT_INT32,
-            /*self$*/SWIFT_POINTER
+            /* -> */SwiftValueLayout.SWIFT_INT32,
+            /*self$*/SwiftValueLayout.SWIFT_POINTER
           );
           """
       )
@@ -123,8 +123,8 @@ final class FunctionDescriptorTests {
         expected:
           """
           public static final FunctionDescriptor DESC_SET = FunctionDescriptor.ofVoid(
-            /*newValue*/SWIFT_INT32,
-            /*self$*/SWIFT_POINTER
+            /*newValue*/SwiftValueLayout.SWIFT_INT32,
+            /*self$*/SwiftValueLayout.SWIFT_POINTER
           );
           """
       )

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -48,16 +48,16 @@ final class VariableImportTests {
         """
         private static class counterInt {
           public static final FunctionDescriptor DESC_GET = FunctionDescriptor.of(
-              /* -> */SWIFT_INT,
-              /*self$*/SWIFT_POINTER
+              /* -> */SwiftValueLayout.SWIFT_INT,
+              /*self$*/SwiftValueLayout.SWIFT_POINTER
           );
           public static final MemorySegment ADDR_GET =
           FakeModule.findOrThrow("swiftjava_FakeModule_MySwiftClass_counterInt");
 
           public static final MethodHandle HANDLE_GET = Linker.nativeLinker().downcallHandle(ADDR_GET, DESC_GET);
           public static final FunctionDescriptor DESC_SET = FunctionDescriptor.ofVoid(
-              /*newValue*/SWIFT_INT,
-              /*self$*/SWIFT_POINTER
+              /*newValue*/SwiftValueLayout.SWIFT_INT,
+              /*self$*/SwiftValueLayout.SWIFT_POINTER
           );
           public static final MemorySegment ADDR_SET =
               FakeModule.findOrThrow("swiftjava_FakeModule_MySwiftClass_counterInt");


### PR DESCRIPTION
- Moves the ValueLayout constants from the generated code to SwiftKit instead.
- Also removes the unused C constants.
- The generated code now correctly uses 32 or 64 bit int for `Int` type, based on platform.

Fixes #231 