### PR TITLE
[JExtract] Fix importing extensions

### DIFF
--- a/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift.org project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -84,7 +84,7 @@ final class Swift2JavaVisitor {
   }
 
   func visit(extensionDecl node: ExtensionDeclSyntax, in parent: ImportedNominalType?) {
-    guard parent != nil else {
+    guard parent == nil else {
       // 'extension' in a nominal type is invalid. Ignore
       return
     }

--- a/Tests/JExtractSwiftTests/ExtensionImportTests.swift
+++ b/Tests/JExtractSwiftTests/ExtensionImportTests.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import JExtractSwiftLib
+import Testing
+
+final class ExtensionImportTests {
+  let interfaceFile =
+    """
+    extension MyStruct {
+      public func methodInExtension() {}
+    }
+
+    public struct MyStruct {}
+    """
+
+  @Test("Import extensions: Swift thunks")
+  func data_swiftThunk() throws {
+    try assertOutput(
+      input: interfaceFile, .ffm, .swift,
+      expectedChunks: [
+        """
+        @_cdecl("swiftjava_getType_SwiftModule_MyStruct")
+        public func swiftjava_getType_SwiftModule_MyStruct() -> UnsafeMutableRawPointer /* Any.Type */ {
+          return unsafeBitCast(MyStruct.self, to: UnsafeMutableRawPointer.self)
+        }
+        """,
+        """
+        @_cdecl("swiftjava_SwiftModule_MyStruct_methodInExtension")
+        public func swiftjava_SwiftModule_MyStruct_methodInExtension(_ self: UnsafeRawPointer) {
+          self.assumingMemoryBound(to: MyStruct.self).pointee.methodInExtension()
+        }
+        """
+      ]
+    )
+  }
+}


### PR DESCRIPTION
The condition was incorrect in `Swift2JavaVisitor.visit(extensionDecl:in:)`. All valid extensions were simply ignored.