### PR TITLE
[JavaRuntime] Add module.modulemap

### DIFF
--- a/Sources/JavaRuntime/include/module.modulemap
+++ b/Sources/JavaRuntime/include/module.modulemap
@@ -1,0 +1,4 @@
+module JavaRuntime {
+    umbrella header "JavaRuntime.h"
+    export *
+}


### PR DESCRIPTION
Fix a build error in 6.1 toolchain. Apparently some targets have both `JavaRuntime-tool.build` and `JavaRuntime.build` as the include paths. The auto generated `module.modulemap` in those directories cause the error `error: redefinition of module 'JavaRuntime'`. To avoid that, add `module.modulemap` in the source directory so it's not generated.

Fixes: https://github.com/swiftlang/swift-java/issues/229