### PR TITLE
[SwiftKit] Move 'selfPointer' to 'JNISwiftInstance'

### DIFF
--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
@@ -17,6 +17,16 @@ package org.swift.swiftkit.core;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class JNISwiftInstance extends SwiftInstance {
+    /// Pointer to the "self".
+    private final long selfPointer;
+
+    /**
+     * The pointer to the instance in memory. I.e. the {@code self} of the Swift object or value.
+     */
+    public final long pointer() {
+        return this.selfPointer;
+    }
+
     /**
      * The designated constructor of any imported Swift types.
      *
@@ -24,7 +34,8 @@ public abstract class JNISwiftInstance extends SwiftInstance {
      * @param arena   the arena this object belongs to. When the arena goes out of scope, this value is destroyed.
      */
     protected JNISwiftInstance(long pointer, SwiftArena arena) {
-        super(pointer, arena);
+        super(arena);
+        this.selfPointer = pointer;
     }
 
     /**

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftInstance.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftInstance.java
@@ -17,15 +17,6 @@ package org.swift.swiftkit.core;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class SwiftInstance {
-    /// Pointer to the "self".
-    private final long selfPointer;
-
-    /**
-     * The pointer to the instance in memory. I.e. the {@code self} of the Swift object or value.
-     */
-    public final long pointer() {
-        return this.selfPointer;
-    }
 
     /**
      * Called when the arena has decided the value should be destroyed.
@@ -55,8 +46,7 @@ public abstract class SwiftInstance {
      * @param pointer a pointer to the memory containing the value
      * @param arena the arena this object belongs to. When the arena goes out of scope, this value is destroyed.
      */
-    protected SwiftInstance(long pointer, SwiftArena arena) {
-        this.selfPointer = pointer;
+    protected SwiftInstance(SwiftArena arena) {
         arena.register(this);
     }
 

--- a/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftInstance.java
+++ b/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftInstance.java
@@ -41,7 +41,7 @@ public abstract class FFMSwiftInstance extends SwiftInstance {
      * @param arena the arena this object belongs to. When the arena goes out of scope, this value is destroyed.
      */
     protected FFMSwiftInstance(MemorySegment segment, AllocatingSwiftArena arena) {
-        super(segment.address(), arena);
+        super(arena);
         this.memorySegment = segment;
     }
 


### PR DESCRIPTION
`FFMSwiftInstance` doesn't need it.