### PR TITLE
[JExtract/FFM] Translate 'some DataProtocol' parameters to 'Data'

### DIFF
--- a/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -63,6 +63,10 @@ public func withBuffer(body: (UnsafeRawBufferPointer) -> Void) {
   body(globalBuffer)
 }
 
+public func globalReceiveSomeDataProtocol(data: some DataProtocol) {
+  p(Array(data).description)
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftKitSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -63,8 +63,9 @@ public func withBuffer(body: (UnsafeRawBufferPointer) -> Void) {
   body(globalBuffer)
 }
 
-public func globalReceiveSomeDataProtocol(data: some DataProtocol) {
+public func globalReceiveSomeDataProtocol(data: some DataProtocol) -> Int {
   p(Array(data).description)
+  return data.count
 }
 
 // ==== Internal helpers

--- a/Samples/SwiftKitSampleApp/ci-validate.sh
+++ b/Samples/SwiftKitSampleApp/ci-validate.sh
@@ -4,3 +4,4 @@ set -x
 set -e
 
 ./gradlew run
+./gradlew test

--- a/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftKitSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -22,10 +22,6 @@ import org.swift.swiftkit.core.SwiftLibraries;
 import org.swift.swiftkit.ffm.AllocatingSwiftArena;
 import org.swift.swiftkit.ffm.SwiftRuntime;
 
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-
 public class HelloJava2Swift {
 
     public static void main(String[] args) {
@@ -93,6 +89,12 @@ public class HelloJava2Swift {
                 var str = retBytes.getString(0);
                 SwiftRuntime.trace("retStr=" + str);
             });
+        }
+
+        try (var arena = AllocatingSwiftArena.ofConfined()) {
+            var bytes = arena.allocateFrom("hello");
+            var dat = Data.init(bytes, bytes.byteSize(), arena);
+            MySwiftLibrary.globalReceiveSomeDataProtocol(dat);
         }
 
 

--- a/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/DataImportTest.java
+++ b/Samples/SwiftKitSampleApp/src/test/java/com/example/swift/DataImportTest.java
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package com.example.swift;
+
+import org.junit.jupiter.api.Test;
+import org.swift.swiftkit.ffm.AllocatingSwiftArena;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DataImportTest {
+    @Test
+    void test_Data_receiveAndReturn() {
+        try (var arena = AllocatingSwiftArena.ofConfined()) {
+            var origBytes = arena.allocateFrom("foobar");
+            var origDat = Data.init(origBytes, origBytes.byteSize(), arena);
+            assertEquals(7, origDat.getCount());
+
+            var retDat = MySwiftLibrary.globalReceiveReturnData(origDat, arena);
+            assertEquals(7, retDat.getCount());
+            retDat.withUnsafeBytes((retBytes) -> {
+                assertEquals(7, retBytes.byteSize());
+                var str = retBytes.getString(0);
+                assertEquals("foobar", str);
+            });
+        }
+    }
+
+    @Test
+    void test_DataProtocol_receive() {
+        try (var arena = AllocatingSwiftArena.ofConfined()) {
+            var bytes = arena.allocateFrom("hello");
+            var dat = Data.init(bytes, bytes.byteSize(), arena);
+            var result = MySwiftLibrary.globalReceiveSomeDataProtocol(dat);
+            assertEquals(6, result);
+        }
+    }
+}

--- a/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
+++ b/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
@@ -24,7 +24,7 @@ extension CType {
   init(cdeclType: SwiftType) throws {
     switch cdeclType {
     case .nominal(let nominalType):
-      if let knownType = nominalType.nominalTypeDecl.knownStandardLibraryType {
+      if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
         if let primitiveCType = knownType.primitiveCType {
           self = primitiveCType
           return
@@ -68,7 +68,7 @@ extension CType {
     case .optional(let wrapped) where wrapped.isPointer:
       try self.init(cdeclType: wrapped)
 
-    case .metatype, .optional, .tuple:
+    case .metatype, .optional, .tuple, .opaque, .existential:
       throw CDeclToCLoweringError.invalidCDeclType(cdeclType)
     }
   }
@@ -125,7 +125,7 @@ extension SwiftKnownTypeDeclKind {
       .qualified(const: true, volatile: false, type: .void)
     )
     case .void: .void
-    case .unsafePointer, .unsafeMutablePointer, .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer, .unsafeBufferPointer, .unsafeMutableBufferPointer, .string, .data:
+    case .unsafePointer, .unsafeMutablePointer, .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer, .unsafeBufferPointer, .unsafeMutableBufferPointer, .string, .data, .dataProtocol:
        nil
     }
   }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -66,7 +66,7 @@ extension JNISwift2JavaGenerator {
     func translate(swiftType: SwiftType) -> JavaType {
       switch swiftType {
       case .nominal(let nominalType):
-        if let knownType = nominalType.nominalTypeDecl.knownStandardLibraryType {
+        if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
           guard let javaType = translate(knownType: knownType) else {
             fatalError("unsupported known type: \(knownType)")
           }
@@ -78,7 +78,7 @@ extension JNISwift2JavaGenerator {
       case .tuple([]):
         return .void
 
-      case .metatype, .optional, .tuple, .function:
+      case .metatype, .optional, .tuple, .function, .existential, .opaque:
         fatalError("unsupported type: \(self)")
       }
     }
@@ -99,10 +99,8 @@ extension JNISwift2JavaGenerator {
           .unsafeRawPointer, .unsafeMutableRawPointer,
           .unsafePointer, .unsafeMutablePointer,
           .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer,
-          .unsafeBufferPointer, .unsafeMutableBufferPointer:
+          .unsafeBufferPointer, .unsafeMutableBufferPointer, .data, .dataProtocol:
         nil
-      case .data:
-        fatalError("unimplemented")
       }
     }
   }

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownModules.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownModules.swift
@@ -86,7 +86,9 @@ private let swiftSourceFile: SourceFileSyntax = """
   """
 
 private let foundationSourceFile: SourceFileSyntax = """
-  public struct Data {
+  public protocol DataProtocol {}
+  
+  public struct Data: DataProtocol {
     public init(bytes: UnsafeRawPointer, count: Int)
     public var count: Int { get }
     public func withUnsafeBytes(_ body: (UnsafeRawBufferPointer) -> Void)

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownTypeDecls.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownTypeDecls.swift
@@ -39,6 +39,7 @@ enum SwiftKnownTypeDeclKind: String, Hashable {
   case void = "Swift.Void"
   case string = "Swift.String"
 
+  case dataProtocol = "Foundation.DataProtocol"
   case data = "Foundation.Data"
 
   var moduleAndName: (module: String, name: String) {

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownTypes.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftKnownTypes.swift
@@ -35,6 +35,9 @@ struct SwiftKnownTypes {
   var unsafeRawPointer: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: symbolTable[.unsafeRawPointer])) }
   var unsafeMutableRawPointer: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: symbolTable[.unsafeMutableRawPointer])) }
 
+  var dataProtocol: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: symbolTable[.dataProtocol])) }
+  var data: SwiftType { .nominal(SwiftNominalType(nominalTypeDecl: symbolTable[.data])) }
+
   func unsafePointer(_ pointeeType: SwiftType) -> SwiftType {
     .nominal(
       SwiftNominalType(
@@ -69,5 +72,14 @@ struct SwiftKnownTypes {
         genericArguments: [elementType]
       )
     )
+  }
+
+  /// Returns the known representative concrete type if there is one for the
+  /// given protocol kind. E.g. `String` for `StringProtocol`
+  func representativeType(of knownProtocol: SwiftKnownTypeDeclKind) -> SwiftType? {
+    switch knownProtocol {
+    case .dataProtocol: return self.data
+    default: return nil
+    }
   }
 }

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftNominalTypeDeclaration.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftNominalTypeDeclaration.swift
@@ -52,7 +52,7 @@ package class SwiftNominalTypeDeclaration {
 
   /// Identify this nominal declaration as one of the known standard library
   /// types, like 'Swift.Int[.
-  lazy var knownStandardLibraryType: SwiftKnownTypeDeclKind? = {
+  lazy var knownTypeKind: SwiftKnownTypeDeclKind? = {
     self.computeKnownStandardLibraryType()
   }()
 


### PR DESCRIPTION
* Introduce `SwiftType.opaque(SwiftType)` and `.existential(SwiftType)` to represent `some` and `any` types respectively.
* Introduce `SwiftKnownTypes.representativeType(of:)` to the hardcoded `DataProtocol` -> `Data` translation mapping.