### PR TITLE
[JExtract] Import initializers as static methods

### DIFF
--- a/Samples/SwiftAndJavaJarSampleLib/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
@@ -45,7 +45,7 @@ public class JavaToSwiftBenchmark {
             System.setProperty("jextract.trace.downcalls", "false");
 
             arena = SwiftArena.ofConfined();
-            obj = new MySwiftClass(1, 2, arena);
+            obj = MySwiftClass.init(1, 2, arena);
         }
 
         @TearDown(Level.Trial)

--- a/Samples/SwiftAndJavaJarSampleLib/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -44,7 +44,7 @@ public class HelloJava2Swift {
 
         // Example of using an arena; MyClass.deinit is run at end of scope
         try (var arena = SwiftArena.ofConfined()) {
-            MySwiftClass obj = new MySwiftClass(2222, 7777, arena);
+            MySwiftClass obj = MySwiftClass.init(2222, 7777, arena);
 
             // just checking retains/releases work
             SwiftKit.retain(obj);

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -43,7 +43,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_voidMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(12, 42, arena);
+            MySwiftClass o = MySwiftClass.init(12, 42, arena);
             o.voidMethod();
         } catch (Throwable throwable) {
             checkPaths(throwable);
@@ -53,7 +53,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_makeIntMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(12, 42, arena);
+            MySwiftClass o = MySwiftClass.init(12, 42, arena);
             var got = o.makeIntMethod();
             assertEquals(12, got);
         }
@@ -63,7 +63,7 @@ public class MySwiftClassTest {
     @Disabled // TODO: Need var mangled names in interfaces
     void test_MySwiftClass_property_len() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(12, 42, arena);
+            MySwiftClass o = MySwiftClass.init(12, 42, arena);
             var got = o.getLen();
             assertEquals(12, got);
         }

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
@@ -25,7 +25,7 @@ public class MySwiftClassTest {
     @Test
     void call_retain_retainCount_release() {
         var arena = SwiftArena.ofConfined();
-        var obj = new MySwiftClass(1, 2, arena);
+        var obj = MySwiftClass.init(1, 2, arena);
 
         assertEquals(1, SwiftKit.retainCount(obj));
         // TODO: test directly on SwiftHeapObject inheriting obj

--- a/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftAndJavaJarSampleLib/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -39,7 +39,7 @@ public class SwiftArenaTest {
     @DisabledIf("isAmd64")
     public void arena_releaseClassOnClose_class_ok() {
         try (var arena = SwiftArena.ofConfined()) {
-            var obj = new MySwiftClass(1, 2, arena);
+            var obj = MySwiftClass.init(1, 2, arena);
 
             retain(obj);
             assertEquals(2, retainCount(obj));

--- a/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
+++ b/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/JavaToSwiftBenchmark.java
@@ -37,7 +37,7 @@ public class JavaToSwiftBenchmark {
         @Setup(Level.Trial)
         public void beforeAll() {
             arena = SwiftArena.ofConfined();
-            obj = new MySwiftClass(1, 2, arena);
+            obj = MySwiftClass.init(1, 2, arena);
         }
 
         @TearDown(Level.Trial)

--- a/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/StringPassingBenchmark.java
+++ b/Samples/SwiftKitSampleApp/src/jmh/java/org/swift/swiftkit/StringPassingBenchmark.java
@@ -46,7 +46,7 @@ public class StringPassingBenchmark {
     @Setup(Level.Trial)
     public void beforeAll() {
         arena = SwiftArena.ofConfined();
-        obj = new MySwiftClass(1, 2, arena);
+        obj = MySwiftClass.init(1, 2, arena);
         string = makeString(stringLen);
     }
 

--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -47,7 +47,7 @@ public class HelloJava2Swift {
 
         // Example of using an arena; MyClass.deinit is run at end of scope
         try (var arena = SwiftArena.ofConfined()) {
-            MySwiftClass obj = new MySwiftClass(2222, 7777, arena);
+            MySwiftClass obj = MySwiftClass.init(2222, 7777, arena);
 
             // just checking retains/releases work
             SwiftKit.trace("retainCount = " + SwiftKit.retainCount(obj));
@@ -65,7 +65,7 @@ public class HelloJava2Swift {
             MySwiftClass otherObj = MySwiftClass.factory(12, 42, arena);
             otherObj.voidMethod();
 
-            MySwiftStruct swiftValue = new MySwiftStruct(2222, 1111, arena);
+            MySwiftStruct swiftValue = MySwiftStruct.init(2222, 1111, arena);
             SwiftKit.trace("swiftValue.capacity = " + swiftValue.getCapacity());
         }
 

--- a/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -42,7 +42,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_voidMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(12, 42, arena);
+            MySwiftClass o = MySwiftClass.init(12, 42, arena);
             o.voidMethod();
         } catch (Throwable throwable) {
             checkPaths(throwable);
@@ -52,7 +52,7 @@ public class MySwiftClassTest {
     @Test
     void test_MySwiftClass_makeIntMethod() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(12, 42, arena);
+            MySwiftClass o = MySwiftClass.init(12, 42, arena);
             var got = o.makeIntMethod();
             assertEquals(12, got);
         }
@@ -62,7 +62,7 @@ public class MySwiftClassTest {
     @Disabled // TODO: Need var mangled names in interfaces
     void test_MySwiftClass_property_len() {
         try(var arena = SwiftArena.ofConfined()) {
-            MySwiftClass o = new MySwiftClass(12, 42, arena);
+            MySwiftClass o = MySwiftClass.init(12, 42, arena);
             var got = o.getLen();
             assertEquals(12, got);
         }

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftClassTest.java
@@ -25,7 +25,7 @@ public class MySwiftClassTest {
     @Test
     void call_retain_retainCount_release() {
         var arena = SwiftArena.ofConfined();
-        var obj = new MySwiftClass(1, 2, arena);
+        var obj = MySwiftClass.init(1, 2, arena);
 
         assertEquals(1, SwiftKit.retainCount(obj));
         // TODO: test directly on SwiftHeapObject inheriting obj

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftStructTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/MySwiftStructTest.java
@@ -26,7 +26,7 @@ public class MySwiftStructTest {
         try (var arena = SwiftArena.ofConfined()) {
             long cap = 12;
             long len = 34;
-            var struct = new MySwiftStruct(cap, len, arena);
+            var struct = MySwiftStruct.init(cap, len, arena);
 
             assertEquals(cap, struct.getCapacity());
             assertEquals(len, struct.getLength());

--- a/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/org/swift/swiftkit/SwiftArenaTest.java
@@ -40,7 +40,7 @@ public class SwiftArenaTest {
     @DisabledIf("isAmd64")
     public void arena_releaseClassOnClose_class_ok() {
         try (var arena = SwiftArena.ofConfined()) {
-            var obj = new MySwiftClass(1, 2, arena);
+            var obj = MySwiftClass.init(1, 2, arena);
 
             retain(obj);
             assertEquals(2, retainCount(obj));
@@ -57,7 +57,7 @@ public class SwiftArenaTest {
         MySwiftClass unsafelyEscapedOutsideArenaScope = null;
 
         try (var arena = SwiftArena.ofConfined()) {
-            var obj = new MySwiftClass(1, 2, arena);
+            var obj = MySwiftClass.init(1, 2, arena);
             unsafelyEscapedOutsideArenaScope = obj;
         }
 
@@ -76,7 +76,7 @@ public class SwiftArenaTest {
         MySwiftStruct unsafelyEscapedOutsideArenaScope = null;
 
         try (var arena = SwiftArena.ofConfined()) {
-            var s = new MySwiftStruct(1, 2, arena);
+            var s = MySwiftStruct.init(1, 2, arena);
             unsafelyEscapedOutsideArenaScope = s;
         }
 

--- a/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+Printing.swift
@@ -125,7 +125,7 @@ extension Swift2JavaTranslator {
 
       // Initializers
       for initDecl in decl.initializers {
-        printInitializerDowncallConstructors(&printer, initDecl)
+        printFunctionDowncallMethods(&printer, initDecl)
       }
 
       // Properties

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftInstance.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftInstance.java
@@ -67,19 +67,6 @@ public abstract class SwiftInstance {
     }
 
     /**
-     * Convenience constructor subclasses can call like:
-     * {@snippet :
-     * super(() -> { ...; return segment; }, swiftArena$)
-     * }
-     *
-     * @param segmentSupplier Should return the memory segment of the value
-     * @param arena the arena where the supplied segment belongs to. When the arena goes out of scope, this value is destroyed.
-     */
-    protected SwiftInstance(Supplier<MemorySegment> segmentSupplier, SwiftArena arena) {
-        this(segmentSupplier.get(), arena);
-    }
-
-    /**
      * Ensures that this instance has not been destroyed.
      * <p/>
      * If this object has been destroyed, calling this method will cause an {@link IllegalStateException}

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -334,7 +334,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printInitializerDowncallConstructor(&printer, initDecl)
+      st.printFuncDowncallMethod(&printer, initDecl)
     }
 
     assertOutput(
@@ -342,26 +342,23 @@ final class MethodImportTests {
       expected:
         """
         /**
-         * Create an instance of {@code MySwiftClass}.
-         *
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
-        public MySwiftClass(long len, long cap, SwiftArena swiftArena$) {
-          super(() -> {
-            var mh$ = swiftjava___FakeModule_MySwiftClass_init_len_cap.HANDLE;
-            try {
-              MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
-              if (SwiftKit.TRACE_DOWNCALLS) {
-                  SwiftKit.traceDowncall(len, cap, _result);
-              }
-              mh$.invokeExact(len, cap, _result);
-              return _result;
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
+        public static MySwiftClass init(long len, long cap, SwiftArena swiftArena$) {
+          var mh$ = swiftjava___FakeModule_MySwiftClass_init_len_cap.HANDLE;
+          try {
+            MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
+            if (SwiftKit.TRACE_DOWNCALLS) {
+                SwiftKit.traceDowncall(len, cap, _result);
             }
-          }, swiftArena$);
+            mh$.invokeExact(len, cap, _result);
+            return new MySwiftClass(_result, swiftArena$);
+          } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+          }
         }
         """
     )
@@ -382,7 +379,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printInitializerDowncallConstructor(&printer, initDecl)
+      st.printFuncDowncallMethod(&printer, initDecl)
     }
 
     assertOutput(
@@ -390,26 +387,23 @@ final class MethodImportTests {
       expected:
         """
         /**
-         * Create an instance of {@code MySwiftStruct}.
-         *
+         * Downcall to Swift:
          * {@snippet lang=swift :
          * public init(len: Swift.Int, cap: Swift.Int)
          * }
          */
-        public MySwiftStruct(long len, long cap, SwiftArena swiftArena$) {
-          super(() -> {
-            var mh$ = swiftjava___FakeModule_MySwiftStruct_init_len_cap.HANDLE;
-            try {
-              MemorySegment _result = swiftArena$.allocate(MySwiftStruct.$LAYOUT);
-              if (SwiftKit.TRACE_DOWNCALLS) {
+        public static MySwiftStruct init(long len, long cap, SwiftArena swiftArena$) {
+          var mh$ = swiftjava___FakeModule_MySwiftStruct_init_len_cap.HANDLE;
+          try {
+            MemorySegment _result = swiftArena$.allocate(MySwiftStruct.$LAYOUT);
+            if (SwiftKit.TRACE_DOWNCALLS) {
                 SwiftKit.traceDowncall(len, cap, _result);
-              }
-              mh$.invokeExact(len, cap, _result);
-              return _result;
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
             }
-          }, swiftArena$);
+            mh$.invokeExact(len, cap, _result);
+            return new MySwiftStruct(_result, swiftArena$);
+          } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+          }
         }
         """
     )


### PR DESCRIPTION
Preparation for importing failable initializers. Since Java 'new' operator can't express 'nil' result from failable initializers importing initializer as 'init' static method is a reasonable choice.