### PR TITLE
[JExtract] Fix methods returning imported type

### DIFF
--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -62,6 +62,9 @@ public class HelloJava2Swift {
             obj.voidMethod();
             obj.takeIntMethod(42);
 
+            MySwiftClass otherObj = MySwiftClass.factory(12, 42, arena);
+            otherObj.voidMethod();
+
             MySwiftStruct swiftValue = new MySwiftStruct(2222, 1111, arena);
             SwiftKit.trace("swiftValue.capacity = " + swiftValue.getCapacity());
         }

--- a/Sources/JExtractSwift/Swift2JavaTranslator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+JavaBindingsPrinting.swift
@@ -259,11 +259,13 @@ extension Swift2JavaTranslator {
     } else if decl.translatedSignature.result.javaResultType == .void {
       printer.print("\(downCall);")
     } else {
-      let placeholder = if decl.translatedSignature.result.outParameters.isEmpty {
-        downCall
+      let placeholder: String
+      if decl.translatedSignature.result.outParameters.isEmpty {
+        placeholder = downCall
       } else {
         // FIXME: Support cdecl thunk returning a value while populating the out parameters.
-        "_result"
+        printer.print("\(downCall);")
+        placeholder = "_result"
       }
       let result = decl.translatedSignature.result.conversion.render(&printer, placeholder)
 


### PR DESCRIPTION
E.g.
  func createMyClass(arg: Int) -> MyClass

Silly mistake. The actual downcall was not printed.