### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,8 @@ func findJavaHome() -> String {
   }
 
 
-  if ProcessInfo.processInfo.environment["SPI_PROCESSING"] == "1" {
-    // just ignore that we're missing a JAVA_HOME when building in Swift Package Index
+  if ProcessInfo.processInfo.environment["SPI_PROCESSING"] == "1" && ProcessInfo.processInfo.environment["SPI_BUILD"] == nil {
+    // Just ignore that we're missing a JAVA_HOME when building in Swift Package Index during general processing where no Java is needed. However, do _not_ suppress the error during SPI's compatibility build stage where Java is required.
     return ""
   }
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")


### PR DESCRIPTION
Improve SPI JAVA_HOME check: don't suppress proper error messaging when the package manifest is used in the context of the SPI's build system.

(This won't make a difference once Java is actually installed on our builders but gives a proper error message in the logs until that's the case.)