### PR TITLE
[JExtract] Stop using SyntaxVisitor for Swift2JavaVisitor

### DIFF
--- a/Sources/JExtractSwiftLib/ImportedDecls.swift
+++ b/Sources/JExtractSwiftLib/ImportedDecls.swift
@@ -37,8 +37,8 @@ package class ImportedNominalType: ImportedDecl {
     self.swiftNominal = swiftNominal
   }
 
-  var javaClassName: String {
-    swiftNominal.name
+  var swiftType: SwiftType {
+    return .nominal(.init(nominalTypeDecl: swiftNominal))
   }
 }
 

--- a/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
@@ -106,7 +106,7 @@ extension Swift2JavaTranslator {
 
     for input in self.inputs {
       log.trace("Analyzing \(input.filePath)")
-      visitor.walk(input.syntax)
+      visitor.visit(sourceFile: input.syntax)
     }
   }
 


### PR DESCRIPTION
Visit manually instead of using SyntaxVisitor:

* Better visitation control than `SyntaxVisitorContinueKind`
* Robust type context control by passing it as a visit parameter.