### PR TITLE
[JExtract] Static 'call' method in binding descriptor classes

### DIFF
--- a/Sources/JExtractSwift/Swift2JavaTranslator+JavaTranslation.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+JavaTranslation.swift
@@ -270,7 +270,7 @@ struct JavaTranslation {
       return TranslatedResult(
         javaResultType: javaType,
         outParameters: [],
-        conversion: .cast(javaType)
+        conversion: .pass
       )
     }
 

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -45,7 +45,7 @@ final class FuncCallbackImportTests {
     let funcDecl = st.importedGlobalFuncs.first { $0.name == "callMe" }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -59,15 +59,8 @@ final class FuncCallbackImportTests {
          * }
          */
         public static void callMe(java.lang.Runnable callback) {
-          var mh$ = swiftjava___FakeModule_callMe_callback.HANDLE;
           try(var arena$ = Arena.ofConfined()) {
-            var callback$ = SwiftKit.toUpcallStub(callback, arena$);
-            if (SwiftKit.TRACE_DOWNCALLS) {
-                SwiftKit.traceDowncall(callback$);
-            }
-            mh$.invokeExact(callback$);
-          } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
+            swiftjava___FakeModule_callMe_callback.call(SwiftKit.toUpcallStub(callback, arena$))
           }
         }
         """

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -51,9 +51,29 @@ final class FunctionDescriptorTests {
         output,
         expected:
           """
-          public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /* i: */SwiftValueLayout.SWIFT_INT
-          );
+          /**
+           * {@snippet lang=c :
+           * void swiftjava_SwiftModule_globalTakeInt_i(ptrdiff_t i)
+           * }
+           */
+          private static class swiftjava_SwiftModule_globalTakeInt_i {
+            public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+              /* i: */SwiftValueLayout.SWIFT_INT
+            );
+            public static final MemorySegment ADDR =
+              SwiftModule.findOrThrow("swiftjava_SwiftModule_globalTakeInt_i");
+            public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+            public static void call(long i) {
+              try {
+                if (SwiftKit.TRACE_DOWNCALLS) {
+                  SwiftKit.traceDowncall(i);
+                }
+                HANDLE.invokeExact(i);
+              } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+              }
+            }
+          }
           """
       )
     }
@@ -66,10 +86,30 @@ final class FunctionDescriptorTests {
         output,
         expected:
           """
-          public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /* l: */SwiftValueLayout.SWIFT_INT64,
-            /* i32: */SwiftValueLayout.SWIFT_INT32
-          );
+          /**
+           * {@snippet lang=c :
+           * void swiftjava_SwiftModule_globalTakeLongInt_l_i32(int64_t l, int32_t i32)
+           * }
+           */
+          private static class swiftjava_SwiftModule_globalTakeLongInt_l_i32 {
+            public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+              /* l: */SwiftValueLayout.SWIFT_INT64,
+              /* i32: */SwiftValueLayout.SWIFT_INT32
+            );
+            public static final MemorySegment ADDR =
+              SwiftModule.findOrThrow("swiftjava_SwiftModule_globalTakeLongInt_l_i32");
+            public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+            public static void call(long l, int i32) {
+              try {
+                if (SwiftKit.TRACE_DOWNCALLS) {
+                  SwiftKit.traceDowncall(l, i32);
+                }
+                HANDLE.invokeExact(l, i32);
+              } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+              }
+            }
+          }
           """
       )
     }
@@ -82,10 +122,30 @@ final class FunctionDescriptorTests {
         output,
         expected:
           """
-          public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            /* -> */SwiftValueLayout.SWIFT_INT,
-            /* i: */SwiftValueLayout.SWIFT_INT
-          );
+          /**
+           * {@snippet lang=c :
+           * ptrdiff_t swiftjava_SwiftModule_echoInt_i(ptrdiff_t i)
+           * }
+           */
+          private static class swiftjava_SwiftModule_echoInt_i {
+            public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+              /* -> */SwiftValueLayout.SWIFT_INT,
+              /* i: */SwiftValueLayout.SWIFT_INT
+            );
+            public static final MemorySegment ADDR =
+              SwiftModule.findOrThrow("swiftjava_SwiftModule_echoInt_i");
+            public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+            public static long call(long i) {
+              try {
+                if (SwiftKit.TRACE_DOWNCALLS) {
+                  SwiftKit.traceDowncall(i);
+                }
+                return (long) HANDLE.invokeExact(i);
+              } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+              }
+            }
+          }
           """
       )
     }
@@ -98,10 +158,30 @@ final class FunctionDescriptorTests {
         output,
         expected:
           """
-          public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            /* -> */SwiftValueLayout.SWIFT_INT32,
-            /* self: */SwiftValueLayout.SWIFT_POINTER
-          );
+          /**
+           * {@snippet lang=c :
+           * int32_t swiftjava_SwiftModule_MySwiftClass_counter$get(const void *self)
+           * }
+           */
+          private static class swiftjava_SwiftModule_MySwiftClass_counter$get {
+            public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+              /* -> */SwiftValueLayout.SWIFT_INT32,
+              /* self: */SwiftValueLayout.SWIFT_POINTER
+            );
+            public static final MemorySegment ADDR =
+              SwiftModule.findOrThrow("swiftjava_SwiftModule_MySwiftClass_counter$get");
+            public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+            public static int call(java.lang.foreign.MemorySegment self) {
+              try {
+                if (SwiftKit.TRACE_DOWNCALLS) {
+                  SwiftKit.traceDowncall(self);
+                }
+                return (int) HANDLE.invokeExact(self);
+              } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+              }
+            }
+          }
           """
       )
     }
@@ -113,10 +193,30 @@ final class FunctionDescriptorTests {
         output,
         expected:
           """
-          public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /* newValue: */SwiftValueLayout.SWIFT_INT32,
-            /* self: */SwiftValueLayout.SWIFT_POINTER
-          );
+          /**
+           * {@snippet lang=c :
+           * void swiftjava_SwiftModule_MySwiftClass_counter$set(int32_t newValue, const void *self)
+           * }
+           */
+          private static class swiftjava_SwiftModule_MySwiftClass_counter$set {
+            public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+              /* newValue: */SwiftValueLayout.SWIFT_INT32,
+              /* self: */SwiftValueLayout.SWIFT_POINTER
+            );
+            public static final MemorySegment ADDR =
+              SwiftModule.findOrThrow("swiftjava_SwiftModule_MySwiftClass_counter$set");
+            public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+            public static void call(int newValue, java.lang.foreign.MemorySegment self) {
+              try {
+                if (SwiftKit.TRACE_DOWNCALLS) {
+                  SwiftKit.traceDowncall(newValue, self);
+                }
+                HANDLE.invokeExact(newValue, self);
+              } catch (Throwable ex$) {
+                throw new AssertionError("should not reach here", ex$);
+              }
+            }
+          }
           """
       )
     }
@@ -145,10 +245,8 @@ extension FunctionDescriptorTests {
       $0.name == methodIdentifier
     }!
 
-    let thunkName = st.thunkNameRegistry.functionThunkName(decl: funcDecl)
-    let cFunc = funcDecl.cFunctionDecl(cName: thunkName)
     let output = CodePrinter.toString { printer in
-      st.printFunctionDescriptorValue(&printer, cFunc)
+      st.printJavaBindingDescriptorClass(&printer, funcDecl)
     }
 
     try body(output)
@@ -180,10 +278,8 @@ extension FunctionDescriptorTests {
       fatalError("Cannot find descriptor of: \(identifier)")
     }
 
-    let thunkName = st.thunkNameRegistry.functionThunkName(decl: accessorDecl)
-    let cFunc = accessorDecl.cFunctionDecl(cName: thunkName)
     let getOutput = CodePrinter.toString { printer in
-      st.printFunctionDescriptorValue(&printer, cFunc)
+      st.printJavaBindingDescriptorClass(&printer, accessorDecl)
     }
 
     try body(getOutput)

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -68,7 +68,7 @@ final class MethodImportTests {
     let funcDecl = st.importedGlobalFuncs.first { $0.name == "helloWorld" }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -82,16 +82,7 @@ final class MethodImportTests {
          * }
          */
         public static void helloWorld() {
-            var mh$ = swiftjava___FakeModule_helloWorld.HANDLE;
-            try {
-                if (SwiftKit.TRACE_DOWNCALLS) {
-                    SwiftKit.traceDowncall();
-                }
-                
-                mh$.invokeExact();
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
-            }
+            swiftjava___FakeModule_helloWorld.call();
         }
         """
     )
@@ -112,7 +103,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -126,15 +117,7 @@ final class MethodImportTests {
          * }
          */
         public static void globalTakeInt(long i) {
-            var mh$ = swiftjava___FakeModule_globalTakeInt_i.HANDLE;
-            try {
-                if (SwiftKit.TRACE_DOWNCALLS) {
-                  SwiftKit.traceDowncall(i);
-                }
-                mh$.invokeExact(i);
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
-            }
+            swiftjava___FakeModule_globalTakeInt_i.call(i);
         }
         """
     )
@@ -155,7 +138,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -170,15 +153,8 @@ final class MethodImportTests {
          * }
          */
         public static void globalTakeIntLongString(int i32, long l, java.lang.String s) {
-            var mh$ = swiftjava___FakeModule_globalTakeIntLongString_i32_l_s.HANDLE;
             try(var arena$ = Arena.ofConfined()) {
-                var s$ = SwiftKit.toCString(s, arena$);
-                if (SwiftKit.TRACE_DOWNCALLS) {
-                    SwiftKit.traceDowncall(i32, l, s$);
-                }
-                mh$.invokeExact(i32, l, s$);
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
+                swiftjava___FakeModule_globalTakeIntLongString_i32_l_s.call(i32, l, SwiftKit.toCString(s, arena$));
             }
         }
         """
@@ -200,7 +176,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -215,17 +191,9 @@ final class MethodImportTests {
          * }
          */
         public static MySwiftClass globalReturnClass(SwiftArena swiftArena$) {
-          var mh$ = swiftjava___FakeModule_globalReturnClass.HANDLE;
-          try {
-            MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
-            if (SwiftKit.TRACE_DOWNCALLS) {
-                SwiftKit.traceDowncall(_result);
-            }
-            mh$.invokeExact(_result);
-            return new MySwiftClass(_result, swiftArena$);
-          } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
-          }
+          MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
+          swiftjava___FakeModule_globalReturnClass.call(_result);
+          return new MySwiftClass(_result, swiftArena$);
         }
         """
     )
@@ -246,7 +214,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -261,15 +229,7 @@ final class MethodImportTests {
          */
         public void helloMemberFunction() {
             $ensureAlive()
-            var mh$ = swiftjava___FakeModule_MySwiftClass_helloMemberFunction.HANDLE;
-            try {
-                if (SwiftKit.TRACE_DOWNCALLS) {
-                    SwiftKit.traceDowncall(this.$memorySegment());
-                }
-                mh$.invokeExact(this.$memorySegment());
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
-            }
+            swiftjava___FakeModule_MySwiftClass_helloMemberFunction.call(this.$memorySegment());
         }
         """
     )
@@ -290,7 +250,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, funcDecl)
+      st.printJavaBindingWrapperMethod(&printer, funcDecl)
     }
 
     assertOutput(
@@ -304,16 +264,8 @@ final class MethodImportTests {
          * }
          */
         public long makeInt() {
-            $ensureAlive()
-            var mh$ = swiftjava___FakeModule_MySwiftClass_makeInt.HANDLE;
-            try {
-                if (SwiftKit.TRACE_DOWNCALLS) {
-                    SwiftKit.traceDowncall(this.$memorySegment());
-                }
-                return (long) mh$.invokeExact(this.$memorySegment());
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
-            }
+            $ensureAlive();
+            return swiftjava___FakeModule_MySwiftClass_makeInt.call(this.$memorySegment());
         }
         """
     )
@@ -334,7 +286,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, initDecl)
+      st.printJavaBindingWrapperMethod(&printer, initDecl)
     }
 
     assertOutput(
@@ -348,17 +300,9 @@ final class MethodImportTests {
          * }
          */
         public static MySwiftClass init(long len, long cap, SwiftArena swiftArena$) {
-          var mh$ = swiftjava___FakeModule_MySwiftClass_init_len_cap.HANDLE;
-          try {
             MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
-            if (SwiftKit.TRACE_DOWNCALLS) {
-                SwiftKit.traceDowncall(len, cap, _result);
-            }
-            mh$.invokeExact(len, cap, _result);
+            swiftjava___FakeModule_MySwiftClass_init_len_cap.call(len, cap, _result)
             return new MySwiftClass(_result, swiftArena$);
-          } catch (Throwable ex$) {
-              throw new AssertionError("should not reach here", ex$);
-          }
         }
         """
     )
@@ -379,7 +323,7 @@ final class MethodImportTests {
     }!
 
     let output = CodePrinter.toString { printer in
-      st.printFuncDowncallMethod(&printer, initDecl)
+      st.printJavaBindingWrapperMethod(&printer, initDecl)
     }
 
     assertOutput(
@@ -393,17 +337,9 @@ final class MethodImportTests {
          * }
          */
         public static MySwiftStruct init(long len, long cap, SwiftArena swiftArena$) {
-          var mh$ = swiftjava___FakeModule_MySwiftStruct_init_len_cap.HANDLE;
-          try {
             MemorySegment _result = swiftArena$.allocate(MySwiftStruct.$LAYOUT);
-            if (SwiftKit.TRACE_DOWNCALLS) {
-                SwiftKit.traceDowncall(len, cap, _result);
-            }
-            mh$.invokeExact(len, cap, _result);
+            swiftjava___FakeModule_MySwiftStruct_init_len_cap.call(len, cap, _result)
             return new MySwiftStruct(_result, swiftArena$);
-          } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
-          }
         }
         """
     )

--- a/Tests/JExtractSwiftTests/StringPassingTests.swift
+++ b/Tests/JExtractSwiftTests/StringPassingTests.swift
@@ -33,8 +33,33 @@ final class StringPassingTests {
 
     try assertOutput(
       st, input: class_interfaceFile, .java,
-      detectChunkByInitialLines: 1,
       expectedChunks: [
+        """
+        /**
+         * {@snippet lang=c :
+         * ptrdiff_t swiftjava___FakeModule_writeString_string(const int8_t *string)
+         * }
+         */
+        private static class swiftjava___FakeModule_writeString_string {
+          public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            /* -> */SwiftValueLayout.SWIFT_INT,
+            /* string: */SwiftValueLayout.SWIFT_POINTER
+          );
+          public static final MemorySegment ADDR =
+            __FakeModule.findOrThrow("swiftjava___FakeModule_writeString_string");
+          public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+          public static long call(java.lang.foreign.MemorySegment string) {
+            try {
+              if (SwiftKit.TRACE_DOWNCALLS) {
+                SwiftKit.traceDowncall(string);
+              }
+              return (long) HANDLE.invokeExact(string);
+            } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+            }
+          }
+        }
+        """,
         """
         /**
          * Downcall to Swift:
@@ -43,15 +68,8 @@ final class StringPassingTests {
          * }
          */
         public static long writeString(java.lang.String string) {
-            var mh$ = swiftjava___FakeModule_writeString_string.HANDLE;
             try(var arena$ = Arena.ofConfined()) {
-                var string$ = SwiftKit.toCString(string, arena$);
-                if (SwiftKit.TRACE_DOWNCALLS) {
-                    SwiftKit.traceDowncall(string$);
-                }
-                return (long) mh$.invokeExact(string$);
-            } catch (Throwable ex$) {
-                throw new AssertionError("should not reach here", ex$);
+                return swiftjava___FakeModule_writeString_string.call(SwiftKit.toCString(string, arena$));
             }
         }
         """

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -54,6 +54,16 @@ final class VariableImportTests {
           public static final MemorySegment ADDR =
             FakeModule.findOrThrow("swiftjava_FakeModule_MySwiftClass_counterInt$get");
           public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+          public static long call(java.lang.foreign.MemorySegment self) {
+            try {
+              if (SwiftKit.TRACE_DOWNCALLS) {
+                SwiftKit.traceDowncall(self);
+              }
+              return (long) HANDLE.invokeExact(self);
+            } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+            }
+          }
         }
         """,
         """
@@ -65,15 +75,7 @@ final class VariableImportTests {
          */
         public long getCounterInt() {
           $ensureAlive();
-          var mh$ = swiftjava_FakeModule_MySwiftClass_counterInt$get.HANDLE;
-          try {
-            if (SwiftKit.TRACE_DOWNCALLS) {
-                SwiftKit.traceDowncall(this.$memorySegment());
-            }
-            return (long) mh$.invokeExact(this.$memorySegment());
-          } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
-          }
+          return swiftjava_FakeModule_MySwiftClass_counterInt$get.call(this.$memorySegment());
         }
         """,
         """
@@ -85,6 +87,16 @@ final class VariableImportTests {
           public static final MemorySegment ADDR =
             FakeModule.findOrThrow("swiftjava_FakeModule_MySwiftClass_counterInt$set");
           public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+          public static void call(long newValue, java.lang.foreign.MemorySegment self) {
+            try {
+              if (SwiftKit.TRACE_DOWNCALLS) {
+                SwiftKit.traceDowncall(newValue, self);
+              }
+              HANDLE.invokeExact(newValue, self);
+            } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+            }
+          }
         }
         """,
         """
@@ -96,15 +108,7 @@ final class VariableImportTests {
          */
         public void setCounterInt(long newValue) {
           $ensureAlive();
-          var mh$ = swiftjava_FakeModule_MySwiftClass_counterInt$set.HANDLE;
-          try {
-            if (SwiftKit.TRACE_DOWNCALLS) {
-                SwiftKit.traceDowncall(newValue, this.$memorySegment());
-            }
-            mh$.invokeExact(newValue, this.$memorySegment());
-          } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
-          }
+          swiftjava_FakeModule_MySwiftClass_counterInt$set.call(newValue, this.$memorySegment())
         }
         """,
       ]


### PR DESCRIPTION
* Add a static `call` method to each binding descriptor class to handle the actual downcall.
* Refactor wrapper methods to delegate to the binding descriptor's `call` method.
* Clearly separate responsibilities: each binding descriptor class now encapsulates the complete lowered Cdecl thunk, while wrapper methods focus on Java-to-Cdecl type conversion.