### PR TITLE
[JExtract] Introduce SwiftKnownTypes

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
+++ b/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
@@ -99,7 +99,7 @@ enum CDeclToCLoweringError: Error {
   case invalidFunctionConvention(SwiftFunctionType)
 }
 
-extension KnownStandardLibraryType {
+extension SwiftStandardLibraryTypeKind {
   /// Determine the primitive C type that corresponds to this C standard
   /// library type, if there is one.
   var primitiveCType: CType? {

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
@@ -144,7 +144,7 @@ extension TranslatedFunctionSignature {
 }
 
 struct JavaTranslation {
-  var swiftStdlibTypes: SwiftStandardLibraryTypes
+  var swiftStdlibTypes: SwiftStandardLibraryTypeDecls
 
   func translate(
     _ decl: ImportedFunc

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -23,7 +23,7 @@ package class FFMSwift2JavaGenerator: Swift2JavaGenerator {
   let javaPackage: String
   let swiftOutputDirectory: String
   let javaOutputDirectory: String
-  let swiftStdlibTypes: SwiftStandardLibraryTypes
+  let swiftStdlibTypes: SwiftStandardLibraryTypeDecls
   let symbolTable: SwiftSymbolTable
 
   var javaPackagePath: String {
@@ -49,7 +49,7 @@ package class FFMSwift2JavaGenerator: Swift2JavaGenerator {
     self.swiftOutputDirectory = swiftOutputDirectory
     self.javaOutputDirectory = javaOutputDirectory
     self.symbolTable = translator.symbolTable
-    self.swiftStdlibTypes = translator.swiftStdlibTypes
+    self.swiftStdlibTypes = translator.swiftStdlibTypeDecls
   }
 
   func generate() throws {

--- a/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
@@ -43,7 +43,7 @@ public final class Swift2JavaTranslator {
   /// type representation.
   package var importedTypes: [String: ImportedNominalType] = [:]
 
-  package var swiftStdlibTypes: SwiftStandardLibraryTypes
+  package var swiftStdlibTypeDecls: SwiftStandardLibraryTypeDecls
 
   package let symbolTable: SwiftSymbolTable
 
@@ -59,7 +59,7 @@ public final class Swift2JavaTranslator {
 
     // Create a mock of the Swift standard library.
     var parsedSwiftModule = SwiftParsedModuleSymbolTable(moduleName: "Swift")
-    self.swiftStdlibTypes = SwiftStandardLibraryTypes(into: &parsedSwiftModule)
+    self.swiftStdlibTypeDecls = SwiftStandardLibraryTypeDecls(into: &parsedSwiftModule)
     self.symbolTable.importedModules.append(parsedSwiftModule.symbolTable)
   }
 }

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownTypes.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownTypes.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+struct SwiftKnownTypes {
+  private let decls: SwiftStandardLibraryTypeDecls
+
+  init(decls: SwiftStandardLibraryTypeDecls) {
+    self.decls = decls
+  }
+
+  var bool: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.bool])) }
+  var int: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.int])) }
+  var uint: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.uint])) }
+  var int8: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.int8])) }
+  var uint8: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.uint8])) }
+  var int16: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.int16])) }
+  var uint16: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.uint16])) }
+  var int32: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.int32])) }
+  var uint32: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.uint32])) }
+  var int64: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.int64])) }
+  var uint64: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.uint64])) }
+  var float: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.float])) }
+  var double: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.double])) }
+  var unsafeRawPointer: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.unsafeRawPointer])) }
+  var unsafeMutableRawPointer: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: decls[.unsafeMutableRawPointer])) }
+  
+  func unsafePointer(_ pointeeType: SwiftType) -> SwiftType {
+    .nominal(
+      SwiftNominalType(
+        nominalTypeDecl: decls.unsafePointerDecl,
+        genericArguments: [pointeeType]
+      )
+    )
+  }
+
+  func unsafeMutablePointer(_ pointeeType: SwiftType) -> SwiftType {
+    .nominal(
+      SwiftNominalType(
+        nominalTypeDecl: decls.unsafeMutablePointerDecl,
+        genericArguments: [pointeeType]
+      )
+    )
+  }
+
+  func unsafeBufferPointer(_ elementType: SwiftType) -> SwiftType {
+    .nominal(
+      SwiftNominalType(
+        nominalTypeDecl: decls.unsafeBufferPointerDecl,
+        genericArguments: [elementType]
+      )
+    )
+  }
+
+  func unsafeMutableBufferPointer(_ elementType: SwiftType) -> SwiftType {
+    .nominal(
+      SwiftNominalType(
+        nominalTypeDecl: decls.unsafeMutableBufferPointerDecl,
+        genericArguments: [elementType]
+      )
+    )
+  }
+}

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftNominalTypeDeclaration.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftNominalTypeDeclaration.swift
@@ -52,7 +52,7 @@ package class SwiftNominalTypeDeclaration {
 
   /// Identify this nominal declaration as one of the known standard library
   /// types, like 'Swift.Int[.
-  lazy var knownStandardLibraryType: KnownStandardLibraryType? = {
+  lazy var knownStandardLibraryType: SwiftStandardLibraryTypeKind? = {
     self.computeKnownStandardLibraryType()
   }()
 
@@ -80,12 +80,12 @@ package class SwiftNominalTypeDeclaration {
 
   /// Determine the known standard library type for this nominal type
   /// declaration.
-  private func computeKnownStandardLibraryType() -> KnownStandardLibraryType? {
+  private func computeKnownStandardLibraryType() -> SwiftStandardLibraryTypeKind? {
     if parent != nil || moduleName != "Swift" {
       return nil
     }
 
-    return KnownStandardLibraryType(typeNameInSwiftModule: name)
+    return SwiftStandardLibraryTypeKind(typeNameInSwiftModule: name)
   }
 
   package var qualifiedName: String {

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftStandardLibraryTypeDecls.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftStandardLibraryTypeDecls.swift
@@ -14,7 +14,7 @@
 
 import SwiftSyntax
 
-enum KnownStandardLibraryType: String, Hashable, CaseIterable {
+enum SwiftStandardLibraryTypeKind: String, Hashable, CaseIterable {
   case bool = "Bool"
   case int = "Int"
   case uint = "UInt"
@@ -60,7 +60,7 @@ enum KnownStandardLibraryType: String, Hashable, CaseIterable {
 
 /// Captures many types from the Swift standard library in their most basic
 /// forms, so that the translator can reason about them in source code.
-public struct SwiftStandardLibraryTypes {
+public struct SwiftStandardLibraryTypeDecls {
   // Swift.UnsafePointer<Element>
   let unsafePointerDecl: SwiftNominalTypeDeclaration
 
@@ -74,16 +74,16 @@ public struct SwiftStandardLibraryTypes {
   let unsafeMutableBufferPointerDecl: SwiftNominalTypeDeclaration
 
   /// Mapping from known standard library types to their nominal type declaration.
-  let knownTypeToNominal: [KnownStandardLibraryType: SwiftNominalTypeDeclaration]
+  let knownTypeToNominal: [SwiftStandardLibraryTypeKind: SwiftNominalTypeDeclaration]
 
   /// Mapping from nominal type declarations to known types.
-  let nominalTypeDeclToKnownType: [SwiftNominalTypeDeclaration: KnownStandardLibraryType]
+  let nominalTypeDeclToKnownType: [SwiftNominalTypeDeclaration: SwiftStandardLibraryTypeKind]
 
   private static func recordKnownType(
-    _ type: KnownStandardLibraryType,
+    _ type: SwiftStandardLibraryTypeKind,
     _ syntax: NominalTypeDeclSyntaxNode,
-    knownTypeToNominal: inout [KnownStandardLibraryType: SwiftNominalTypeDeclaration],
-    nominalTypeDeclToKnownType: inout [SwiftNominalTypeDeclaration: KnownStandardLibraryType],
+    knownTypeToNominal: inout [SwiftStandardLibraryTypeKind: SwiftNominalTypeDeclaration],
+    nominalTypeDeclToKnownType: inout [SwiftNominalTypeDeclaration: SwiftStandardLibraryTypeKind],
     parsedModule: inout SwiftParsedModuleSymbolTable
   ) {
     let nominalDecl = parsedModule.addNominalTypeDeclaration(syntax, parent: nil)
@@ -92,9 +92,9 @@ public struct SwiftStandardLibraryTypes {
   }
 
   private static func recordKnownNonGenericStruct(
-    _ type: KnownStandardLibraryType,
-    knownTypeToNominal: inout [KnownStandardLibraryType: SwiftNominalTypeDeclaration],
-    nominalTypeDeclToKnownType: inout [SwiftNominalTypeDeclaration: KnownStandardLibraryType],
+    _ type: SwiftStandardLibraryTypeKind,
+    knownTypeToNominal: inout [SwiftStandardLibraryTypeKind: SwiftNominalTypeDeclaration],
+    nominalTypeDeclToKnownType: inout [SwiftNominalTypeDeclaration: SwiftStandardLibraryTypeKind],
     parsedModule: inout SwiftParsedModuleSymbolTable
   ) {
     recordKnownType(
@@ -155,11 +155,11 @@ public struct SwiftStandardLibraryTypes {
       parent: nil
     )
 
-    var knownTypeToNominal: [KnownStandardLibraryType: SwiftNominalTypeDeclaration] = [:]
-    var nominalTypeDeclToKnownType: [SwiftNominalTypeDeclaration: KnownStandardLibraryType] = [:]
+    var knownTypeToNominal: [SwiftStandardLibraryTypeKind: SwiftNominalTypeDeclaration] = [:]
+    var nominalTypeDeclToKnownType: [SwiftNominalTypeDeclaration: SwiftStandardLibraryTypeKind] = [:]
 
     // Handle all of the non-generic types at once.
-    for knownType in KnownStandardLibraryType.allCases {
+    for knownType in SwiftStandardLibraryTypeKind.allCases {
       guard !knownType.isGeneric else {
         continue
       }
@@ -176,11 +176,11 @@ public struct SwiftStandardLibraryTypes {
     self.nominalTypeDeclToKnownType = nominalTypeDeclToKnownType
   }
 
-  subscript(knownType: KnownStandardLibraryType) -> SwiftNominalTypeDeclaration {
+  subscript(knownType: SwiftStandardLibraryTypeKind) -> SwiftNominalTypeDeclaration {
     knownTypeToNominal[knownType]!
   }
 
-  subscript(nominalType: SwiftNominalTypeDeclaration) -> KnownStandardLibraryType? {
+  subscript(nominalType: SwiftNominalTypeDeclaration) -> SwiftStandardLibraryTypeKind? {
     nominalTypeDeclToKnownType[nominalType]
   }
 }

--- a/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
@@ -73,7 +73,7 @@ func assertLoweredFunction(
     cName: "c_\(swiftFunctionName)",
     swiftAPIName: swiftFunctionName,
     as: apiKind,
-    stdlibTypes: translator.swiftStdlibTypes
+    stdlibTypes: translator.swiftStdlibTypeDecls
   )
 
   #expect(
@@ -141,7 +141,7 @@ func assertLoweredVariableAccessor(
     cName: "c_\(swiftVariableName)",
     swiftAPIName: swiftVariableName,
     as: isSet ? .setter : .getter,
-    stdlibTypes: translator.swiftStdlibTypes
+    stdlibTypes: translator.swiftStdlibTypeDecls
   )
 
   #expect(


### PR DESCRIPTION
to construct stdlib types easily.

For example, constructing `UnsafePointer<Int8>` is now:
```swift
knownTypes.unsafePointer(knownTypes.int8)
```
compared to:
```swift
SwiftType.nominal(SwiftNominalType(
  nominalTypeDecl: swiftStdlibTypes.unsafePointerDecl,
  genericArguments: [
    .nominal(SwiftNominalType(nominalTypeDecl: swiftStdlibTypes[.int8]))
  ]
))
```

Rename `SwiftStandardLibraryTypes` to `SwiftStandardLibraryTypeDecls`
Rename `KnownStandardLibraryType` to `SwiftStandardLibraryTypeKind`