### PR TITLE
[JExtract] Lazy Cdecl lowering and Java translation 

### DIFF
--- a/Sources/JExtractSwift/ImportedDecls.swift
+++ b/Sources/JExtractSwift/ImportedDecls.swift
@@ -52,30 +52,18 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
 
   public var swiftDecl: any DeclSyntaxProtocol
 
-  var translatedSignature: TranslatedFunctionSignature
-
   package var apiKind: SwiftAPIKind
+
+  var functionSignature: SwiftFunctionSignature
 
   public var signatureString: String {
     // FIXME: Remove comments and normalize trivia.
     self.swiftDecl.signatureString
   }
 
-  var loweredSignature: LoweredFunctionSignature {
-    translatedSignature.loweredSignature
-  }
-
-  var swiftSignature: SwiftFunctionSignature {
-    loweredSignature.original
-  }
-
-  package func cFunctionDecl(cName: String) -> CFunction {
-    // 'try!' because we know 'loweredSignature' can be described with C.
-    try! loweredSignature.cFunctionDecl(cName: cName)
-  }
 
   var parentType: SwiftType? {
-    guard let selfParameter = swiftSignature.selfParameter else {
+    guard let selfParameter = functionSignature.selfParameter else {
       return nil
     }
     switch selfParameter {
@@ -92,7 +80,7 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
   /// this will contain that declaration's imported name.
   ///
   /// This is necessary when rendering accessor Java code we need the type that "self" is expecting to have.
-  public var hasParent: Bool { translatedSignature.selfParameter != nil }
+  public var hasParent: Bool { functionSignature.selfParameter != nil }
 
   /// A display name to use to refer to the Swift declaration with its
   /// enclosing type, if there is one.
@@ -117,13 +105,13 @@ public final class ImportedFunc: ImportedDecl, CustomStringConvertible {
     swiftDecl: any DeclSyntaxProtocol,
     name: String,
     apiKind: SwiftAPIKind,
-    translatedSignature: TranslatedFunctionSignature
+    functionSignature: SwiftFunctionSignature
   ) {
     self.module = module
     self.name = name
     self.swiftDecl = swiftDecl
     self.apiKind = apiKind
-    self.translatedSignature = translatedSignature
+    self.functionSignature = functionSignature
   }
 
   public var description: String {

--- a/Sources/JExtractSwift/Swift2JavaTranslator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator+SwiftThunkPrinting.swift
@@ -174,8 +174,13 @@ struct SwiftThunkTranslator {
 
   func render(forFunc decl: ImportedFunc) -> [DeclSyntax] {
     st.log.trace("Rendering thunks for: \(decl.displayName)")
+
     let thunkName = st.thunkNameRegistry.functionThunkName(decl: decl)
-    let thunkFunc = decl.loweredSignature.cdeclThunk(
+    guard let translatedSignatures = st.translatedSignature(for: decl) else {
+      return []
+    }
+
+    let thunkFunc = translatedSignatures.loweredSignature.cdeclThunk(
       cName: thunkName,
       swiftAPIName: decl.name,
       as: decl.apiKind,

--- a/Sources/JExtractSwift/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwift/Swift2JavaTranslator.swift
@@ -56,6 +56,9 @@ public final class Swift2JavaTranslator {
 
   package var thunkNameRegistry: ThunkNameRegistry = ThunkNameRegistry()
 
+  /// Cached Java translation result. 'nil' indicates failed translation.
+  var translatedSignatures: [ImportedFunc: TranslatedFunctionSignature?] = [:]
+
   /// The name of the Swift module being translated.
   var swiftModuleName: String {
     symbolTable.moduleName

--- a/Sources/JExtractSwift/ThunkNameRegistry.swift
+++ b/Sources/JExtractSwift/ThunkNameRegistry.swift
@@ -37,7 +37,7 @@ package struct ThunkNameRegistry {
     case .setter:
       suffix = "$set"
     default:
-      suffix = decl.swiftSignature.parameters
+      suffix = decl.functionSignature.parameters
         .map { "_" + ($0.argumentLabel ?? "_") }
         .joined()
     }


### PR DESCRIPTION
(Based on #251)

Make `Swift2JavaTranslator.analyze()` analyze only Swift signatures.
Postpone Cdecl lowering and Java translation for cleaner separation of responsibilities.