### PR TITLE
replace Java2Swift.config with swift-java.config

### DIFF
--- a/Sources/SwiftJavaDocumentation/Documentation.docc/SwiftJavaCommandLineTool.md
+++ b/Sources/SwiftJavaDocumentation/Documentation.docc/SwiftJavaCommandLineTool.md
@@ -57,7 +57,7 @@ OPTIONS:
                           The name of the Swift module into which the resulting Swift types will be generated.
   --depends-on <depends-on>
                           A swift-java configuration file for a given Swift module name on which this module depends,
-                          e.g., JavaKitJar=Sources/JavaKitJar/Java2Swift.config. There should be one of these options
+                          e.g., JavaKitJar=Sources/JavaKitJar/swift-java.config. There should be one of these options
                           for each Swift module that this module depends on (transitively) that contains wrapped Java sources.
   --swift-native-implementation <swift-native-implementation>
                           The names of Java classes whose declared native methods will be implemented in Swift.

--- a/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
@@ -70,7 +70,7 @@ extension SwiftJava {
     @Option(
       help: """
             A swift-java configuration file for a given Swift module name on which this module depends,
-            e.g., Sources/JavaKitJar/Java2Swift.config. There should be one of these options
+            e.g., Sources/JavaKitJar/swift-java.config. There should be one of these options
             for each Swift module that this module depends on (transitively) that contains wrapped Java sources.
             """
     )

--- a/Sources/SwiftJavaTool/Commands/WrapJavaCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/WrapJavaCommand.swift
@@ -40,7 +40,7 @@ extension SwiftJava {
     @Option(
       help: """
             A swift-java configuration file for a given Swift module name on which this module depends,
-            e.g., JavaKitJar=Sources/JavaKitJar/Java2Swift.config. There should be one of these options
+            e.g., JavaKitJar=Sources/JavaKitJar/swift-java.config. There should be one of these options
             for each Swift module that this module depends on (transitively) that contains wrapped Java sources.
             """
     )


### PR DESCRIPTION
**Reduce confusion for new contributors and users of the swift-java package with an updated config filename**

## Summary
Update subcommand help message from JavaSwift.config with swift-java.config

## Changes
- Replace Java2Swift.config in SwiftJavaCommandLineTool.md, JExtractCommand.swift, and WrapJavaCommand.swift
- "--depends-on" help message, e.g., Sources/JavaKitJar/swift-java.config" from Java2Swift.config 

## Type of Change
- [x] Documentation improvement