### PR TITLE
[JExtract] Unify mechanisms between value types and reference types

### DIFF
--- a/Samples/SwiftAndJavaJarSampleLib/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
@@ -33,6 +33,7 @@ public class JavaToSwiftBenchmark {
 
     @State(Scope.Benchmark)
     public static class BenchmarkState {
+        ClosableSwiftArena arena;
         MySwiftClass obj;
 
         @Setup(Level.Trial)
@@ -43,7 +44,13 @@ public class JavaToSwiftBenchmark {
             // Tune down debug statements so they don't fill up stdout
             System.setProperty("jextract.trace.downcalls", "false");
 
-            obj = new MySwiftClass(1, 2);
+            arena = SwiftArena.ofConfined();
+            obj = new MySwiftClass(arena, 1, 2);
+        }
+
+        @TearDown(Level.Trial)
+        public void afterAll() {
+            arena.close();
         }
     }
 

--- a/Samples/SwiftAndJavaJarSampleLib/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
@@ -45,7 +45,7 @@ public class JavaToSwiftBenchmark {
             System.setProperty("jextract.trace.downcalls", "false");
 
             arena = SwiftArena.ofConfined();
-            obj = new MySwiftClass(arena, 1, 2);
+            obj = new MySwiftClass(1, 2, arena);
         }
 
         @TearDown(Level.Trial)

--- a/Samples/SwiftAndJavaJarSampleLib/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -47,8 +47,8 @@ public class HelloJava2Swift {
             MySwiftClass obj = new MySwiftClass(arena, 2222, 7777);
 
             // just checking retains/releases work
-            SwiftKit.retain(obj.$memorySegment());
-            SwiftKit.release(obj.$memorySegment());
+            SwiftKit.retain(obj);
+            SwiftKit.release(obj);
 
             obj.voidMethod();
             obj.takeIntMethod(42);

--- a/Samples/SwiftAndJavaJarSampleLib/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -44,7 +44,7 @@ public class HelloJava2Swift {
 
         // Example of using an arena; MyClass.deinit is run at end of scope
         try (var arena = SwiftArena.ofConfined()) {
-            MySwiftClass obj = new MySwiftClass(arena, 2222, 7777);
+            MySwiftClass obj = new MySwiftClass(2222, 7777, arena);
 
             // just checking retains/releases work
             SwiftKit.retain(obj);

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -43,7 +43,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_voidMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            MySwiftClass o = new MySwiftClass(12, 42, arena);
             o.voidMethod();
         } catch (Throwable throwable) {
             checkPaths(throwable);
@@ -53,7 +53,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_makeIntMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            MySwiftClass o = new MySwiftClass(12, 42, arena);
             var got = o.makeIntMethod();
             assertEquals(12, got);
         }
@@ -63,7 +63,7 @@ public class MySwiftClassTest {
     @Disabled // TODO: Need var mangled names in interfaces
     void test_MySwiftClass_property_len() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            MySwiftClass o = new MySwiftClass(12, 42, arena);
             var got = o.getLen();
             assertEquals(12, got);
         }

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -16,6 +16,7 @@ package com.example.swift;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.swift.swiftkit.SwiftArena;
 import org.swift.swiftkit.SwiftKit;
 
 import java.io.File;
@@ -41,8 +42,8 @@ public class MySwiftClassTest {
 
     @Test
     void test_MySwiftClass_voidMethod() {
-        try {
-            MySwiftClass o = new MySwiftClass(12, 42);
+        try(var arena = SwiftArena.ofConfined()) {
+            MySwiftClass o = new MySwiftClass(arena, 12, 42);
             o.voidMethod();
         } catch (Throwable throwable) {
             checkPaths(throwable);
@@ -51,17 +52,21 @@ public class MySwiftClassTest {
 
     @Test
     void test_MySwiftClass_makeIntMethod() {
-        MySwiftClass o = new MySwiftClass(12, 42);
-        var got = o.makeIntMethod();
-        assertEquals(12, got);
+        try(var arena = SwiftArena.ofConfined()) {
+            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            var got = o.makeIntMethod();
+            assertEquals(12, got);
+        }
     }
 
     @Test
     @Disabled // TODO: Need var mangled names in interfaces
     void test_MySwiftClass_property_len() {
-        MySwiftClass o = new MySwiftClass(12, 42);
-        var got = o.getLen();
-        assertEquals(12, got);
+        try(var arena = SwiftArena.ofConfined()) {
+            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            var got = o.getLen();
+            assertEquals(12, got);
+        }
     }
 
 }

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
@@ -25,7 +25,7 @@ public class MySwiftClassTest {
     @Test
     void call_retain_retainCount_release() {
         var arena = SwiftArena.ofConfined();
-        var obj = new MySwiftClass(arena, 1, 2);
+        var obj = new MySwiftClass(1, 2, arena);
 
         assertEquals(1, SwiftKit.retainCount(obj));
         // TODO: test directly on SwiftHeapObject inheriting obj

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
@@ -27,13 +27,13 @@ public class MySwiftClassTest {
         var arena = SwiftArena.ofConfined();
         var obj = new MySwiftClass(arena, 1, 2);
 
-        assertEquals(1, SwiftKit.retainCount(obj.$memorySegment()));
+        assertEquals(1, SwiftKit.retainCount(obj));
         // TODO: test directly on SwiftHeapObject inheriting obj
 
-        SwiftKit.retain(obj.$memorySegment());
-        assertEquals(2, SwiftKit.retainCount(obj.$memorySegment()));
+        SwiftKit.retain(obj);
+        assertEquals(2, SwiftKit.retainCount(obj));
 
-        SwiftKit.release(obj.$memorySegment());
-        assertEquals(1, SwiftKit.retainCount(obj.$memorySegment()));
+        SwiftKit.release(obj);
+        assertEquals(1, SwiftKit.retainCount(obj));
     }
 }

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -50,26 +50,4 @@ public class SwiftArenaTest {
 
         // TODO: should we zero out the $memorySegment perhaps?
     }
-
-    @Test
-    public void arena_releaseClassOnClose_class_leaked() {
-        String memorySegmentDescription = "<none>";
-
-        try {
-            try (var arena = SwiftArena.ofConfined()) {
-                var obj = new MySwiftClass(arena,1, 2);
-                memorySegmentDescription = obj.$memorySegment().toString();
-
-                // Pretend that we "leaked" the class, something still holds a reference to it while we try to destroy it
-                retain(obj.$memorySegment());
-                assertEquals(2, retainCount(obj.$memorySegment()));
-            }
-
-            fail("Expected exception to be thrown while the arena is closed!");
-        } catch (Exception ex) {
-            // The message should point out which objects "leaked":
-            assertTrue(ex.getMessage().contains(memorySegmentDescription));
-        }
-
-    }
 }

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -41,11 +41,11 @@ public class SwiftArenaTest {
         try (var arena = SwiftArena.ofConfined()) {
             var obj = new MySwiftClass(arena,1, 2);
 
-            retain(obj.$memorySegment());
-            assertEquals(2, retainCount(obj.$memorySegment()));
+            retain(obj);
+            assertEquals(2, retainCount(obj));
 
-            release(obj.$memorySegment());
-            assertEquals(1, retainCount(obj.$memorySegment()));
+            release(obj);
+            assertEquals(1, retainCount(obj));
         }
 
         // TODO: should we zero out the $memorySegment perhaps?

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -39,7 +39,7 @@ public class SwiftArenaTest {
     @DisabledIf("isAmd64")
     public void arena_releaseClassOnClose_class_ok() {
         try (var arena = SwiftArena.ofConfined()) {
-            var obj = new MySwiftClass(arena,1, 2);
+            var obj = new MySwiftClass(1, 2, arena);
 
             retain(obj);
             assertEquals(2, retainCount(obj));

--- a/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
+++ b/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
@@ -37,7 +37,7 @@ public class JavaToSwiftBenchmark {
         @Setup(Level.Trial)
         public void beforeAll() {
             arena = SwiftArena.ofConfined();
-            obj = new MySwiftClass(arena, 1, 2);
+            obj = new MySwiftClass(1, 2, arena);
         }
 
         @TearDown(Level.Trial)

--- a/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/StringPassingBenchmark.java
+++ b/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/StringPassingBenchmark.java
@@ -46,7 +46,7 @@ public class StringPassingBenchmark {
     @Setup(Level.Trial)
     public void beforeAll() {
         arena = SwiftArena.ofConfined();
-        obj = new MySwiftClass(arena, 1, 2);
+        obj = new MySwiftClass(1, 2, arena);
         string = makeString(stringLen);
     }
 

--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -42,7 +42,7 @@ public class HelloJava2Swift {
 
         // Example of using an arena; MyClass.deinit is run at end of scope
         try (var arena = SwiftArena.ofConfined()) {
-             MySwiftClass obj = new MySwiftClass(arena, 2222, 7777);
+             MySwiftClass obj = new MySwiftClass(2222, 7777, arena);
 
              // just checking retains/releases work
              SwiftKit.trace("retainCount = " + SwiftKit.retainCount(obj));
@@ -54,7 +54,7 @@ public class HelloJava2Swift {
              obj.voidMethod();
              obj.takeIntMethod(42);
 
-            MySwiftStruct swiftValue = new MySwiftStruct(arena, 2222, 1111);
+            MySwiftStruct swiftValue = new MySwiftStruct(2222, 1111, arena);
         }
 
         System.out.println("DONE.");

--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -45,8 +45,11 @@ public class HelloJava2Swift {
              MySwiftClass obj = new MySwiftClass(arena, 2222, 7777);
 
              // just checking retains/releases work
-             SwiftKit.retain(obj.$memorySegment());
-             SwiftKit.release(obj.$memorySegment());
+             SwiftKit.trace("retainCount = " + SwiftKit.retainCount(obj));
+             SwiftKit.retain(obj);
+             SwiftKit.trace("retainCount = " + SwiftKit.retainCount(obj));
+             SwiftKit.release(obj);
+             SwiftKit.trace("retainCount = " + SwiftKit.retainCount(obj));
 
              obj.voidMethod();
              obj.takeIntMethod(42);

--- a/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -16,6 +16,7 @@ package com.example.swift;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.swift.swiftkit.SwiftArena;
 import org.swift.swiftkit.SwiftKit;
 
 import java.io.File;
@@ -40,8 +41,8 @@ public class MySwiftClassTest {
 
     @Test
     void test_MySwiftClass_voidMethod() {
-        try {
-            MySwiftClass o = new MySwiftClass(12, 42);
+        try(var arena = SwiftArena.ofConfined()) {
+            MySwiftClass o = new MySwiftClass(arena, 12, 42);
             o.voidMethod();
         } catch (Throwable throwable) {
             checkPaths(throwable);
@@ -50,17 +51,21 @@ public class MySwiftClassTest {
 
     @Test
     void test_MySwiftClass_makeIntMethod() {
-        MySwiftClass o = new MySwiftClass(12, 42);
-        var got = o.makeIntMethod();
-        assertEquals(12, got);
+        try(var arena = SwiftArena.ofConfined()) {
+            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            var got = o.makeIntMethod();
+            assertEquals(12, got);
+        }
     }
 
     @Test
     @Disabled // TODO: Need var mangled names in interfaces
     void test_MySwiftClass_property_len() {
-        MySwiftClass o = new MySwiftClass(12, 42);
-        var got = o.getLen();
-        assertEquals(12, got);
+        try(var arena = SwiftArena.ofConfined()) {
+            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            var got = o.getLen();
+            assertEquals(12, got);
+        }
     }
 
 }

--- a/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -42,7 +42,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_voidMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            MySwiftClass o = new MySwiftClass(12, 42, arena);
             o.voidMethod();
         } catch (Throwable throwable) {
             checkPaths(throwable);
@@ -52,7 +52,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_makeIntMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            MySwiftClass o = new MySwiftClass(12, 42, arena);
             var got = o.makeIntMethod();
             assertEquals(12, got);
         }
@@ -62,7 +62,7 @@ public class MySwiftClassTest {
     @Disabled // TODO: Need var mangled names in interfaces
     void test_MySwiftClass_property_len() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(arena, 12, 42);
+            MySwiftClass o = new MySwiftClass(12, 42, arena);
             var got = o.getLen();
             assertEquals(12, got);
         }

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
@@ -25,7 +25,7 @@ public class MySwiftClassTest {
     @Test
     void call_retain_retainCount_release() {
         var arena = SwiftArena.ofConfined();
-        var obj = new MySwiftClass(arena, 1, 2);
+        var obj = new MySwiftClass(1, 2, arena);
 
         assertEquals(1, SwiftKit.retainCount(obj));
         // TODO: test directly on SwiftHeapObject inheriting obj

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
@@ -27,13 +27,13 @@ public class MySwiftClassTest {
         var arena = SwiftArena.ofConfined();
         var obj = new MySwiftClass(arena, 1, 2);
 
-        assertEquals(1, SwiftKit.retainCount(obj.$memorySegment()));
+        assertEquals(1, SwiftKit.retainCount(obj));
         // TODO: test directly on SwiftHeapObject inheriting obj
 
-        SwiftKit.retain(obj.$memorySegment());
-        assertEquals(2, SwiftKit.retainCount(obj.$memorySegment()));
+        SwiftKit.retain(obj);
+        assertEquals(2, SwiftKit.retainCount(obj));
 
-        SwiftKit.release(obj.$memorySegment());
-        assertEquals(1, SwiftKit.retainCount(obj.$memorySegment()));
+        SwiftKit.release(obj);
+        assertEquals(1, SwiftKit.retainCount(obj));
     }
 }

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftStructTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftStructTest.java
@@ -26,7 +26,7 @@ public class MySwiftStructTest {
         try (var arena = SwiftArena.ofConfined()) {
             long cap = 12;
             long len = 34;
-            var struct = new MySwiftStruct(arena, cap, len);
+            var struct = new MySwiftStruct(cap, len, arena);
 
             assertEquals(cap, struct.getCapacity());
             assertEquals(len, struct.getLength());

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -40,7 +40,7 @@ public class SwiftArenaTest {
     @DisabledIf("isAmd64")
     public void arena_releaseClassOnClose_class_ok() {
         try (var arena = SwiftArena.ofConfined()) {
-            var obj = new MySwiftClass(arena,1, 2);
+            var obj = new MySwiftClass(1, 2, arena);
 
             retain(obj);
             assertEquals(2, retainCount(obj));
@@ -57,7 +57,7 @@ public class SwiftArenaTest {
         MySwiftClass unsafelyEscapedOutsideArenaScope = null;
 
         try (var arena = SwiftArena.ofConfined()) {
-            var obj = new MySwiftClass(arena,1, 2);
+            var obj = new MySwiftClass(1, 2, arena);
             unsafelyEscapedOutsideArenaScope = obj;
         }
 
@@ -76,7 +76,7 @@ public class SwiftArenaTest {
         MySwiftStruct unsafelyEscapedOutsideArenaScope = null;
 
         try (var arena = SwiftArena.ofConfined()) {
-            var s = new MySwiftStruct(arena,1, 2);
+            var s = new MySwiftStruct(1, 2, arena);
             unsafelyEscapedOutsideArenaScope = s;
         }
 

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -42,11 +42,11 @@ public class SwiftArenaTest {
         try (var arena = SwiftArena.ofConfined()) {
             var obj = new MySwiftClass(arena,1, 2);
 
-            retain(obj.$memorySegment());
-            assertEquals(2, retainCount(obj.$memorySegment()));
+            retain(obj);
+            assertEquals(2, retainCount(obj));
 
-            release(obj.$memorySegment());
-            assertEquals(1, retainCount(obj.$memorySegment()));
+            release(obj);
+            assertEquals(1, retainCount(obj));
         }
     }
 

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -89,27 +89,6 @@ public class SwiftArenaTest {
     }
 
     @Test
-    public void arena_releaseClassOnClose_class_leaked() {
-        String memorySegmentDescription = "<none>";
-
-        try {
-            try (var arena = SwiftArena.ofConfined()) {
-                var obj = new MySwiftClass(arena,1, 2);
-                memorySegmentDescription = obj.$memorySegment().toString();
-
-                // Pretend that we "leaked" the class, something still holds a reference to it while we try to destroy it
-                retain(obj.$memorySegment());
-                assertEquals(2, retainCount(obj.$memorySegment()));
-            }
-
-            fail("Expected exception to be thrown while the arena is closed!");
-        } catch (Exception ex) {
-            // The message should point out which objects "leaked":
-            assertTrue(ex.getMessage().contains(memorySegmentDescription));
-        }
-    }
-
-    @Test
     public void arena_initializeWithCopy_struct() {
 
     }

--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -267,8 +267,12 @@ public struct ImportedFunc: ImportedDecl, CustomStringConvertible {
   public var isInit: Bool = false
 
   public var isIndirectReturn: Bool {
-    returnType.isValueType ||
-      (isInit && (parent?.isValueType ?? false))
+    switch returnType.originalSwiftTypeKind {
+    case .actor, .class, .struct, .enum:
+      return true
+    default:
+      return false
+    }
   }
 
   public init(

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -290,11 +290,8 @@ extension Swift2JavaTranslator {
       parentProtocol = "SwiftValue"
     }
 
-    printer.printTypeDecl("public final class \(decl.javaClassName) implements \(parentProtocol)") {
+    printer.printTypeDecl("public final class \(decl.javaClassName) extends SwiftInstance implements \(parentProtocol)") {
       printer in
-      // ==== Storage of the class
-      printClassSelfProperty(&printer, decl)
-      printStatusFlagsField(&printer, decl)
 
       // Constants
       printClassConstants(printer: &printer)
@@ -400,35 +397,6 @@ extension Swift2JavaTranslator {
     )
   }
 
-  /// Print a property where we can store the "self" pointer of a class.
-  private func printClassSelfProperty(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
-    printer.print(
-      """
-      // Pointer to the referred to class instance's "self".
-      private final MemorySegment selfMemorySegment;
-
-      public final MemorySegment $memorySegment() {
-        return this.selfMemorySegment;
-      }
-      """
-    )
-  }
-
-  private func printStatusFlagsField(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
-    printer.print(
-      """
-      // TODO: make this a flagset integer and/or use a field updater
-      /** Used to track additional state of the underlying object, e.g. if it was explicitly destroyed. */
-      private final AtomicBoolean $state$destroyed = new AtomicBoolean(false);
-
-      @Override
-      public final AtomicBoolean $statusDestroyedFlag() {
-        return this.$state$destroyed;
-      }
-      """
-    )
-  }
-
   private func printClassMemoryLayout(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
     printer.print(
       """
@@ -472,29 +440,10 @@ extension Swift2JavaTranslator {
       \(decl.renderCommentSnippet ?? " *")
        */
       public \(parentName.unqualifiedJavaTypeName)(\(renderJavaParamDecls(decl, paramPassingStyle: .wrapper))) {
-        this(/*arena=*/null, \(renderForwardJavaParams(decl, paramPassingStyle: .wrapper)));
+        this(SwiftArena.ofAuto(), \(renderForwardJavaParams(decl, paramPassingStyle: .wrapper)));
       }
       """
     )
-
-    let initializeMemorySegment =
-      if let parent = decl.parent,
-        parent.isReferenceType
-      {
-        """
-        this.selfMemorySegment = (MemorySegment) mh$.invokeExact(
-          \(renderForwardJavaParams(decl, paramPassingStyle: nil))
-          );
-        """
-      } else {
-        """
-        this.selfMemorySegment = arena.allocate($layout());
-        mh$.invokeExact(
-          \(renderForwardJavaParams(decl, paramPassingStyle: nil)),
-          /* indirect return buffer */this.selfMemorySegment
-        );
-        """
-      }
 
     printer.print(
       """
@@ -505,20 +454,23 @@ extension Swift2JavaTranslator {
       \(decl.renderCommentSnippet ?? " *")
        */
       public \(parentName.unqualifiedJavaTypeName)(SwiftArena arena, \(renderJavaParamDecls(decl, paramPassingStyle: .wrapper))) {
-        var mh$ = \(descClassIdentifier).HANDLE;
-        try {
+        super(() -> {
+          var mh$ = \(descClassIdentifier).HANDLE;
+          try {
+            MemorySegment _result = arena.allocate($LAYOUT);
+      
             if (SwiftKit.TRACE_DOWNCALLS) {
               SwiftKit.traceDowncall(\(renderForwardJavaParams(decl, paramPassingStyle: nil)));
             }
-
-            \(initializeMemorySegment)
-
-            if (arena != null) {
-                arena.register(this);
-            }
-        } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
-        }
+            mh$.invokeExact(
+              \(renderForwardJavaParams(decl, paramPassingStyle: nil)),
+              /* indirect return buffer */_result
+            );
+            return _result;
+          } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+          }
+        }, arena);
       }
       """
     )
@@ -714,9 +666,7 @@ extension Swift2JavaTranslator {
       let guardFromDestroyedObjectCalls: String =
       if decl.hasParent {
         """
-        if (this.$state$destroyed.get()) {
-          throw new IllegalStateException("Attempted to call method on already destroyed instance of " + getClass().getSimpleName() + "!");
-        }
+        $ensureAlive();
         """
       } else { "" }
 

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -436,19 +436,6 @@ extension Swift2JavaTranslator {
       """
       /**
        * Create an instance of {@code \(parentName.unqualifiedJavaTypeName)}.
-       *
-      \(decl.renderCommentSnippet ?? " *")
-       */
-      public \(parentName.unqualifiedJavaTypeName)(\(renderJavaParamDecls(decl, paramPassingStyle: .wrapper))) {
-        this(SwiftArena.ofAuto(), \(renderForwardJavaParams(decl, paramPassingStyle: .wrapper)));
-      }
-      """
-    )
-
-    printer.print(
-      """
-      /**
-       * Create an instance of {@code \(parentName.unqualifiedJavaTypeName)}.
        * This instance is managed by the passed in {@link SwiftArena} and may not outlive the arena's lifetime.
        *
       \(decl.renderCommentSnippet ?? " *")

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -440,7 +440,7 @@ extension Swift2JavaTranslator {
        *
       \(decl.renderCommentSnippet ?? " *")
        */
-      public \(parentName.unqualifiedJavaTypeName)(SwiftArena arena, \(renderJavaParamDecls(decl, paramPassingStyle: .wrapper))) {
+      public \(parentName.unqualifiedJavaTypeName)(\(renderJavaParamDecls(decl, paramPassingStyle: .wrapper)), SwiftArena arena) {
         super(() -> {
           var mh$ = \(descClassIdentifier).HANDLE;
           try {

--- a/SwiftKit/src/main/java/org/swift/swiftkit/AutoSwiftMemorySession.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/AutoSwiftMemorySession.java
@@ -48,38 +48,16 @@ final class AutoSwiftMemorySession implements SwiftArena {
     }
 
     @Override
-    public void register(SwiftHeapObject object) {
-        var statusDestroyedFlag = object.$statusDestroyedFlag();
-        Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
-
-        SwiftHeapObjectCleanup cleanupAction = new SwiftHeapObjectCleanup(
-                object.$memorySegment(),
-                object.$swiftType(),
-                markAsDestroyed
-        );
-        register(object, cleanupAction);
-    }
-
-    // visible for testing
-    void register(SwiftHeapObject object, SwiftHeapObjectCleanup cleanupAction) {
-        Objects.requireNonNull(object, "obj");
-        Objects.requireNonNull(cleanupAction, "cleanupAction");
-
-
-        cleaner.register(object, cleanupAction);
-    }
-
-    @Override
-    public void register(SwiftValue value) {
-        Objects.requireNonNull(value, "value");
+    public void register(SwiftInstance instance) {
+        Objects.requireNonNull(instance, "value");
 
         // We're doing this dance to avoid keeping a strong reference to the value itself
-        var statusDestroyedFlag = value.$statusDestroyedFlag();
+        var statusDestroyedFlag = instance.$statusDestroyedFlag();
         Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
 
-        MemorySegment resource = value.$memorySegment();
-        var cleanupAction = new SwiftValueCleanup(resource, value.$swiftType(), markAsDestroyed);
-        cleaner.register(value, cleanupAction);
+        MemorySegment resource = instance.$memorySegment();
+        var cleanupAction = new SwiftInstanceCleanup(resource, instance.$swiftType(), markAsDestroyed);
+        cleaner.register(instance, cleanupAction);
     }
 
     @Override

--- a/SwiftKit/src/main/java/org/swift/swiftkit/ConfinedSwiftMemorySession.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/ConfinedSwiftMemorySession.java
@@ -61,28 +61,15 @@ final class ConfinedSwiftMemorySession implements ClosableSwiftArena {
     }
 
     @Override
-    public void register(SwiftHeapObject object) {
+    public void register(SwiftInstance instance) {
         checkValid();
 
-        var statusDestroyedFlag = object.$statusDestroyedFlag();
+        var statusDestroyedFlag = instance.$statusDestroyedFlag();
         Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
 
-        var cleanup = new SwiftHeapObjectCleanup(
-                object.$memorySegment(), object.$swiftType(),
-                markAsDestroyed);
-        this.resources.add(cleanup);
-    }
-
-    @Override
-    public void register(SwiftValue value) {
-        checkValid();
-
-        var statusDestroyedFlag = value.$statusDestroyedFlag();
-        Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
-
-        var cleanup = new SwiftValueCleanup(
-                value.$memorySegment(),
-                value.$swiftType(),
+        var cleanup = new SwiftInstanceCleanup(
+                instance.$memorySegment(),
+                instance.$swiftType(),
                 markAsDestroyed);
         this.resources.add(cleanup);
     }

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftAnyType.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftAnyType.java
@@ -34,20 +34,6 @@ public final class SwiftAnyType {
         this.memorySegment = memorySegment.asReadOnly();
     }
 
-//    public SwiftAnyType(SwiftHeapObject object) {
-//        if (object.$layout().name().isEmpty()) {
-//            throw new IllegalArgumentException("SwiftHeapObject must have a mangled name in order to obtain its SwiftType.");
-//        }
-//
-//        String mangledName = object.$layout().name().get();
-//        var type = SwiftKit.getTypeByMangledNameInEnvironment(mangledName);
-//        if (type.isEmpty()) {
-//            throw new IllegalArgumentException("A Swift Any.Type cannot be null!");
-//        }
-//        this.memorySegment = type.get().memorySegment;
-//    }
-
-
     public MemorySegment $memorySegment() {
         return memorySegment;
     }

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftAnyType.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftAnyType.java
@@ -34,18 +34,18 @@ public final class SwiftAnyType {
         this.memorySegment = memorySegment.asReadOnly();
     }
 
-    public SwiftAnyType(SwiftHeapObject object) {
-        if (object.$layout().name().isEmpty()) {
-            throw new IllegalArgumentException("SwiftHeapObject must have a mangled name in order to obtain its SwiftType.");
-        }
-
-        String mangledName = object.$layout().name().get();
-        var type = SwiftKit.getTypeByMangledNameInEnvironment(mangledName);
-        if (type.isEmpty()) {
-            throw new IllegalArgumentException("A Swift Any.Type cannot be null!");
-        }
-        this.memorySegment = type.get().memorySegment;
-    }
+//    public SwiftAnyType(SwiftHeapObject object) {
+//        if (object.$layout().name().isEmpty()) {
+//            throw new IllegalArgumentException("SwiftHeapObject must have a mangled name in order to obtain its SwiftType.");
+//        }
+//
+//        String mangledName = object.$layout().name().get();
+//        var type = SwiftKit.getTypeByMangledNameInEnvironment(mangledName);
+//        if (type.isEmpty()) {
+//            throw new IllegalArgumentException("A Swift Any.Type cannot be null!");
+//        }
+//        this.memorySegment = type.get().memorySegment;
+//    }
 
 
     public MemorySegment $memorySegment() {

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftArena.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftArena.java
@@ -36,16 +36,10 @@ public interface SwiftArena extends SegmentAllocator {
     }
 
     /**
-     * Register a Swift reference counted heap object with this arena (such as a {@code class} or {@code actor}).
+     * Register a Swift object.
      * Its memory should be considered managed by this arena, and be destroyed when the arena is closed.
      */
-    void register(SwiftHeapObject object);
-
-    /**
-     * Register a struct, enum or other non-reference counted Swift object.
-     * Its memory should be considered managed by this arena, and be destroyed when the arena is closed.
-     */
-    void register(SwiftValue value);
+    void register(SwiftInstance instance);
 
 }
 

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftHeapObject.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftHeapObject.java
@@ -14,9 +14,18 @@
 
 package org.swift.swiftkit;
 
+import java.lang.foreign.MemorySegment;
+
 /**
  * Represents a wrapper around a Swift heap object, e.g. a {@code class} or an {@code actor}.
  */
-public interface SwiftHeapObject extends SwiftInstance {
-    SwiftAnyType $swiftType();
+public interface SwiftHeapObject {
+    MemorySegment $memorySegment();
+
+    /**
+     * Pointer to the instance.
+     */
+    public default MemorySegment $instance() {
+        return this.$memorySegment().get(SwiftValueLayout.SWIFT_POINTER, 0);
+    }
 }

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftInstanceCleanup.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftInstanceCleanup.java
@@ -19,65 +19,20 @@ import java.lang.foreign.MemorySegment;
 /**
  * A Swift memory instance cleanup, e.g. count-down a reference count and destroy a class, or destroy struct/enum etc.
  */
-interface SwiftInstanceCleanup extends Runnable {
-}
-
-/**
- * Implements cleaning up a Swift {@link SwiftHeapObject}.
- * <p>
- * This class does not store references to the Java wrapper class, and therefore the wrapper may be subject to GC,
- * which may trigger a cleanup (using this class), which will clean up its underlying native memory resource.
- */
-// non-final for testing
-class SwiftHeapObjectCleanup implements SwiftInstanceCleanup {
-
-    private final MemorySegment selfPointer;
-    private final SwiftAnyType selfType;
-    private final Runnable markAsDestroyed;
-
-    /**
-     * This constructor on purpose does not just take a {@link SwiftHeapObject} in order to make it very
-     * clear that it does not take ownership of it, but we ONLY manage the native resource here.
-     * </p>
-     * This is important for {@link AutoSwiftMemorySession} which relies on the wrapper type to be GC-able,
-     * when no longer "in use" on the Java side.
-     */
-    SwiftHeapObjectCleanup(MemorySegment selfPointer,
-                           SwiftAnyType selfType, Runnable markAsDestroyed) {
-        this.selfPointer  = selfPointer;
-        this.markAsDestroyed = markAsDestroyed;
-        this.selfType = selfType;
-    }
-
-    @Override
-    public void run() throws UnexpectedRetainCountException {
-        // Verify we're only destroying an object that's indeed not retained by anyone else:
-        long retainedCount = SwiftKit.retainCount(selfPointer);
-        if (retainedCount > 1) {
-            throw new UnexpectedRetainCountException(selfPointer, retainedCount, 1);
-        }
-
-        this.markAsDestroyed.run();
-
-        // Destroy (and deinit) the object:
-        SwiftValueWitnessTable.destroy(selfType, selfPointer);
-
-        // Invalidate the Java wrapper class, in order to prevent effectively use-after-free issues.
-        // FIXME: some trouble with setting the pointer to null, need to figure out an appropriate way to do this
-    }
-}
-
-record SwiftValueCleanup(
+record SwiftInstanceCleanup(
         MemorySegment selfPointer,
         SwiftAnyType selfType,
         Runnable markAsDestroyed
-) implements SwiftInstanceCleanup {
+) implements Runnable {
 
     @Override
     public void run() {
-        System.out.println("[debug] Destroy swift value [" + selfType.getSwiftName() + "]: " + selfPointer);
-
         markAsDestroyed.run();
-        SwiftValueWitnessTable.destroy(selfType, selfPointer);
+
+        // Allow null pointers just for AutoArena tests.
+        if (selfType != null && selfPointer != null) {
+            System.out.println("[debug] Destroy swift value [" + selfType.getSwiftName() + "]: " + selfPointer);
+            SwiftValueWitnessTable.destroy(selfType, selfPointer);
+        }
     }
 }

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftKit.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftKit.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.file.CopyOption;
 import java.nio.file.FileSystems;
@@ -206,7 +207,7 @@ public class SwiftKit {
     }
 
     public static long retainCount(SwiftHeapObject object) {
-        return retainCount(object.$memorySegment());
+        return retainCount(object.$instance());
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -236,7 +237,7 @@ public class SwiftKit {
     }
 
     public static void retain(SwiftHeapObject object) {
-        retain(object.$memorySegment());
+        retain(object.$instance());
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -266,7 +267,7 @@ public class SwiftKit {
     }
 
     public static long release(SwiftHeapObject object) {
-        return retainCount(object.$memorySegment());
+        return retainCount(object.$instance());
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------
@@ -446,6 +447,28 @@ public class SwiftKit {
         }
     }
 
+    /**
+     * Convert String to a MemorySegment filled with the C string.
+     */
+    public static MemorySegment toCString(String str, Arena arena) {
+        return arena.allocateFrom(str);
+    }
+
+    /**
+     * Convert Runnable to a MemorySegment which is an upcall stub for it.
+     */
+    public static MemorySegment toUpcallStub(Runnable callback, Arena arena) {
+        try {
+            FunctionDescriptor descriptor = FunctionDescriptor.ofVoid();
+            MethodHandle handle = MethodHandles.lookup()
+                    .findVirtual(Runnable.class, "run", descriptor.toMethodType())
+                    .bindTo(callback);
+            return Linker.nativeLinker()
+                    .upcallStub(handle, descriptor, arena);
+        } catch (Exception e) {
+            throw new AssertionError("should be unreachable");
+        }
+    }
 
     private static class swift_getTypeName {
 

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftKit.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftKit.java
@@ -266,8 +266,8 @@ public class SwiftKit {
         }
     }
 
-    public static long release(SwiftHeapObject object) {
-        return retainCount(object.$instance());
+    public static void release(SwiftHeapObject object) {
+        release(object.$instance());
     }
 
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValue.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValue.java
@@ -14,6 +14,8 @@
 
 package org.swift.swiftkit;
 
-public interface SwiftValue extends SwiftInstance {
-    SwiftAnyType $swiftType();
+/**
+ * Represent a wrapper around a Swift value object. e.g. {@code struct} or {@code enum}.
+ */
+public interface SwiftValue {
 }

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueWitnessTable.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueWitnessTable.java
@@ -220,12 +220,8 @@ public abstract class SwiftValueWitnessTable {
 
         var mh = destroy.handle(type);
 
-        try (var arena = Arena.ofConfined()) {
-            // we need to make a pointer to the self pointer when calling witness table functions:
-            MemorySegment indirect = arena.allocate(SwiftValueLayout.SWIFT_POINTER); // TODO: remove this and just have classes have this always anyway
-            MemorySegmentUtils.setSwiftPointerAddress(indirect, object);
-
-            mh.invokeExact(indirect, wtable);
+        try {
+            mh.invokeExact(object, wtable);
         } catch (Throwable th) {
             throw new AssertionError("Failed to destroy '" + type + "' at " + object, th);
         }
@@ -285,15 +281,8 @@ public abstract class SwiftValueWitnessTable {
 
         var mh = initializeWithCopy.handle(type);
 
-        try (var arena = Arena.ofConfined()) {
-            // we need to make a pointer to the self pointer when calling witness table functions:
-            MemorySegment indirectDest = arena.allocate(SwiftValueLayout.SWIFT_POINTER);
-            MemorySegmentUtils.setSwiftPointerAddress(indirectDest, dest);
-            MemorySegment indirectSrc = arena.allocate(SwiftValueLayout.SWIFT_POINTER);
-            MemorySegmentUtils.setSwiftPointerAddress(indirectSrc, src);
-
-            var returnedDest = (MemorySegment) mh.invokeExact(indirectDest, indirectSrc, wtable);
-            return returnedDest;
+        try {
+            return (MemorySegment) mh.invokeExact(dest, src, wtable);
         } catch (Throwable th) {
             throw new AssertionError("Failed to initializeWithCopy '" + type + "' (" + dest + ", " + src + ")", th);
         }

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -349,9 +349,7 @@ final class MethodImportTests {
          * }
          */
         public void helloMemberFunction() {
-            if (this.$state$destroyed.get()) {
-              throw new IllegalStateException("Attempted to call method on already destroyed instance of " + getClass().getSimpleName() + "!")
-            }
+            $ensureAlive();
             helloMemberFunction($memorySegment());
         }
         """
@@ -387,9 +385,7 @@ final class MethodImportTests {
          * }
          */
         public long makeInt() {
-          if (this.$state$destroyed.get()) {
-            throw new IllegalStateException("Attempted to call method on already destroyed instance of " + getClass().getSimpleName() + "!")
-          }
+          $ensureAlive();
 
           return (long) makeInt($memorySegment());
         }
@@ -427,7 +423,7 @@ final class MethodImportTests {
          * }
          */
         public MySwiftClass(long len, long cap) {
-          this(/*arena=*/null, len, cap);
+          this(SwiftArena.ofAuto(), len, cap);
         }
         /**
          * Create an instance of {@code MySwiftClass}.
@@ -438,20 +434,22 @@ final class MethodImportTests {
          * }
          */
         public MySwiftClass(SwiftArena arena, long len, long cap) {
-          var mh$ = init_len_cap.HANDLE;
-          try {
+          super(() -> {
+            var mh$ = init_len_cap.HANDLE;
+            try {
+              MemorySegment _result = arena.allocate($LAYOUT);
               if (SwiftKit.TRACE_DOWNCALLS) {
                 SwiftKit.traceDowncall(len, cap);
               }
-              this.selfMemorySegment = (MemorySegment) mh$.invokeExact(
-                  len, cap
+              mh$.invokeExact(
+                len, cap,
+                /* indirect return buffer */_result
               );
-              if (arena != null) {
-                  arena.register(this);
-              }
-          } catch (Throwable ex$) {
-              throw new AssertionError("should not reach here", ex$);
-          }
+              return _result;
+            } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+            }
+          }, arena);
         }
         """
     )
@@ -487,7 +485,7 @@ final class MethodImportTests {
          * }
          */
         public MySwiftStruct(long len, long cap) {
-          this(/*arena=*/null, len, cap);
+          this(SwiftArena.ofAuto(), len, cap);
         }
         /**
          * Create an instance of {@code MySwiftStruct}.
@@ -497,24 +495,23 @@ final class MethodImportTests {
          * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
-
         public MySwiftStruct(SwiftArena arena, long len, long cap) {
-          var mh$ = init_len_cap.HANDLE;
-          try {
+          super(() -> {
+            var mh$ = init_len_cap.HANDLE;
+            try {
+              MemorySegment _result = arena.allocate($LAYOUT);
               if (SwiftKit.TRACE_DOWNCALLS) {
                 SwiftKit.traceDowncall(len, cap);
               }
-              this.selfMemorySegment = arena.allocate($layout());
               mh$.invokeExact(
-                  len, cap,
-                  /* indirect return buffer */this.selfMemorySegment
+                len, cap,
+                /* indirect return buffer */_result
               );
-              if (arena != null) {
-                  arena.register(this);
-              }
-          } catch (Throwable ex$) {
-              throw new AssertionError("should not reach here", ex$);
-          }
+              return _result;
+            } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+            }
+          }, arena);
         }
         """
     )

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -417,16 +417,6 @@ final class MethodImportTests {
         """
         /**
          * Create an instance of {@code MySwiftClass}.
-         *
-         * {@snippet lang=swift :
-         * public init(len: Swift.Int, cap: Swift.Int)
-         * }
-         */
-        public MySwiftClass(long len, long cap) {
-          this(SwiftArena.ofAuto(), len, cap);
-        }
-        /**
-         * Create an instance of {@code MySwiftClass}.
          * This instance is managed by the passed in {@link SwiftArena} and may not outlive the arena's lifetime.
          *
          * {@snippet lang=swift :
@@ -477,16 +467,6 @@ final class MethodImportTests {
       output,
       expected:
         """
-        /**
-         * Create an instance of {@code MySwiftStruct}.
-         *
-         * {@snippet lang=swift :
-         * public init(len: Swift.Int, cap: Swift.Int)
-         * }
-         */
-        public MySwiftStruct(long len, long cap) {
-          this(SwiftArena.ofAuto(), len, cap);
-        }
         /**
          * Create an instance of {@code MySwiftStruct}.
          * This instance is managed by the passed in {@link SwiftArena} and may not outlive the arena's lifetime.

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -423,7 +423,7 @@ final class MethodImportTests {
          * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
-        public MySwiftClass(SwiftArena arena, long len, long cap) {
+        public MySwiftClass(long len, long cap, SwiftArena arena) {
           super(() -> {
             var mh$ = init_len_cap.HANDLE;
             try {
@@ -475,7 +475,7 @@ final class MethodImportTests {
          * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
-        public MySwiftStruct(SwiftArena arena, long len, long cap) {
+        public MySwiftStruct(long len, long cap, SwiftArena arena) {
           super(() -> {
             var mh$ = init_len_cap.HANDLE;
             try {

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -158,9 +158,7 @@ final class VariableImportTests {
          * }
          */
         public long getCounterInt() {
-          if (this.$state$destroyed.get()) {
-            throw new IllegalStateException("Attempted to call method on already destroyed instance of " + getClass().
-          }
+          $ensureAlive();
           return (long) getCounterInt($memorySegment());
         }
         """,
@@ -191,9 +189,7 @@ final class VariableImportTests {
          * }
          */
         public void setCounterInt(long newValue) {
-          if (this.$state$destroyed.get()) {
-            throw new IllegalStateException("Attempted to call method on already destroyed instance of " + getClass().getSimpleName() + "!");
-          }
+          $ensureAlive();
           setCounterInt(newValue, $memorySegment());
         }
         """,


### PR DESCRIPTION
Part of #236 with minimal `Sources/JExtractSwift` changes. All the changes for it are going to be replaced with the remaining changes in #236 . This PR is mostly for reviewing `SwiftKit` changes.

Unify memory and instance management mechanism between value types (e.g. `string` or `enum`) and reference types (e.g. `class` and `actor`). Now all imported nominal types are allocated using the value witness table, are returned indirectly, and are destroyed in the same manner.

`SwiftInstance` is now the abstract base class for all the imported types including reference types. Concrete types can simply construct it by calling `super(memorySegment, arena)`.