### PR TITLE
[JExtract/JNI] Fix boolean naming for variables already called `isX`

### DIFF
--- a/Sources/JExtractSwiftLib/Convenience/String+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/String+Extensions.swift
@@ -14,8 +14,7 @@
 
 extension String {
 
-  // TODO: naive implementation good enough for our simple case `methodMethodSomething` -> `MethodSomething`
-  var toCamelCase: String {
+  var firstCharacterUppercased: String {
     guard let f = first else {
       return self
     }

--- a/Sources/JExtractSwiftLib/ImportedDecls.swift
+++ b/Sources/JExtractSwiftLib/ImportedDecls.swift
@@ -169,6 +169,16 @@ extension ImportedFunc {
   }
 
   var javaSetterName: String {
-    "set\(self.name.firstCharacterUppercased)"
+    let isBooleanSetter = self.functionSignature.parameters.first?.type.asNominalTypeDeclaration?.knownTypeKind == .bool
+
+    // If the variable is already named "isX", then we make
+    // the setter "setX" to match beans spec.
+    if isBooleanSetter && self.name.hasJavaBooleanNamingConvention {
+      // Safe to force unwrap due to `hasJavaBooleanNamingConvention` check.
+      let propertyName = self.name.split(separator: "is", maxSplits: 1).last!
+      return "set\(propertyName)"
+    } else {
+      return "set\(self.name.firstCharacterUppercased)"
+    }
   }
 }

--- a/Sources/JExtractSwiftLib/ImportedDecls.swift
+++ b/Sources/JExtractSwiftLib/ImportedDecls.swift
@@ -160,15 +160,15 @@ extension ImportedFunc {
     let returnsBoolean = self.functionSignature.result.type.asNominalTypeDeclaration?.knownTypeKind == .bool
 
     if !returnsBoolean {
-      return "get\(self.name.toCamelCase)"
+      return "get\(self.name.firstCharacterUppercased)"
     } else if !self.name.hasJavaBooleanNamingConvention {
-      return "is\(self.name.toCamelCase)"
+      return "is\(self.name.firstCharacterUppercased)"
     } else {
-      return self.name.toCamelCase
+      return self.name
     }
   }
 
   var javaSetterName: String {
-    "set\(self.name.toCamelCase)"
+    "set\(self.name.firstCharacterUppercased)"
   }
 }

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -115,7 +115,6 @@ func assertOutput(
       print("==== ---------------------------------------------------------------")
       
       #expect(output.contains(expectedChunk), sourceLocation: sourceLocation)
-      fatalError("Failed: \(filePath):\(line)")
       continue
     }
 

--- a/Tests/JExtractSwiftTests/JNI/JNIVariablesTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIVariablesTests.swift
@@ -33,7 +33,7 @@ struct JNIVariablesTests {
         set { }
       }
       public var someBoolean: Bool
-      public let isBoolean: Bool
+      public var isBoolean: Bool
     }
     """
 
@@ -463,7 +463,7 @@ struct JNIVariablesTests {
       /**
       * Downcall to Swift:
       * {@snippet lang=swift :
-      * public let isBoolean: Bool
+      * public var isBoolean: Bool
       * }
       */
       public boolean isBoolean() {
@@ -472,8 +472,23 @@ struct JNIVariablesTests {
       }
       """,
       """
+      /**
+      * Downcall to Swift:
+      * {@snippet lang=swift :
+      * public var isBoolean: Bool
+      * }
+      */
+      public void setBoolean(boolean newValue) {
+        long self$ = this.$memoryAddress();
+        MyClass.$setBoolean(newValue, self$);
+      }
+      """,
+      """
       private static native boolean $isBoolean(long selfPointer);
       """,
+      """
+      private static native void $setBoolean(boolean newValue, long selfPointer);
+      """
       ]
     )
   }
@@ -501,6 +516,20 @@ struct JNIVariablesTests {
           return result.getJNIValue(in: environment)
         }
         """,
+        """
+        @_cdecl("Java_com_example_swift_MyClass__00024setBoolean__ZJ")
+        func Java_com_example_swift_MyClass__00024setBoolean__ZJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, newValue: jboolean, selfPointer: jlong) {
+          guard let env$ = environment else {
+            fatalError("Missing JNIEnv in downcall to \\(#function)")
+          }
+          assert(selfPointer != 0, "selfPointer memory address was null")
+          let selfBits$ = Int(Int64(fromJNI: selfPointer, in: env$))
+          guard let self$ = UnsafeMutablePointer<MyClass>(bitPattern: selfBits$) else {
+            fatalError("self memory address was null in call to \\(#function)!")
+          }
+          self$.pointee.isBoolean = Bool(fromJNI: newValue, in: environment!)
+        }
+        """
       ]
     )
   }


### PR DESCRIPTION
Fixes a bug where variables named `isX` was imported as `IsX` instead. 