### PR TITLE
CI: Correct validation & bring back pointer "max" bounds workaround

### DIFF
--- a/.github/scripts/validate_sample.sh
+++ b/.github/scripts/validate_sample.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 # shellcheck disable=SC2034
 declare -r GREEN='\033[0;32m'
 declare -r BOLD='\033[1m'
@@ -14,14 +17,11 @@ echo "========================================================================"
 printf "Validate sample '${BOLD}%s${RESET}' using: " "$sampleDir"
 cd "$sampleDir" || exit
 if [[ $(find . -name ${CI_VALIDATE_SCRIPT} -maxdepth 1) ]]; then
-  echo -e "Custom ${BOLD}${CI_VALIDATE_SCRIPT}${RESET} script..."
-  ./${CI_VALIDATE_SCRIPT} || exit
-elif [[ $(find . -name 'build.gradle*' -maxdepth 1) ]]; then
-  echo -e "${BOLD}Gradle${RESET} build..."
-  ./gradlew build || ./gradlew build --info # re-run to get better failure output
+  echo -e "Run ${BOLD}${CI_VALIDATE_SCRIPT}${RESET} script..."
+  ./${CI_VALIDATE_SCRIPT}
 else
-  echo -e "${BOLD}SwiftPM${RESET} build..."
-  swift build || exit
+  echo -e "${BOLD}Missing ${CI_VALIDATE_SCRIPT} file!${RESET}"
+  exit
 fi
 
 echo -e "Validated sample '${BOLD}${sampleDir}${RESET}': ${BOLD}passed${RESET}."

--- a/Samples/SwiftKitSampleApp/ci-validate.sh
+++ b/Samples/SwiftKitSampleApp/ci-validate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+set -e
+
+./gradlew run

--- a/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueLayout.java
+++ b/SwiftKit/src/main/java/org/swift/swiftkit/SwiftValueLayout.java
@@ -41,8 +41,10 @@ public class SwiftValueLayout {
     public static final ValueLayout.OfLong SWIFT_INT64 = ValueLayout.JAVA_LONG;
     public static final ValueLayout.OfFloat SWIFT_FLOAT = ValueLayout.JAVA_FLOAT;
     public static final ValueLayout.OfDouble SWIFT_DOUBLE = ValueLayout.JAVA_DOUBLE;
-    public static final AddressLayout SWIFT_POINTER = ValueLayout.ADDRESS;
-            // .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE));
+
+    // FIXME: this sequence layout is a workaround, we must properly size pointers when we get them.
+    public static final AddressLayout SWIFT_POINTER = ValueLayout.ADDRESS
+           .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE));
     public static final SequenceLayout SWIFT_BYTE_ARRAY = MemoryLayout.sequenceLayout(8, ValueLayout.JAVA_BYTE);
 
     /**


### PR DESCRIPTION
FYI @rintaro bringing back the workaround for the ADDRESS bounds.

I'll look into the real solution here though, to properly size things when we use a pointer.