### PR TITLE
[JExtract] Translate generic parameters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -422,6 +422,7 @@ let package = Package(
       name: "JExtractSwiftLib",
       dependencies: [
         .product(name: "SwiftBasicFormat", package: "swift-syntax"),
+        .product(name: "SwiftLexicalLookup", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),

--- a/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
+++ b/Sources/JExtractSwiftLib/FFM/CDeclLowering/CRepresentation.swift
@@ -68,7 +68,7 @@ extension CType {
     case .optional(let wrapped) where wrapped.isPointer:
       try self.init(cdeclType: wrapped)
 
-    case .metatype, .optional, .tuple, .opaque, .existential:
+    case .genericParameter, .metatype, .optional, .tuple, .opaque, .existential:
       throw CDeclToCLoweringError.invalidCDeclType(cdeclType)
     }
   }
@@ -98,7 +98,7 @@ extension CFunction {
 
 enum CDeclToCLoweringError: Error {
   case invalidCDeclType(SwiftType)
-  case invalidNominalType(SwiftNominalTypeDeclaration)
+  case invalidNominalType(SwiftTypeDeclaration)
   case invalidFunctionConvention(SwiftFunctionType)
 }
 

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -125,7 +125,7 @@ extension FFMSwift2JavaGenerator {
   }
 
   func printSwiftThunkImports(_ printer: inout CodePrinter) {
-    for module in self.symbolTable.importedModules.keys.sorted() {
+    for module in self.lookupContext.symbolTable.importedModules.keys.sorted() {
       guard module != "Swift" else {
         continue
       }

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -24,7 +24,7 @@ package class FFMSwift2JavaGenerator: Swift2JavaGenerator {
   let javaPackage: String
   let swiftOutputDirectory: String
   let javaOutputDirectory: String
-  let symbolTable: SwiftSymbolTable
+  let lookupContext: SwiftTypeLookupContext
 
   var javaPackagePath: String {
     javaPackage.replacingOccurrences(of: ".", with: "/")
@@ -51,7 +51,7 @@ package class FFMSwift2JavaGenerator: Swift2JavaGenerator {
     self.javaPackage = javaPackage
     self.swiftOutputDirectory = swiftOutputDirectory
     self.javaOutputDirectory = javaOutputDirectory
-    self.symbolTable = translator.symbolTable
+    self.lookupContext = translator.lookupContext
 
     // If we are forced to write empty files, construct the expected outputs
     if translator.config.writeEmptyFiles ?? false {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -216,7 +216,7 @@ extension JNISwift2JavaGenerator {
           conversion: .placeholder
         )
 
-      case .metatype, .optional, .tuple, .existential, .opaque:
+      case .metatype, .optional, .tuple, .existential, .opaque, .genericParameter:
         throw JavaTranslationError.unsupportedSwiftType(swiftType)
       }
     }
@@ -251,7 +251,7 @@ extension JNISwift2JavaGenerator {
       case .tuple([]):
         return TranslatedResult(javaType: .void, conversion: .placeholder)
 
-      case .metatype, .optional, .tuple, .function, .existential, .opaque:
+      case .metatype, .optional, .tuple, .function, .existential, .opaque, .genericParameter:
         throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
       }
     }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -129,7 +129,7 @@ extension JNISwift2JavaGenerator {
           )
         )
 
-      case .metatype, .optional, .tuple, .existential, .opaque:
+      case .metatype, .optional, .tuple, .existential, .opaque, .genericParameter:
         throw JavaTranslationError.unsupportedSwiftType(swiftParameter.type)
       }
     }
@@ -160,7 +160,7 @@ extension JNISwift2JavaGenerator {
           conversion: .placeholder
         )
 
-      case .function, .metatype, .optional, .tuple, .existential, .opaque:
+      case .function, .metatype, .optional, .tuple, .existential, .opaque, .genericParameter:
         throw JavaTranslationError.unsupportedSwiftType(type)
       }
     }
@@ -187,7 +187,7 @@ extension JNISwift2JavaGenerator {
         // Custom types are not supported yet.
         throw JavaTranslationError.unsupportedSwiftType(type)
 
-      case .function, .metatype, .optional, .tuple, .existential, .opaque:
+      case .function, .metatype, .optional, .tuple, .existential, .opaque, .genericParameter:
         throw JavaTranslationError.unsupportedSwiftType(type)
       }
     }
@@ -223,7 +223,7 @@ extension JNISwift2JavaGenerator {
           conversion: .placeholder
         )
 
-      case .metatype, .optional, .tuple, .function, .existential, .opaque:
+      case .metatype, .optional, .tuple, .function, .existential, .opaque, .genericParameter:
         throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
       }
 

--- a/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
@@ -104,7 +104,7 @@ final class Swift2JavaVisitor {
       signature = try SwiftFunctionSignature(
         node,
         enclosingType: typeContext?.swiftType,
-        symbolTable: self.translator.symbolTable
+        lookupContext: translator.lookupContext
       )
     } catch {
       self.log.debug("Failed to import: '\(node.qualifiedNameForDebug)'; \(error)")
@@ -145,7 +145,7 @@ final class Swift2JavaVisitor {
         node,
         isSet: kind == .setter,
         enclosingType: typeContext?.swiftType,
-        symbolTable: self.translator.symbolTable
+        lookupContext: translator.lookupContext
       )
 
       let imported = ImportedFunc(
@@ -193,7 +193,7 @@ final class Swift2JavaVisitor {
       signature = try SwiftFunctionSignature(
         node,
         enclosingType: typeContext.swiftType,
-        symbolTable: self.translator.symbolTable
+        lookupContext: translator.lookupContext
       )
     } catch {
       self.log.debug("Failed to import: \(node.qualifiedNameForDebug); \(error)")

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftFunctionType.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftFunctionType.swift
@@ -40,18 +40,18 @@ extension SwiftFunctionType {
   init(
     _ node: FunctionTypeSyntax,
     convention: Convention,
-    symbolTable: SwiftSymbolTable
+    lookupContext: SwiftTypeLookupContext
   ) throws {
     self.convention = convention
     self.parameters = try node.parameters.map { param in
       let isInout = param.inoutKeyword != nil
       return SwiftParameter(
         convention: isInout ? .inout : .byValue,
-        type: try SwiftType(param.type, symbolTable: symbolTable)
+        type: try SwiftType(param.type, lookupContext: lookupContext)
       )
     }
 
-    self.resultType = try SwiftType(node.returnClause.type, symbolTable: symbolTable)
+    self.resultType = try SwiftType(node.returnClause.type, lookupContext: lookupContext)
 
     // check for effect specifiers
     if let throwsClause = node.effectSpecifiers?.throwsClause {

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftParameter.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftParameter.swift
@@ -58,7 +58,7 @@ enum SwiftParameterConvention: Equatable {
 }
 
 extension SwiftParameter {
-  init(_ node: FunctionParameterSyntax, symbolTable: SwiftSymbolTable) throws {
+  init(_ node: FunctionParameterSyntax, lookupContext: SwiftTypeLookupContext) throws {
     // Determine the convention. The default is by-value, but there are
     // specifiers on the type for other conventions (like `inout`).
     var type = node.type
@@ -90,7 +90,7 @@ extension SwiftParameter {
     self.convention = convention
 
     // Determine the type.
-    self.type = try SwiftType(type, symbolTable: symbolTable)
+    self.type = try SwiftType(type, lookupContext: lookupContext)
 
     // FIXME: swift-syntax itself should have these utilities based on identifiers.
     if let secondName = node.secondName {

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftParsedModuleSymbolTableBuilder.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftParsedModuleSymbolTableBuilder.swift
@@ -122,7 +122,8 @@ extension SwiftParsedModuleSymbolTableBuilder {
       parsedModule: symbolTable,
       importedModules: importedModules
     )
-    guard let extendedType = try? SwiftType(node.extendedType, symbolTable: table) else {
+    let lookupContext = SwiftTypeLookupContext(symbolTable: table)
+    guard let extendedType = try? SwiftType(node.extendedType, lookupContext: lookupContext) else {
       return false
     }
     guard let extendedNominal = extendedType.asNominalTypeDeclaration else {

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftType+RepresentativeConcreteeType.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftType+RepresentativeConcreteeType.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension SwiftType {
+  /// Returns a concrete type if this is a generic parameter in the list and it
+  /// conforms to a protocol with representative concrete type.
+  func representativeConcreteTypeIn(
+    knownTypes: SwiftKnownTypes,
+    genericParameters: [SwiftGenericParameterDeclaration],
+    genericRequirements: [SwiftGenericRequirement]
+  ) -> SwiftType? {
+    return representativeConcreteType(
+      self,
+      knownTypes: knownTypes,
+      genericParameters: genericParameters,
+      genericRequirements: genericRequirements
+    )
+  }
+}
+
+private func representativeConcreteType(
+  _ type: SwiftType,
+  knownTypes: SwiftKnownTypes,
+  genericParameters: [SwiftGenericParameterDeclaration],
+  genericRequirements: [SwiftGenericRequirement]
+) -> SwiftType? {
+  var maybeProto: SwiftType? = nil
+  switch type {
+  case .existential(let proto), .opaque(let proto):
+    maybeProto = proto
+  case .genericParameter(let genericParam):
+    // If the type is a generic parameter declared in this function and
+    // conforms to a protocol with representative concrete type, use it.
+    if genericParameters.contains(genericParam) {
+      for requirement in genericRequirements {
+        if case .inherits(let left, let right) = requirement, left == type {
+          guard maybeProto == nil else {
+            // multiple requirements on the generic parameter.
+            return nil
+          }
+          maybeProto = right
+          break
+        }
+      }
+    }
+  default:
+    return nil
+  }
+
+  if let knownProtocol = maybeProto?.asNominalTypeDeclaration?.knownTypeKind {
+    return knownTypes.representativeType(of: knownProtocol)
+  }
+  return nil
+}

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftTypeLookupContext.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftTypeLookupContext.swift
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+@_spi(Experimental) import SwiftLexicalLookup
+
+/// Unqualified type lookup manager.
+/// All unqualified lookup should be done via this instance. This caches the
+/// association of `Syntax.ID` to `SwiftTypeDeclaration`, and guarantees that
+/// there's only one `SwiftTypeDeclaration` per declaration `Syntax`.
+class SwiftTypeLookupContext {
+  var symbolTable: SwiftSymbolTable
+
+  private var typeDecls: [Syntax.ID: SwiftTypeDeclaration] = [:]
+
+  init(symbolTable: SwiftSymbolTable) {
+    self.symbolTable = symbolTable
+  }
+
+  /// Perform unqualified type lookup.
+  ///
+  /// - Parameters:
+  ///   - name: name to lookup
+  ///   - node: `Syntax` node the lookup happened
+  func unqualifiedLookup(name: Identifier, from node: some SyntaxProtocol) throws -> SwiftTypeDeclaration? {
+
+    for result in node.lookup(name) {
+      switch result {
+      case .fromScope(_, let names):
+        if !names.isEmpty {
+          return typeDeclaration(for: names)
+        }
+
+      case .fromFileScope(_, let names):
+        if !names.isEmpty {
+          return typeDeclaration(for: names)
+        }
+
+      case .lookInMembers(let scopeNode):
+        if let nominalDecl = try typeDeclaration(for: scopeNode) {
+          if let found = symbolTable.lookupNestedType(name.name, parent: nominalDecl as! SwiftNominalTypeDeclaration) {
+            return found
+          }
+        }
+
+      case .lookInGenericParametersOfExtendedType(let extensionNode):
+        // TODO: Implement
+        _ = extensionNode
+        break
+
+      case .mightIntroduceDollarIdentifiers:
+        // Dollar identifier can't be a type, ignore.
+        break
+      }
+    }
+
+    // Fallback to global symbol table lookup.
+    return symbolTable.lookupTopLevelNominalType(name.name)
+  }
+
+  /// Find the first type declaration in the `LookupName` results.
+  private func typeDeclaration(for names: [LookupName]) -> SwiftTypeDeclaration? {
+    for name in names {
+      switch name {
+      case .identifier(let identifiableSyntax, _):
+        return try? typeDeclaration(for: identifiableSyntax)
+      case .declaration(let namedDeclSyntax):
+        return try? typeDeclaration(for: namedDeclSyntax)
+      case .implicit(let implicitDecl):
+        // TODO: Implement
+        _ = implicitDecl
+        break
+      case .dollarIdentifier:
+        break
+      }
+    }
+    return nil
+  }
+
+  /// Returns the type declaration object associated with the `Syntax` node.
+  /// If there's no declaration created, create an instance on demand, and cache it.
+  func typeDeclaration(for node: some SyntaxProtocol) throws -> SwiftTypeDeclaration? {
+    if let found = typeDecls[node.id] {
+      return found
+    }
+
+    let typeDecl: SwiftTypeDeclaration
+    switch Syntax(node).as(SyntaxEnum.self) {
+    case .genericParameter(let node):
+      typeDecl = SwiftGenericParameterDeclaration(moduleName: symbolTable.moduleName, node: node)
+    case .classDecl(let node):
+      typeDecl = try nominalTypeDeclaration(for: node)
+    case .actorDecl(let node):
+      typeDecl = try nominalTypeDeclaration(for: node)
+    case .structDecl(let node):
+      typeDecl = try nominalTypeDeclaration(for: node)
+    case .enumDecl(let node):
+      typeDecl = try nominalTypeDeclaration(for: node)
+    case .protocolDecl(let node):
+      typeDecl = try nominalTypeDeclaration(for: node)
+    case .typeAliasDecl:
+      fatalError("typealias not implemented")
+    case .associatedTypeDecl:
+      fatalError("associatedtype not implemented")
+    default:
+      throw TypeLookupError.notType(Syntax(node))
+    }
+
+    typeDecls[node.id] = typeDecl
+    return typeDecl
+  }
+
+  /// Create a nominal type declaration instance for the specified syntax node.
+  private func nominalTypeDeclaration(for node: NominalTypeDeclSyntaxNode) throws -> SwiftNominalTypeDeclaration {
+    SwiftNominalTypeDeclaration(
+      moduleName: self.symbolTable.moduleName,
+      parent: try parentTypeDecl(for: node),
+      node: node
+    )
+  }
+
+  /// Find a parent nominal type declaration of the specified syntax node.
+  private func parentTypeDecl(for node: some DeclSyntaxProtocol) throws -> SwiftNominalTypeDeclaration? {
+    var node: DeclSyntax = DeclSyntax(node)
+    while let parentDecl = node.ancestorDecl {
+      switch parentDecl.as(DeclSyntaxEnum.self) {
+      case .structDecl, .classDecl, .actorDecl, .enumDecl, .protocolDecl:
+        return (try typeDeclaration(for: parentDecl) as! SwiftNominalTypeDeclaration)
+      default:
+        node = parentDecl
+        continue
+      }
+    }
+    return nil
+  }
+}
+
+enum TypeLookupError: Error {
+  case notType(Syntax)
+}

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -37,6 +37,7 @@ func assertOutput(
   column: Int = #column
 ) throws {
   var config = Configuration()
+  config.logLevel = .trace
   config.swiftModule = swiftModuleName
   let translator = Swift2JavaTranslator(config: config)
   translator.dependenciesClasses = Array(javaClassLookupTable.keys)

--- a/Tests/JExtractSwiftTests/DataImportTests.swift
+++ b/Tests/JExtractSwiftTests/DataImportTests.swift
@@ -28,7 +28,7 @@ final class DataImportTests {
     """
     import Foundation
     
-    public func receiveDataProtocol(dat: some DataProtocol)
+    public func receiveDataProtocol<T: DataProtocol>(dat: some DataProtocol, dat2: T?)
     """
 
 
@@ -342,9 +342,9 @@ final class DataImportTests {
         import Foundation
         """,
         """
-        @_cdecl("swiftjava_SwiftModule_receiveDataProtocol_dat")
-        public func swiftjava_SwiftModule_receiveDataProtocol_dat(_ dat: UnsafeRawPointer) {
-          receiveDataProtocol(dat: dat.assumingMemoryBound(to: Data.self).pointee)
+        @_cdecl("swiftjava_SwiftModule_receiveDataProtocol_dat_dat2")
+        public func swiftjava_SwiftModule_receiveDataProtocol_dat_dat2(_ dat: UnsafeRawPointer, _ dat2: UnsafeRawPointer?) {
+          receiveDataProtocol(dat: dat.assumingMemoryBound(to: Data.self).pointee, dat2: dat2?.assumingMemoryBound(to: Data.self).pointee)
         }
         """,
 
@@ -365,22 +365,23 @@ final class DataImportTests {
         """
         /**
          * {@snippet lang=c :
-         * void swiftjava_SwiftModule_receiveDataProtocol_dat(const void *dat)
+         * void swiftjava_SwiftModule_receiveDataProtocol_dat_dat2(const void *dat, const void *dat2)
          * }
          */
-        private static class swiftjava_SwiftModule_receiveDataProtocol_dat {
+        private static class swiftjava_SwiftModule_receiveDataProtocol_dat_dat2 {
           private static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /* dat: */SwiftValueLayout.SWIFT_POINTER
+            /* dat: */SwiftValueLayout.SWIFT_POINTER,
+            /* dat2: */SwiftValueLayout.SWIFT_POINTER
           );
           private static final MemorySegment ADDR =
-            SwiftModule.findOrThrow("swiftjava_SwiftModule_receiveDataProtocol_dat");
+            SwiftModule.findOrThrow("swiftjava_SwiftModule_receiveDataProtocol_dat_dat2");
           private static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
-          public static void call(java.lang.foreign.MemorySegment dat) {
+          public static void call(java.lang.foreign.MemorySegment dat, java.lang.foreign.MemorySegment dat2) {
             try {
               if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall(dat);
+                CallTraces.traceDowncall(dat, dat2);
               }
-              HANDLE.invokeExact(dat);
+              HANDLE.invokeExact(dat, dat2);
             } catch (Throwable ex$) {
               throw new AssertionError("should not reach here", ex$);
             }
@@ -392,11 +393,11 @@ final class DataImportTests {
         /**
          * Downcall to Swift:
          * {@snippet lang=swift :
-         * public func receiveDataProtocol(dat: some DataProtocol)
+         * public func receiveDataProtocol<T: DataProtocol>(dat: some DataProtocol, dat2: T?)
          * }
          */
-        public static void receiveDataProtocol(Data dat) {
-          swiftjava_SwiftModule_receiveDataProtocol_dat.call(dat.$memorySegment());
+        public static void receiveDataProtocol(Data dat, Optional<Data> dat2) {
+          swiftjava_SwiftModule_receiveDataProtocol_dat_dat2.call(dat.$memorySegment(), SwiftRuntime.toOptionalSegmentInstance(dat2));
         }
         """,
 

--- a/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
+++ b/Tests/JExtractSwiftTests/FunctionLoweringTests.swift
@@ -404,6 +404,27 @@ final class FunctionLoweringTests {
       """)
   }
 
+  @Test("Lowering generic parameters")
+  func genericParam() throws {
+    try assertLoweredFunction(
+      """
+      func fn<T, U: DataProtocol>(x: T, y: U?) where T: DataProtocol
+      """,
+      sourceFile: """
+      import Foundation
+      """,
+      expectedCDecl: """
+      @_cdecl("c_fn")
+      public func c_fn(_ x: UnsafeRawPointer, _ y: UnsafeRawPointer?) {
+        fn(x: x.assumingMemoryBound(to: Data.self).pointee, y: y?.assumingMemoryBound(to: Data.self).pointee)
+      }
+      """,
+      expectedCFunction: """
+      void c_fn(const void *x, const void *y)
+      """
+    )
+  }
+
   @Test("Lowering read accessor")
   func lowerGlobalReadAccessor() throws {
     try assertLoweredVariableAccessor(


### PR DESCRIPTION
Limited generic parameter support in JExtract

* Integrate `SwiftLexicalLookup` for unqualified type lookups. This is required to find the generic parameter declaration from parameter types.
* Introduce `SwiftTypeLookupContext` as a facade for `SwiftLexicalLookup` and a cached conversion from Syntax to `SwiftTypeDeclaration` instance. This wraps and replaces `SwiftSymbolTable`.
* Introduce `SwiftGenericParameterDeclaration` as a subclass of `SwiftTypeDeclaration` to represent generic parameters.
* Store generic parameters and requirements in `SwiftFunctionSignature`.
* `SwiftType.representativeConcreteTypeIn()` for getting `Data` from `T: DataProtocol` type.