### PR TITLE
[JExtract] Generate JNI code for memory management with `SwiftKitCore`

### DIFF
--- a/Samples/JExtractJNISampleApp/src/main/java/com/example/swift/HelloJava2SwiftJNI.java
+++ b/Samples/JExtractJNISampleApp/src/main/java/com/example/swift/HelloJava2SwiftJNI.java
@@ -19,6 +19,7 @@ package com.example.swift;
 // Import javakit/swiftkit support libraries
 
 import org.swift.swiftkit.core.SwiftLibraries;
+import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
 
 public class HelloJava2SwiftJNI {
 
@@ -40,8 +41,10 @@ public class HelloJava2SwiftJNI {
 
         MySwiftClass.method();
 
-        MySwiftClass myClass = MySwiftClass.init(10, 5);
-        MySwiftClass myClass2 = MySwiftClass.init();
+        try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
+            MySwiftClass myClass = MySwiftClass.init(10, 5, arena);
+            MySwiftClass myClass2 = MySwiftClass.init(arena);
+        }
 
         System.out.println("DONE.");
     }

--- a/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -14,24 +14,25 @@
 
 package com.example.swift;
 
-import com.example.swift.MySwiftLibrary;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MySwiftClassTest {
     @Test
     void init_noParameters() {
-        MySwiftClass c = MySwiftClass.init();
-        assertNotNull(c);
+        try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
+            MySwiftClass c = MySwiftClass.init(arena);
+            assertNotNull(c);
+        }
     }
 
     @Test
     void init_withParameters() {
-        MySwiftClass c = MySwiftClass.init(1337, 42);
-        assertNotNull(c);
+        try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
+            MySwiftClass c = MySwiftClass.init(1337, 42, arena);
+            assertNotNull(c);
+        }
     }
-
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -213,10 +213,10 @@ extension JNISwift2JavaGenerator {
     let cName =
       "Java_"
       + self.javaPackage.replacingOccurrences(of: ".", with: "_")
-      + "_\(parentName.nativeJNIEscaped)_"
-      + javaMethodName.nativeJNIEscaped
+      + "_\(parentName.escapedJNIIdentifier)_"
+      + javaMethodName.escapedJNIIdentifier
       + "__"
-      + jniSignature.nativeJNIEscaped
+      + jniSignature.escapedJNIIdentifier
 
     let translatedParameters = parameters.map {
       "\($0.name): \($0.type.jniTypeName)"
@@ -294,7 +294,7 @@ extension JNISwift2JavaGenerator {
 
 extension String {
   /// Returns a version of the string correctly escaped for a JNI
-  var nativeJNIEscaped: String {
+  var escapedJNIIdentifier: String {
     self.map {
       if $0 == "_" {
         return "_1"

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
@@ -39,7 +39,7 @@ public abstract class JNISwiftInstance extends SwiftInstance {
      *
      * @return a function that is called when the value should be destroyed.
      */
-    abstract Runnable $createDestroyFunction();
+    protected abstract Runnable $createDestroyFunction();
 
     @Override
     public SwiftInstanceCleanup createCleanupAction() {


### PR DESCRIPTION
Adds SwiftKitCore support for the generated code for classes. This means that we will actually destroy the instances once the arena decides to so.