### PR TITLE
[JavaKit] Add `JNIEnvPointer` and `JNINativeInterface_` for Android

### DIFF
--- a/Sources/JavaKit/JavaEnvironment.swift
+++ b/Sources/JavaKit/JavaEnvironment.swift
@@ -14,6 +14,10 @@
 
 import JavaRuntime
 
+#if canImport(Android)
+typealias JNINativeInterface_ = JNINativeInterface
+#endif
+
 extension UnsafeMutablePointer<JNIEnv?> {
   var interface: JNINativeInterface_ { self.pointee!.pointee }
 }


### PR DESCRIPTION
The JNI C header included in the Android NDK is slightly different (as is the case with most C API's Android exposes) from the standard desktop Java counterpart. This PR allows JavaKit to compile on Android with the `jni.h` provided in the NDK.