### PR TITLE
[JExtract] Add support for JNI member methods

### DIFF
--- a/Samples/JExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
+++ b/Samples/JExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
@@ -34,4 +34,20 @@ public class MySwiftClass {
   deinit {
     p("deinit called!")
   }
+
+  public func sum() -> Int64 {
+    return x + y
+  }
+
+  public func xMultiplied(by z: Int64) -> Int64 {
+    return x * z;
+  }
+
+  enum MySwiftClassError: Error {
+    case swiftError
+  }
+
+  public func throwingFunction() throws {
+    throw MySwiftClassError.swiftError
+  }
 }

--- a/Samples/JExtractJNISampleApp/src/main/java/com/example/swift/HelloJava2SwiftJNI.java
+++ b/Samples/JExtractJNISampleApp/src/main/java/com/example/swift/HelloJava2SwiftJNI.java
@@ -44,6 +44,12 @@ public class HelloJava2SwiftJNI {
         try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
             MySwiftClass myClass = MySwiftClass.init(10, 5, arena);
             MySwiftClass myClass2 = MySwiftClass.init(arena);
+
+            try {
+                myClass.throwingFunction();
+            } catch (Exception e) {
+                System.out.println("Caught exception: " + e.getMessage());
+            }
         }
 
         System.out.println("DONE.");

--- a/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -35,4 +35,30 @@ public class MySwiftClassTest {
             assertNotNull(c);
         }
     }
+
+    @Test
+    void sum() {
+        try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
+            MySwiftClass c = MySwiftClass.init(20, 10, arena);
+            assertEquals(30, c.sum());
+        }
+    }
+
+    @Test
+    void xMultiplied() {
+        try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
+            MySwiftClass c = MySwiftClass.init(20, 10, arena);
+            assertEquals(200, c.xMultiplied(10));
+        }
+    }
+
+    @Test
+    void throwingFunction() {
+        try (var arena = new ConfinedSwiftMemorySession(Thread.currentThread())) {
+            MySwiftClass c = MySwiftClass.init(20, 10, arena);
+            Exception exception = assertThrows(Exception.class, () -> c.throwingFunction());
+
+            assertEquals("swiftError", exception.getMessage());
+        }
+    }
 }

--- a/Sources/JavaKit/Exceptions/ExceptionHandling.swift
+++ b/Sources/JavaKit/Exceptions/ExceptionHandling.swift
@@ -39,7 +39,7 @@ extension JNIEnvironment {
     }
 
     // Otherwise, create a exception with a message.
-    _ = try! JavaClass<Exception>.withJNIClass(in: self) { exceptionClass in
+    _ = try! Exception.withJNIClass(in: self) { exceptionClass in
       interface.ThrowNew(self, exceptionClass, String(describing: error))
     }
   }


### PR DESCRIPTION
Adds support for generating code for member methods in JNI mode. Also fixes a bug with throwing functions, that also affected the JavaKit macros.

```swift
public func doSomething(x: Int64) {}
```

is generated as:

### Java
```java
 public void doSomething(long x) {
  long selfPointer = this.pointer();
  MyClass.$doSomething(x, selfPointer);
}

private static native void $doSomething(long x, long selfPointer);
```

### Swift
```swift
@_cdecl("Java_com_example_swift_MyClass__00024doSomething__JJ")
func Java_com_example_swift_MyClass__00024doSomething__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, x: jlong, selfPointer: jlong) {
  let self$ = UnsafeMutablePointer<MyClass>(bitPattern: Int(Int64(fromJNI: selfPointer, in: environment!)))!
  self$.pointee.doSomething(x: Int64(fromJNI: x, in: environment!))
}
```