### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ func findJavaHome() -> String {
   }
 
 
-  if ProcessInfo.processInfo.environment["SPI_BUILD"] == "1" {
+  if ProcessInfo.processInfo.environment["SPI_PROCESSING"] == "1" {
     // just ignore that we're missing a JAVA_HOME when building in Swift Package Index
     return ""
   }


### PR DESCRIPTION
This check needs to happen at an earlier stage than SPI's build system and we've just added a new variable to indicate that things are happening in the context of SPI's processing in general via SPI_PROCESSING.

FYI @ktoso 