### PR TITLE
[JExtract] Bridge closures with UnsafeRawBufferPointer parameter

### DIFF
--- a/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -53,6 +53,10 @@ public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
 
 public var globalBuffer: UnsafeRawBufferPointer = UnsafeRawBufferPointer(UnsafeMutableRawBufferPointer.allocate(byteCount: 124, alignment: 1))
 
+public func withBuffer(body: (UnsafeRawBufferPointer) -> Void) {
+  body(globalBuffer)
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -47,6 +47,9 @@ public class HelloJava2Swift {
 
         SwiftKit.trace("getGlobalBuffer().byteSize()=" + MySwiftLibrary.getGlobalBuffer().byteSize());
 
+        MySwiftLibrary.withBuffer((buf) -> {
+            SwiftKit.trace("withBuffer{$0.byteSize()}=" + buf.byteSize());
+        });
         // Example of using an arena; MyClass.deinit is run at end of scope
         try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass obj = MySwiftClass.init(2222, 7777, arena);

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -333,6 +333,24 @@ final class FunctionLoweringTests {
     )
   }
 
+  @Test("Lowering non-C-compatible closures")
+  func lowerComplexClosureParameter() throws {
+    try assertLoweredFunction(
+      """
+      func withBuffer(body: (UnsafeRawBufferPointer) -> Int) {}
+      """,
+      expectedCDecl: """
+      @_cdecl("c_withBuffer")
+      public func c_withBuffer(_ body: @convention(c) (UnsafeRawPointer?, Int) -> Int) {
+        withBuffer(body: { (_0) in
+          return body(_0.baseAddress, _0.count)
+        })
+      }
+      """,
+      expectedCFunction: "void c_withBuffer(ptrdiff_t (*body)(const void *, ptrdiff_t))"
+    )
+  }
+
   @Test("Lowering () -> Void type")
   func lowerSimpleClosureTypes() throws {
     try assertLoweredFunction("""


### PR DESCRIPTION
First step to bridging closures with conversions.

E.g.
```swift
public func withBuffer(body: (UnsafeRawBufferPointer) -> Void)
```
is lowered to:
```c
void c_withBuffer(void (*body)(const void *, ptrdiff_t));
```
then translated to:
```java
public static class withBuffer {
    @FunctionalInterface
    public interface body {
      void apply(java.lang.foreign.MemorySegment _0);
    }
}
public static void withBuffer(withBuffer.body body);
```
