### PR TITLE
[JExtract] Move 'apiKind' property to 'ImportedFunc'

### DIFF
--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -17,7 +17,12 @@ import SwiftSyntax
 /// Any imported (Swift) declaration
 protocol ImportedDecl: AnyObject {}
 
-public typealias JavaPackage = String
+package enum SwiftAPIKind {
+  case function
+  case initializer
+  case getter
+  case setter
+}
 
 /// Describes a Swift nominal type (e.g., a class, struct, enum) that has been
 /// imported and is being translated into Java.
@@ -49,6 +54,8 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
 
   var translatedSignature: TranslatedFunctionSignature
 
+  package var apiKind: SwiftAPIKind
+
   public var signatureString: String {
     // FIXME: Remove comments and normalize trivia.
     self.swiftDecl.signatureString
@@ -65,10 +72,6 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
   package func cFunctionDecl(cName: String) -> CFunction {
     // 'try!' because we know 'loweredSignature' can be described with C.
     try! loweredSignature.cFunctionDecl(cName: cName)
-  }
-
-  package var kind: SwiftAPIKind {
-    loweredSignature.apiKind
   }
 
   var parentType: SwiftType? {
@@ -94,7 +97,7 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
   /// A display name to use to refer to the Swift declaration with its
   /// enclosing type, if there is one.
   public var displayName: String {
-    let prefix = switch self.kind {
+    let prefix = switch self.apiKind {
     case .getter: "getter:"
     case .setter: "setter:"
     case .function, .initializer: ""
@@ -113,18 +116,20 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
     module: String,
     swiftDecl: any DeclSyntaxProtocol,
     name: String,
+    apiKind: SwiftAPIKind,
     translatedSignature: TranslatedFunctionSignature
   ) {
     self.module = module
     self.name = name
     self.swiftDecl = swiftDecl
+    self.apiKind = apiKind
     self.translatedSignature = translatedSignature
   }
 
   public var description: String {
     """
     ImportedFunc {
-      kind: \(kind)
+      apiKind: \(apiKind)
       module: \(module)
       name: \(name)
       signature: \(self.swiftDecl.signatureString)

--- a/Sources/JExtractSwift/Swift2JavaTranslator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+JavaBindingsPrinting.swift
@@ -122,7 +122,7 @@ extension Swift2JavaTranslator {
   public func printJavaBindingWrapperMethod(
     _ printer: inout CodePrinter,
     _ decl: ImportedFunc) {
-    let methodName: String = switch decl.kind {
+    let methodName: String = switch decl.apiKind {
     case .getter: "get\(decl.name.toCamelCase)"
     case .setter: "set\(decl.name.toCamelCase)"
     case .function, .initializer: decl.name

--- a/Sources/JExtractSwift/Swift2JavaTranslator+JavaTranslation.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+JavaTranslation.swift
@@ -16,11 +16,10 @@ import JavaTypes
 
 extension Swift2JavaTranslator {
   func translate(
-    swiftSignature: SwiftFunctionSignature,
-    as apiKind: SwiftAPIKind
+    swiftSignature: SwiftFunctionSignature
   ) throws -> TranslatedFunctionSignature {
     let lowering = CdeclLowering(swiftStdlibTypes: self.swiftStdlibTypes)
-    let loweredSignature = try lowering.lowerFunctionSignature(swiftSignature, apiKind: apiKind)
+    let loweredSignature = try lowering.lowerFunctionSignature(swiftSignature)
 
     let translation = JavaTranslation(swiftStdlibTypes: self.swiftStdlibTypes)
     let translated = try translation.translate(loweredFunctionSignature: loweredSignature)

--- a/Sources/JExtractSwift/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwift/Swift2JavaVisitor.swift
@@ -128,7 +128,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
         enclosingType: self.currentSwiftType,
         symbolTable: self.translator.symbolTable
       )
-      translatedSignature = try translator.translate(swiftSignature: swiftSignature, as: .function)
+      translatedSignature = try translator.translate(swiftSignature: swiftSignature)
     } catch {
       self.log.debug("Failed to translate: '\(node.qualifiedNameForDebug)'; \(error)")
       return .skipChildren
@@ -138,6 +138,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
       module: translator.swiftModuleName,
       swiftDecl: node,
       name: node.name.text,
+      apiKind: .function,
       translatedSignature: translatedSignature
     )
 
@@ -173,7 +174,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
           enclosingType: self.currentSwiftType,
           symbolTable: self.translator.symbolTable
         )
-        translatedSignature = try translator.translate(swiftSignature: swiftSignature, as: kind)
+        translatedSignature = try translator.translate(swiftSignature: swiftSignature)
       } catch {
         self.log.debug("Failed to translate: \(node.qualifiedNameForDebug); \(error)")
         throw error
@@ -183,6 +184,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
         module: translator.swiftModuleName,
         swiftDecl: node,
         name: varName,
+        apiKind: kind,
         translatedSignature: translatedSignature
       )
       
@@ -227,7 +229,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
         enclosingType: self.currentSwiftType,
         symbolTable: self.translator.symbolTable
       )
-      translatedSignature = try translator.translate(swiftSignature: swiftSignature, as: .initializer)
+      translatedSignature = try translator.translate(swiftSignature: swiftSignature)
     } catch {
       self.log.debug("Failed to translate: \(node.qualifiedNameForDebug); \(error)")
       return .skipChildren
@@ -236,6 +238,7 @@ final class Swift2JavaVisitor: SyntaxVisitor {
       module: translator.swiftModuleName,
       swiftDecl: node,
       name: "init",
+      apiKind: .initializer,
       translatedSignature: translatedSignature
     )
 

--- a/Sources/JExtractSwift/SwiftThunkTranslator.swift
+++ b/Sources/JExtractSwift/SwiftThunkTranslator.swift
@@ -178,6 +178,7 @@ struct SwiftThunkTranslator {
     let thunkFunc = decl.loweredSignature.cdeclThunk(
       cName: thunkName,
       swiftAPIName: decl.name,
+      as: decl.apiKind,
       stdlibTypes: st.swiftStdlibTypes
     )
     return [DeclSyntax(thunkFunc)]

--- a/Sources/JExtractSwift/ThunkNameRegistry.swift
+++ b/Sources/JExtractSwift/ThunkNameRegistry.swift
@@ -31,7 +31,7 @@ package struct ThunkNameRegistry {
     }
 
     let suffix: String
-    switch decl.kind {
+    switch decl.apiKind {
     case .getter:
       suffix = "$get"
     case .setter:

--- a/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
@@ -43,6 +43,7 @@ func assertLoweredFunction(
   translator.prepareForTranslation()
 
   let swiftFunctionName: String
+  let apiKind: SwiftAPIKind
   let loweredFunction: LoweredFunctionSignature
   if let inputFunction = inputDecl.as(FunctionDeclSyntax.self) {
     loweredFunction = try translator.lowerFunctionSignature(
@@ -50,12 +51,14 @@ func assertLoweredFunction(
       enclosingType: enclosingType
     )
     swiftFunctionName = inputFunction.name.text
+    apiKind = .function
   } else if let inputInitializer = inputDecl.as(InitializerDeclSyntax.self) {
     loweredFunction = try translator.lowerFunctionSignature(
       inputInitializer,
       enclosingType: enclosingType
     )
     swiftFunctionName = "init"
+    apiKind = .initializer
   } else {
     fatalError("Unhandling declaration kind for lowering")
   }
@@ -63,6 +66,7 @@ func assertLoweredFunction(
   let loweredCDecl = loweredFunction.cdeclThunk(
     cName: "c_\(swiftFunctionName)",
     swiftAPIName: swiftFunctionName,
+    as: apiKind,
     stdlibTypes: translator.swiftStdlibTypes
   )
 
@@ -124,6 +128,7 @@ func assertLoweredVariableAccessor(
   let loweredCDecl = loweredFunction?.cdeclThunk(
     cName: "c_\(swiftVariableName)",
     swiftAPIName: swiftVariableName,
+    as: isSet ? .setter : .getter,
     stdlibTypes: translator.swiftStdlibTypes
   )
 

--- a/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionDescriptorImportTests.swift
@@ -271,7 +271,7 @@ extension FunctionDescriptorTests {
     let accessorDecl: ImportedFunc? =
       st.importedTypes.values.compactMap {
         $0.variables.first {
-          $0.name == identifier && $0.kind == accessorKind
+          $0.name == identifier && $0.apiKind == accessorKind
         }
       }.first
     guard let accessorDecl else {


### PR DESCRIPTION
It was weird "the lowered signature" being the owner of the API kind information, and it was only used for rendering.
Move it to `ImportedFunc` and pass it to `LoweredFunctionSignature.cdeclThunk()` API.