### PR TITLE
[JExtract] Santize trivia for declartion signature string

### DIFF
--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -50,7 +50,6 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
   var translatedSignature: TranslatedFunctionSignature
 
   public var signatureString: String {
-    // FIXME: Remove comments and normalize trivia.
     self.swiftDecl.signatureString
   }
 

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -28,11 +28,16 @@ final class MethodImportTests {
     import _StringProcessing
     import _SwiftConcurrencyShims
 
-    public func helloWorld()
+    /// Hello World!
+    public func /*comment*/helloWorld()
 
     public func globalTakeInt(i: Int)
 
-    public func globalTakeIntLongString(i32: Int32, l: Int64, s: String)
+    public func globalTakeIntLongString(
+      i32: Int32,
+      l: Int64,
+      s: String
+    )
     
     public func globalReturnClass() -> MySwiftClass
 


### PR DESCRIPTION
Introduce `triviaSanitizedDescription` that prints tokens with trivia condensed into a single whitespace, or removed after opening or before closing parentheses.