### PR TITLE
WIP: [JExtract] Add `auto` arena to SwiftKitCore and add memory management options

### DIFF
--- a/Samples/JExtractJNISampleApp/src/main/java/com/example/swift/HelloJava2SwiftJNI.java
+++ b/Samples/JExtractJNISampleApp/src/main/java/com/example/swift/HelloJava2SwiftJNI.java
@@ -18,8 +18,8 @@ package com.example.swift;
 
 // Import javakit/swiftkit support libraries
 
+import org.swift.swiftkit.core.SwiftArena;
 import org.swift.swiftkit.core.SwiftLibraries;
-import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
 
 public class HelloJava2SwiftJNI {
 
@@ -41,7 +41,7 @@ public class HelloJava2SwiftJNI {
 
         MySwiftClass.method();
 
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass myClass = MySwiftClass.init(10, 5, arena);
             MySwiftClass myClass2 = MySwiftClass.init(arena);
 

--- a/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -15,7 +15,7 @@
 package com.example.swift;
 
 import org.junit.jupiter.api.Test;
-import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
+import org.swift.swiftkit.core.SwiftArena;
 
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MySwiftClassTest {
     @Test
     void init_noParameters() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(arena);
             assertNotNull(c);
         }
@@ -34,7 +34,7 @@ public class MySwiftClassTest {
 
     @Test
     void init_withParameters() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(1337, 42, arena);
             assertNotNull(c);
         }
@@ -42,7 +42,7 @@ public class MySwiftClassTest {
 
     @Test
     void sum() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertEquals(30, c.sum());
         }
@@ -50,7 +50,7 @@ public class MySwiftClassTest {
 
     @Test
     void xMultiplied() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertEquals(200, c.xMultiplied(10));
         }
@@ -58,7 +58,7 @@ public class MySwiftClassTest {
 
     @Test
     void throwingFunction() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             Exception exception = assertThrows(Exception.class, () -> c.throwingFunction());
 
@@ -68,7 +68,7 @@ public class MySwiftClassTest {
 
     @Test
     void constant() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertEquals(100, c.getConstant());
         }
@@ -76,7 +76,7 @@ public class MySwiftClassTest {
 
     @Test
     void mutable() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertEquals(0, c.getMutable());
             c.setMutable(42);
@@ -86,7 +86,7 @@ public class MySwiftClassTest {
 
     @Test
     void product() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertEquals(200, c.getProduct());
         }
@@ -94,7 +94,7 @@ public class MySwiftClassTest {
 
     @Test
     void throwingVariable() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
 
             Exception exception = assertThrows(Exception.class, () -> c.getThrowingVariable());
@@ -105,7 +105,7 @@ public class MySwiftClassTest {
 
     @Test
     void mutableDividedByTwo() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertEquals(0, c.getMutableDividedByTwo());
             c.setMutable(20);
@@ -117,7 +117,7 @@ public class MySwiftClassTest {
 
     @Test
     void isWarm() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(20, 10, arena);
             assertFalse(c.isWarm());
         }
@@ -125,7 +125,7 @@ public class MySwiftClassTest {
 
     @Test
     void sumWithX() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c1 = MySwiftClass.init(20, 10, arena);
             MySwiftClass c2 = MySwiftClass.init(50, 10, arena);
             assertEquals(70, c1.sumX(c2));
@@ -134,7 +134,7 @@ public class MySwiftClassTest {
 
     @Test
     void copy() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c1 = MySwiftClass.init(20, 10, arena);
             MySwiftClass c2 = c1.copy(arena);
 
@@ -146,7 +146,7 @@ public class MySwiftClassTest {
 
     @Test
     void addXWithJavaLong() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c1 = MySwiftClass.init(20, 10, arena);
             Long javaLong = 50L;
             assertEquals(70, c1.addXWithJavaLong(javaLong));

--- a/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftStructTest.java
+++ b/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/MySwiftStructTest.java
@@ -16,13 +16,14 @@ package com.example.swift;
 
 import org.junit.jupiter.api.Test;
 import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
+import org.swift.swiftkit.core.SwiftArena;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MySwiftStructTest {
     @Test
     void init() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftStruct s = MySwiftStruct.init(1337, 42, arena);
             assertEquals(1337, s.getCapacity());
             assertEquals(42, s.getLen());
@@ -31,7 +32,7 @@ public class MySwiftStructTest {
 
     @Test
     void getAndSetLen() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftStruct s = MySwiftStruct.init(1337, 42, arena);
             s.setLen(100);
             assertEquals(100, s.getLen());
@@ -40,7 +41,7 @@ public class MySwiftStructTest {
 
     @Test
     void increaseCap() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftStruct s = MySwiftStruct.init(1337, 42, arena);
             long newCap = s.increaseCap(10);
             assertEquals(1347, newCap);

--- a/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/OptionalsTest.java
+++ b/Samples/JExtractJNISampleApp/src/test/java/com/example/swift/OptionalsTest.java
@@ -15,7 +15,7 @@
 package com.example.swift;
 
 import org.junit.jupiter.api.Test;
-import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
+import org.swift.swiftkit.core.SwiftArena;
 
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -82,7 +82,7 @@ public class OptionalsTest {
 
     @Test
     void optionalClass() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(arena);
             assertEquals(Optional.empty(), MySwiftLibrary.optionalClass(Optional.empty(), arena));
             Optional<MySwiftClass> optionalClass = MySwiftLibrary.optionalClass(Optional.of(c), arena);
@@ -99,7 +99,7 @@ public class OptionalsTest {
 
     @Test
     void multipleOptionals() {
-        try (var arena = new ConfinedSwiftMemorySession()) {
+        try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c = MySwiftClass.init(arena);
             OptionalLong result = MySwiftLibrary.multipleOptionals(
                     Optional.of((byte) 1),

--- a/Sources/JavaKitConfigurationShared/Configuration.swift
+++ b/Sources/JavaKitConfigurationShared/Configuration.swift
@@ -51,6 +51,11 @@ public struct Configuration: Codable {
     minimumInputAccessLevelMode ?? .default
   }
 
+  public var memoryManagementMode: JExtractMemoryManagementMode?
+  public var effectiveMemoryManagementMode: JExtractMemoryManagementMode {
+    memoryManagementMode ?? .forceExplicit
+  }
+
   // ==== java 2 swift ---------------------------------------------------------
 
   /// The Java class path that should be passed along to the swift-java tool.

--- a/Sources/JavaKitConfigurationShared/Configuration.swift
+++ b/Sources/JavaKitConfigurationShared/Configuration.swift
@@ -53,7 +53,7 @@ public struct Configuration: Codable {
 
   public var memoryManagementMode: JExtractMemoryManagementMode?
   public var effectiveMemoryManagementMode: JExtractMemoryManagementMode {
-    memoryManagementMode ?? .forceExplicit
+    memoryManagementMode ?? .default
   }
 
   // ==== java 2 swift ---------------------------------------------------------

--- a/Sources/JavaKitConfigurationShared/GenerationMode.swift
+++ b/Sources/JavaKitConfigurationShared/GenerationMode.swift
@@ -90,4 +90,15 @@ public enum JExtractMemoryManagementMode: String, Codable {
   /// Force all memory management to a default global automatic `SwiftArena`
   /// that will deallocate memory when the GC decides to.
   case forceAutomatic
+
+  public static var `default`: Self {
+    .forceExplicit
+  }
+
+  public var requiresGlobalArena: Bool {
+    switch self {
+    case .forceExplicit: false
+    case .allowAutomatic, .forceAutomatic: true
+    }
+  }
 }

--- a/Sources/JavaKitConfigurationShared/GenerationMode.swift
+++ b/Sources/JavaKitConfigurationShared/GenerationMode.swift
@@ -76,3 +76,18 @@ extension JExtractMinimumAccessLevelMode {
     .public
   }
 }
+
+
+/// Configures how memory should be managed by the user
+public enum JExtractMemoryManagementMode: String, Codable {
+  /// Force users to provide an explicit `SwiftArena` to all calls that require them.
+  case forceExplicit
+
+  /// Provide both explicit `SwiftArena` support
+  /// and a default global automatic `SwiftArena` that will deallocate memory when the GC decides to.
+  case allowAutomatic
+
+  /// Force all memory management to a default global automatic `SwiftArena`
+  /// that will deallocate memory when the GC decides to.
+  case forceAutomatic
+}

--- a/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
@@ -67,6 +67,9 @@ extension SwiftJava {
     @Option(help: "The lowest access level of Swift declarations that should be extracted, defaults to 'public'.")
     var minimumInputAccessLevel: JExtractMinimumAccessLevelMode = .default
 
+    @Option(help: "The memory management mode to use for the generated code. By default, the user must explicitly provide `SwiftArena` to all calls that require it. By choosing `allow-automatic`, user can omit this parameter and a global GC-based arena will be used. `force-automatic` removes all explicit memory management.")
+    var memoryManagementMode: JExtractMemoryManagementMode = .forceExplicit
+
     @Option(
       help: """
             A swift-java configuration file for a given Swift module name on which this module depends,
@@ -89,6 +92,7 @@ extension SwiftJava.JExtractCommand {
     config.writeEmptyFiles = writeEmptyFiles
     config.unsignedNumbersMode = unsignedNumbers
     config.minimumInputAccessLevelMode = minimumInputAccessLevel
+    config.memoryManagementMode = memoryManagementMode
 
     try checkModeCompatibility()
 
@@ -116,6 +120,10 @@ extension SwiftJava.JExtractCommand {
         throw IllegalModeCombinationError("JNI mode does not support '\(JExtractUnsignedIntegerMode.wrapGuava)' Unsigned integer mode! \(Self.helpMessage)")
       case .wrapGuava:
         () // OK
+      }
+    } else if self.mode == .ffm {
+      guard self.memoryManagementMode == .forceExplicit else {
+        throw IllegalModeCombinationError("FFM mode does not support '\(self.memoryManagementMode)' memory management mode! \(Self.helpMessage)")
       }
     }
   }
@@ -148,3 +156,4 @@ struct IllegalModeCombinationError: Error {
 extension JExtractGenerationMode: ExpressibleByArgument {}
 extension JExtractUnsignedIntegerMode: ExpressibleByArgument {}
 extension JExtractMinimumAccessLevelMode: ExpressibleByArgument {}
+extension JExtractMemoryManagementMode: ExpressibleByArgument {}

--- a/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
@@ -68,7 +68,7 @@ extension SwiftJava {
     var minimumInputAccessLevel: JExtractMinimumAccessLevelMode = .default
 
     @Option(help: "The memory management mode to use for the generated code. By default, the user must explicitly provide `SwiftArena` to all calls that require it. By choosing `allow-automatic`, user can omit this parameter and a global GC-based arena will be used. `force-automatic` removes all explicit memory management.")
-    var memoryManagementMode: JExtractMemoryManagementMode = .forceExplicit
+    var memoryManagementMode: JExtractMemoryManagementMode = .default
 
     @Option(
       help: """

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/AutoSwiftMemorySession.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/AutoSwiftMemorySession.java
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package org.swift.swiftkit.core;
+
+
+import org.swift.swiftkit.core.ref.Cleaner;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A memory session which manages registered objects via the Garbage Collector.
+ *
+ * <p> When registered Java wrapper classes around native Swift instances {@link SwiftInstance},
+ * are eligible for collection, this will trigger the cleanup of the native resources as well.
+ *
+ * <p> This memory session is LESS reliable than using a {@link ConfinedSwiftMemorySession} because
+ * the timing of when the native resources are cleaned up is somewhat undefined, and rely on the
+ * system GC. Meaning, that if an object nas been promoted to an old generation, there may be a
+ * long time between the resource no longer being referenced "in Java" and its native memory being released,
+ * and also the deinit of the Swift type being run.
+ *
+ * <p> This can be problematic for Swift applications which rely on quick release of resources, and may expect
+ * the deinits to run in expected and "quick" succession.
+ *
+ * <p> Whenever possible, prefer using an explicitly managed {@link SwiftArena}, such as {@link SwiftArena#ofConfined()}.
+ */
+final class AutoSwiftMemorySession implements SwiftArena {
+    private final Cleaner cleaner;
+
+    public AutoSwiftMemorySession(ThreadFactory cleanerThreadFactory) {
+        this.cleaner = Cleaner.create(cleanerThreadFactory);
+    }
+
+    @Override
+    public void register(SwiftInstance instance) {
+        Objects.requireNonNull(instance, "value");
+
+        // We make sure we don't capture `instance` in the
+        // cleanup action, so we can ignore the warning below.
+        var cleanupAction = instance.$createCleanup();
+        cleaner.register(instance, cleanupAction);
+    }
+}

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/AutoSwiftMemorySession.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/AutoSwiftMemorySession.java
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ConfinedSwiftMemorySession.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ConfinedSwiftMemorySession.java
@@ -28,17 +28,13 @@ public class ConfinedSwiftMemorySession implements ClosableSwiftArena {
 
     final ConfinedResourceList resources;
 
-    public ConfinedSwiftMemorySession() {
-        this(Thread.currentThread());
-    }
-
     public ConfinedSwiftMemorySession(Thread owner) {
         this.owner = owner;
         this.state = new AtomicInteger(ACTIVE);
         this.resources = new ConfinedResourceList();
     }
 
-    public void checkValid() throws RuntimeException {
+    void checkValid() throws RuntimeException {
         if (this.owner != null && this.owner != Thread.currentThread()) {
             throw new WrongThreadException(String.format("ConfinedSwift arena is confined to %s but was closed from %s!", this.owner, Thread.currentThread()));
         } else if (this.state.get() < ACTIVE) {

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
@@ -56,13 +56,8 @@ public abstract class JNISwiftInstance extends SwiftInstance {
 
     @Override
     public SwiftInstanceCleanup $createCleanup() {
-        final AtomicBoolean statusDestroyedFlag = $statusDestroyedFlag();
-        Runnable markAsDestroyed = new Runnable() {
-            @Override
-            public void run() {
-                statusDestroyedFlag.set(true);
-            }
-        };
+        var statusDestroyedFlag = $statusDestroyedFlag();
+        Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
 
         return new JNISwiftInstanceCleanup(this.$createDestroyFunction(), markAsDestroyed);
     }

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftArena.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftArena.java
@@ -14,6 +14,8 @@
 
 package org.swift.swiftkit.core;
 
+import java.util.concurrent.ThreadFactory;
+
 /**
  * A Swift arena manages Swift allocated memory for classes, structs, enums etc.
  * When an arena is closed, it will destroy all managed swift objects in a way appropriate to their type.
@@ -27,6 +29,15 @@ public interface SwiftArena  {
      * Its memory should be considered managed by this arena, and be destroyed when the arena is closed.
      */
     void register(SwiftInstance instance);
+
+    static ClosableSwiftArena ofConfined() {
+        return new ConfinedSwiftMemorySession(Thread.currentThread());
+    }
+
+    static SwiftArena ofAuto() {
+        ThreadFactory cleanerThreadFactory = r -> new Thread(r, "AutoSwiftArenaCleanerThread");
+        return new AutoSwiftMemorySession(cleanerThreadFactory);
+    }
 }
 
 /**

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/Cleaner.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/Cleaner.java
@@ -1,0 +1,51 @@
+package org.swift.swiftkit.core.ref;
+
+import java.lang.ref.ReferenceQueue;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+
+public class Cleaner implements Runnable {
+    final ReferenceQueue<Object> referenceQueue;
+    final LinkedList<PhantomCleanable> list;
+
+    private Cleaner() {
+        this.referenceQueue = new ReferenceQueue<>();
+        this.list = new LinkedList<>();
+    }
+
+    public static Cleaner create(ThreadFactory threadFactory) {
+        Cleaner cleaner = new Cleaner();
+        cleaner.start(threadFactory);
+        return cleaner;
+    }
+
+    void start(ThreadFactory threadFactory) {
+        // This makes sure the linked list is not empty when the thread starts,
+        // and the thread will run at least until the cleaner itself can be GCed.
+        new PhantomCleanable(this, this, () -> {});
+
+        Thread thread = threadFactory.newThread(this);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    public void register(Object resourceHolder, Runnable cleaningAction) {
+        Objects.requireNonNull(resourceHolder, "resourceHolder");
+        Objects.requireNonNull(cleaningAction, "cleaningAction");
+        new PhantomCleanable(resourceHolder, this, cleaningAction);
+    }
+
+    @Override
+    public void run() {
+        while (!list.isEmpty()) {
+            try {
+                PhantomCleanable removed = (PhantomCleanable) referenceQueue.remove(60 * 1000L);
+                removed.cleanup();
+            } catch (Throwable e) {
+                // ignore exceptions from the cleanup action
+                // (including interruption of cleanup thread)
+            }
+        }
+    }
+}

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/Cleaner.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/Cleaner.java
@@ -1,17 +1,19 @@
 package org.swift.swiftkit.core.ref;
 
 import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 
 public class Cleaner implements Runnable {
     final ReferenceQueue<Object> referenceQueue;
-    final LinkedList<PhantomCleanable> list;
+    final List<PhantomCleanable> list;
 
     private Cleaner() {
         this.referenceQueue = new ReferenceQueue<>();
-        this.list = new LinkedList<>();
+        this.list = Collections.synchronizedList(new LinkedList<>());
     }
 
     public static Cleaner create(ThreadFactory threadFactory) {

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/Cleaner.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/Cleaner.java
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 package org.swift.swiftkit.core.ref;
 
 import java.lang.ref.ReferenceQueue;

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/PhantomCleanable.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/PhantomCleanable.java
@@ -1,0 +1,26 @@
+package org.swift.swiftkit.core.ref;
+
+import java.lang.ref.PhantomReference;
+
+/**
+ * PhantomCleanableRef
+ *
+ * @author Mads Odgaard (202206257)
+ */
+public class PhantomCleanable extends PhantomReference<Object> {
+    private final Runnable cleanupAction;
+    private final Cleaner cleaner;
+
+    public PhantomCleanable(Object referent, Cleaner cleaner, Runnable cleanupAction) {
+        super(referent, cleaner.referenceQueue);
+        this.cleanupAction = cleanupAction;
+        this.cleaner = cleaner;
+        cleaner.list.add(this);
+    }
+
+    public void cleanup() {
+        if (cleaner.list.remove(this)) {
+            cleanupAction.run();
+        }
+    }
+}

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/PhantomCleanable.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/ref/PhantomCleanable.java
@@ -1,12 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 package org.swift.swiftkit.core.ref;
 
 import java.lang.ref.PhantomReference;
 
-/**
- * PhantomCleanableRef
- *
- * @author Mads Odgaard (202206257)
- */
 public class PhantomCleanable extends PhantomReference<Object> {
     private final Runnable cleanupAction;
     private final Cleaner cleaner;

--- a/SwiftKitCore/src/test/java/org/swift/swiftkit/AutoArenaTest.java
+++ b/SwiftKitCore/src/test/java/org/swift/swiftkit/AutoArenaTest.java
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package org.swift.swiftkit;
+
+import org.junit.jupiter.api.Test;
+import org.swift.swiftkit.core.JNISwiftInstance;
+import org.swift.swiftkit.core.SwiftArena;
+
+public class AutoArenaTest {
+
+    @Test
+    @SuppressWarnings("removal") // System.runFinalization() will be removed
+    public void cleaner_releases_native_resource() {
+        SwiftArena arena = SwiftArena.ofAuto();
+
+        // This object is registered to the arena.
+        var object = new FakeSwiftInstance(arena);
+        var statusDestroyedFlag = object.$statusDestroyedFlag();
+
+        // Release the object and hope it gets GC-ed soon
+
+        // noinspection UnusedAssignment
+        object = null;
+
+        var i = 1_000;
+        while (!statusDestroyedFlag.get()) {
+            System.runFinalization();
+            System.gc();
+
+            if (i-- < 1) {
+                throw new RuntimeException("Reference was not cleaned up! Did Cleaner not pick up the release?");
+            }
+        }
+    }
+
+    private static class FakeSwiftInstance extends JNISwiftInstance {
+        public FakeSwiftInstance(SwiftArena arena) {
+            super(1, arena);
+        }
+
+        protected Runnable $createDestroyFunction() {
+            return () -> {};
+        }
+    }
+}

--- a/SwiftKitCore/src/test/java/org/swift/swiftkit/AutoArenaTest.java
+++ b/SwiftKitCore/src/test/java/org/swift/swiftkit/AutoArenaTest.java
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
Since `java.lang.ref.Cleaner` is not available in Android (before API 34), we introduce our own `Cleaner` which is very similar to the original JDK implementation, but a few simplications for our use case. This allows us to introduce the `Auto` arena to the JNI mode through `SwiftArena.ofAuto()`.

In an ideal world we would somehow differentiate between users needing to support Android (use our own) and people just running on regular JVM (then we use the original `Cleaner`) - perhaps that is something we could look into in the future, by providing an Android "compatibility" library of `SwiftKitCore`.

On top of that we introduce a new "memory management mode" _(maybe we need a different name?)_. This mode can be specified using `--memory-management-mode` and has the following options:

- `force-explicit`: Generates only wrappers that require explicit passing of `SwifttArena`
- `allow-automatic`: Generates wrappers that use a default global auto arena, but also explicit APIs
- `force-automatic`: Generates only wrappers that use the global auto arena, completely removing the responsibility of the user to pass any `SwiftArena`s around.

This option is only supported in JNI for now.

Resolves #318 