### PR TITLE
[JExtract] Bridge UnsafeRawBufferPointer

### DIFF
--- a/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -47,6 +47,12 @@ public func globalCallMeRunnable(run: () -> ()) {
   run()
 }
 
+public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
+  return buf.count
+}
+
+public var globalBuffer: UnsafeRawBufferPointer = UnsafeRawBufferPointer(UnsafeMutableRawBufferPointer.allocate(byteCount: 124, alignment: 1))
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -45,6 +45,8 @@ public class HelloJava2Swift {
             SwiftKit.trace("running runnable");
         });
 
+        SwiftKit.trace("getGlobalBuffer().byteSize()=" + MySwiftLibrary.getGlobalBuffer().byteSize());
+
         // Example of using an arena; MyClass.deinit is run at end of scope
         try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass obj = MySwiftClass.init(2222, 7777, arena);

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -41,6 +41,10 @@ public func globalCallMeRunnable(run: () -> ()) {
   run()
 }
 
+public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
+  return buf.count
+}
+
 public class MySwiftClass {
 
   public var len: Int

--- a/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
+++ b/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
@@ -65,6 +65,9 @@ extension CType {
     case .tuple([]):
       self = .void
 
+    case .optional(let wrapped) where wrapped.isPointer:
+      try self.init(cdeclType: wrapped)
+
     case .metatype, .optional, .tuple:
       throw CDeclToCLoweringError.invalidCDeclType(cdeclType)
     }
@@ -122,7 +125,7 @@ extension SwiftStandardLibraryTypeKind {
       .qualified(const: true, volatile: false, type: .void)
     )
     case .void: .void
-    case .unsafePointer, .unsafeMutablePointer, .unsafeBufferPointer, .unsafeMutableBufferPointer, .string:
+    case .unsafePointer, .unsafeMutablePointer, .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer, .unsafeBufferPointer, .unsafeMutableBufferPointer, .string:
        nil
     }
   }

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -138,7 +138,12 @@ extension FFMSwift2JavaGenerator {
     printImports(&printer)
 
     printModuleClass(&printer) { printer in
-      // TODO: print all "static" methods
+
+      for decl in analysis.importedGlobalVariables {
+        self.log.trace("Print imported decl: \(decl)")
+        printFunctionDowncallMethods(&printer, decl)
+      }
+
       for decl in analysis.importedGlobalFuncs {
         self.log.trace("Print imported decl: \(decl)")
         printFunctionDowncallMethods(&printer, decl)

--- a/Sources/JExtractSwiftLib/FFM/ForeignValueLayouts.swift
+++ b/Sources/JExtractSwiftLib/FFM/ForeignValueLayouts.swift
@@ -43,6 +43,7 @@ public struct ForeignValueLayout: CustomStringConvertible, Equatable {
     case .long: self =  .SwiftInt64
     case .float: self =  .SwiftFloat
     case .double: self =  .SwiftDouble
+    case .javaForeignMemorySegment: self = .SwiftPointer
     case .array, .class, .void: return nil
     }
   }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
@@ -248,7 +248,12 @@ extension SwiftStandardLibraryTypeKind {
     case .double: .double
     case .void: .void
     case .string: .javaLangString
-    case .uint, .uint8, .uint32, .uint64, .unsafeRawPointer, .unsafeMutableRawPointer, .unsafePointer, .unsafeMutablePointer, .unsafeBufferPointer, .unsafeMutableBufferPointer: nil
+    case .uint, .uint8, .uint32, .uint64,
+        .unsafeRawPointer, .unsafeMutableRawPointer,
+        .unsafePointer, .unsafeMutablePointer,
+        .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer,
+        .unsafeBufferPointer, .unsafeMutableBufferPointer:
+      nil
     }
   }
 }

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftStandardLibraryTypeDecls.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftStandardLibraryTypeDecls.swift
@@ -30,6 +30,8 @@ enum SwiftStandardLibraryTypeKind: String, Hashable, CaseIterable {
   case double = "Double"
   case unsafeRawPointer = "UnsafeRawPointer"
   case unsafeMutableRawPointer = "UnsafeMutableRawPointer"
+  case unsafeRawBufferPointer = "UnsafeRawBufferPointer"
+  case unsafeMutableRawBufferPointer = "UnsafeMutableRawBufferPointer"
   case unsafePointer = "UnsafePointer"
   case unsafeMutablePointer = "UnsafeMutablePointer"
   case unsafeBufferPointer = "UnsafeBufferPointer"
@@ -48,12 +50,22 @@ enum SwiftStandardLibraryTypeKind: String, Hashable, CaseIterable {
     switch self {
     case .bool, .double, .float, .int, .int8, .int16, .int32, .int64,
         .uint, .uint8, .uint16, .uint32, .uint64, .unsafeRawPointer,
-        .unsafeMutableRawPointer, .string, .void:
+        .unsafeMutableRawPointer, .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer,
+        .string, .void:
       false
 
     case .unsafePointer, .unsafeMutablePointer, .unsafeBufferPointer,
         .unsafeMutableBufferPointer:
       true
+    }
+  }
+
+  var isPointer: Bool {
+    switch self {
+    case .unsafePointer, .unsafeMutablePointer, .unsafeRawPointer, .unsafeMutableRawPointer:
+      return true
+    default:
+      return false
     }
   }
 }

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftType.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftType.swift
@@ -38,8 +38,7 @@ enum SwiftType: Equatable {
     asNominalType?.nominalTypeDecl
   }
 
-  /// Whether this is the "Void" type, which is actually an empty
-  /// tuple.
+  /// Whether this is the "Void" type, which is actually an empty tuple.
   var isVoid: Bool {
     switch self {
     case .tuple([]):
@@ -49,6 +48,19 @@ enum SwiftType: Equatable {
     default:
       return false
     }
+  }
+
+  /// Whether this is a pointer type. I.e 'Unsafe[Mutable][Raw]Pointer'
+  var isPointer: Bool {
+    switch self {
+    case .nominal(let nominal):
+      if let knownType = nominal.nominalTypeDecl.knownStandardLibraryType {
+        return knownType.isPointer
+      }
+    default:
+      break
+    }
+    return false;
   }
 
   /// Reference type

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -315,6 +315,24 @@ final class FunctionLoweringTests {
     )
   }
 
+  @Test("Lowering UnsafeRawBufferPointer")
+  func lowerRawBufferPointer() throws {
+    try assertLoweredFunction(
+      """
+      func swapRawBufferPointer(buffer: UnsafeRawBufferPointer) -> UnsafeMutableRawBufferPointer {}
+      """,
+      expectedCDecl: """
+      @_cdecl("c_swapRawBufferPointer")
+      public func c_swapRawBufferPointer(_ buffer_pointer: UnsafeRawPointer?, _ buffer_count: Int, _ _result_pointer: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ _result_count: UnsafeMutablePointer<Int>) {
+        let _result = swapRawBufferPointer(buffer: UnsafeRawBufferPointer(start: buffer_pointer, count: buffer_count))
+        _result_pointer.initialize(to: _result.baseAddress)
+        _result_count.initialize(to: _result.count)
+      }
+      """,
+      expectedCFunction: "void c_swapRawBufferPointer(const void *buffer_pointer, ptrdiff_t buffer_count, void **_result_pointer, ptrdiff_t *_result_count)"
+    )
+  }
+
   @Test("Lowering () -> Void type")
   func lowerSimpleClosureTypes() throws {
     try assertLoweredFunction("""


### PR DESCRIPTION
Lower `Unsafe(Mutable)RawBufferPointer` to a pair of pointer and count. Implement parameter and result conversion both in Swift thunks and Java bindings.

`JavaConversionStep` is now nested structure just like `ConversionStep`.