### PR TITLE
Don't link `jvm` on Android

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -207,7 +207,10 @@ let package = Package(
             "-L\(javaHome)/lib"
           ],
           .when(platforms: [.windows])),
-        .linkedLibrary("jvm"),
+        .linkedLibrary(
+          "jvm",
+          .when(platforms: [.linux, .macOS, .windows])
+        ),
       ]
     ),
     .target(


### PR DESCRIPTION
Android doesn't have an equivalent `jvm` so this library should not be linked for that platform. 