### PR TITLE
jextract: hide memory location wrapping constructor, give it proper name

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/ConversionStep.swift
+++ b/Sources/JExtractSwiftLib/FFM/ConversionStep.swift
@@ -123,7 +123,7 @@ enum ConversionStep: Equatable {
       // of splatting out text.
       let renderedArgumentList = renderedArguments.joined(separator: ", ")
       return "\(raw: type.description)(\(raw: renderedArgumentList))"
-
+    
     case .tuplify(let elements):
       let renderedElements: [String] = elements.enumerated().map { (index, element) in
         element.asExprSyntax(placeholder: "\(placeholder)_\(index)", bodyItems: &bodyItems)!.description

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
@@ -684,7 +684,7 @@ extension FFMSwift2JavaGenerator {
           outParameters: [
             JavaParameter(name: "", type: javaType)
           ],
-          conversion: .constructSwiftValue(.placeholder, javaType)
+          conversion: .wrapMemoryAddressUnsafe(.placeholder, javaType)
         )
 
       case .tuple:
@@ -731,6 +731,9 @@ extension FFMSwift2JavaGenerator {
 
     // Call 'new \(Type)(\(placeholder), swiftArena$)'.
     indirect case constructSwiftValue(JavaConversionStep, JavaType)
+
+    /// Call the `MyType.wrapMemoryAddressUnsafe` in order to wrap a memory address using the Java binding type
+    indirect case wrapMemoryAddressUnsafe(JavaConversionStep, JavaType)
 
     // Construct the type using the placeholder as arguments.
     indirect case construct(JavaConversionStep, JavaType)

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -216,8 +216,21 @@ extension FFMSwift2JavaGenerator {
 
       printer.print(
         """
-        public \(decl.swiftNominal.name)(MemorySegment segment, AllocatingSwiftArena arena) {
+        private \(decl.swiftNominal.name)(MemorySegment segment, AllocatingSwiftArena arena) {
           super(segment, arena);
+        }
+
+        /** 
+         * Assume that the passed {@code MemorySegment} represents a memory address of a {@link \(decl.swiftNominal.name)}.
+         * <p/>
+         * Warnings:
+         * <ul>
+         *   <li>No checks are performed about the compatibility of the pointed at memory and the actual \(decl.swiftNominal.name) types.</li>
+         *   <li>This operation does not copy, or retain, the pointed at pointer, so its lifetime must be ensured manually to be valid when wrapping.</li>
+         * </ul>
+         */
+        public static \(decl.swiftNominal.name) wrapMemoryAddressUnsafe(MemorySegment selfPointer, AllocatingSwiftArena swiftArena) {
+          return new \(decl.swiftNominal.name)(selfPointer, swiftArena);
         }
         """
       )

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -117,8 +117,21 @@ extension JNISwift2JavaGenerator {
 
       printer.print(
         """
-        public \(decl.swiftNominal.name)(long selfPointer, SwiftArena swiftArena) {
+        private \(decl.swiftNominal.name)(long selfPointer, SwiftArena swiftArena) {
           super(selfPointer, swiftArena);
+        }
+
+        /** 
+         * Assume that the passed {@code long} represents a memory address of a {@link \(decl.swiftNominal.name)}.
+         * <p/>
+         * Warnings:
+         * <ul>
+         *   <li>No checks are performed about the compatibility of the pointed at memory and the actual \(decl.swiftNominal.name) types.</li>
+         *   <li>This operation does not copy, or retain, the pointed at pointer, so its lifetime must be ensured manually to be valid when wrapping.</li>
+         * </ul>
+         */
+        public static \(decl.swiftNominal.name) wrapMemoryAddressUnsafe(long selfPointer, SwiftArena swiftArena) {
+          return new \(decl.swiftNominal.name)(selfPointer, swiftArena);
         }
         """
       )

--- a/Tests/JExtractSwiftTests/DataImportTests.swift
+++ b/Tests/JExtractSwiftTests/DataImportTests.swift
@@ -86,7 +86,7 @@ final class DataImportTests {
       ]
     )
   }
-
+  
   @Test("Import Data: JavaBindings")
   func data_javaBindings() throws {
 
@@ -167,7 +167,7 @@ final class DataImportTests {
         public static Data returnData(AllocatingSwiftArena swiftArena$) {
           MemorySegment _result = swiftArena$.allocate(Data.$LAYOUT);
           swiftjava_SwiftModule_returnData.call(_result);
-          return new Data(_result, swiftArena$);
+          return Data.wrapMemoryAddressUnsafe(_result, swiftArena$);
         }
         """,
 
@@ -210,7 +210,7 @@ final class DataImportTests {
         public static Data init(java.lang.foreign.MemorySegment bytes, long count, AllocatingSwiftArena swiftArena$) {
           MemorySegment _result = swiftArena$.allocate(Data.$LAYOUT);
           swiftjava_SwiftModule_Data_init_bytes_count.call(bytes, count, _result);
-          return new Data(_result, swiftArena$);
+          return Data.wrapMemoryAddressUnsafe(_result, swiftArena$);
         }
         """,
 
@@ -408,4 +408,5 @@ final class DataImportTests {
       ]
     )
   }
+  
 }

--- a/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
@@ -66,11 +66,17 @@ struct JNIClassTests {
             System.loadLibrary(LIB_NAME);
             return true;
           }
-
-          public MyClass(long selfPointer, SwiftArena swiftArena) {
+        """,
+        """
+          private MyClass(long selfPointer, SwiftArena swiftArena) {
             super(selfPointer, swiftArena);
           }
         """,
+        """
+        public static MyClass wrapMemoryAddressUnsafe(long selfPointer, SwiftArena swiftArena) {
+          return new MyClass(selfPointer, swiftArena);
+        }
+        """
       ])
     try assertOutput(
       input: source,
@@ -164,7 +170,7 @@ struct JNIClassTests {
           * }
           */
         public static MyClass init(long x, long y, SwiftArena swiftArena$) {
-          return new MyClass(MyClass.$init(x, y), swiftArena$);
+          return MyClass.wrapMemoryAddressUnsafe(MyClass.$init(x, y), swiftArena$);
         }
         """,
         """
@@ -175,7 +181,7 @@ struct JNIClassTests {
           * }
           */
         public static MyClass init(SwiftArena swiftArena$) {
-          return new MyClass(MyClass.$init(), swiftArena$);
+          return MyClass.wrapMemoryAddressUnsafe(MyClass.$init(), swiftArena$);
         }
         """,
         """
@@ -309,7 +315,7 @@ struct JNIClassTests {
           * }
           */
         public MyClass copy(SwiftArena swiftArena$) {
-          return new MyClass(MyClass.$copy(this.$memoryAddress()), swiftArena$);
+          return MyClass.wrapMemoryAddressUnsafe(MyClass.$copy(this.$memoryAddress()), swiftArena$);
         }
         """,
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
@@ -158,7 +158,7 @@ struct JNIOptionalTests {
         public static Optional<MyClass> optionalClass(Optional<MyClass> arg, SwiftArena swiftArena$) {
           byte[] result_discriminator$ = new byte[1];
           long result$ = SwiftModule.$optionalClass(arg.map(MyClass::$memoryAddress).orElse(0L), result_discriminator$);
-          return (result_discriminator$[0] == 1) ? Optional.of(new MyClass(result$, swiftArena$)) : Optional.empty();
+          return (result_discriminator$[0] == 1) ? Optional.of(MyClass.wrapMemoryAddressUnsafe(result$, swiftArena$)) : Optional.empty();
         }
       """,
       """

--- a/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
@@ -56,10 +56,16 @@ struct JNIStructTests {
             System.loadLibrary(LIB_NAME);
             return true;
           }
-
-          public MyStruct(long selfPointer, SwiftArena swiftArena) {
+        """,
+        """
+          private MyStruct(long selfPointer, SwiftArena swiftArena) {
             super(selfPointer, swiftArena);
           }
+        """,
+        """
+        public static MyStruct wrapMemoryAddressUnsafe(long selfPointer, SwiftArena swiftArena) {
+          return new MyStruct(selfPointer, swiftArena);
+        }
         """
       ])
     try assertOutput(
@@ -110,7 +116,7 @@ struct JNIStructTests {
           * }
           */
         public static MyStruct init(long x, long y, SwiftArena swiftArena$) {
-          return new MyStruct(MyStruct.$init(x, y), swiftArena$);
+          return MyStruct.wrapMemoryAddressUnsafe(MyStruct.$init(x, y), swiftArena$);
         }
         """,
         """

--- a/Tests/JExtractSwiftTests/MemoryManagementModeTests.swift
+++ b/Tests/JExtractSwiftTests/MemoryManagementModeTests.swift
@@ -43,7 +43,7 @@ struct MemoryManagementModeTests {
           * }
           */
           public static MyClass f(SwiftArena swiftArena$) {
-            return new MyClass(SwiftModule.$f(), swiftArena$);
+            return MyClass.wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena$);
           }
         """,
       ]
@@ -68,7 +68,7 @@ struct MemoryManagementModeTests {
         """,
         """
         public static MyClass f(SwiftArena swiftArena$) {
-          return new MyClass(SwiftModule.$f(), swiftArena$);
+          return MyClass.wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena$);
         }
         """,
       ]

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -227,7 +227,7 @@ final class MethodImportTests {
         public static MySwiftClass globalReturnClass(AllocatingSwiftArena swiftArena$) {
           MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
           swiftjava___FakeModule_globalReturnClass.call(_result);
-          return new MySwiftClass(_result, swiftArena$);
+          return MySwiftClass.wrapMemoryAddressUnsafe(_result, swiftArena$);
         }
         """
     )
@@ -404,7 +404,7 @@ final class MethodImportTests {
         public static MySwiftClass init(long len, long cap, AllocatingSwiftArena swiftArena$) {
             MemorySegment _result = swiftArena$.allocate(MySwiftClass.$LAYOUT);
             swiftjava___FakeModule_MySwiftClass_init_len_cap.call(len, cap, _result)
-            return new MySwiftClass(_result, swiftArena$);
+            return MySwiftClass.wrapMemoryAddressUnsafe(_result, swiftArena$);
         }
         """
     )
@@ -449,7 +449,7 @@ final class MethodImportTests {
         public static MySwiftStruct init(long len, long cap, AllocatingSwiftArena swiftArena$) {
             MemorySegment _result = swiftArena$.allocate(MySwiftStruct.$LAYOUT);
             swiftjava___FakeModule_MySwiftStruct_init_len_cap.call(len, cap, _result)
-            return new MySwiftStruct(_result, swiftArena$);
+            return MySwiftStruct.wrapMemoryAddressUnsafe(_result, swiftArena$);
         }
         """
     )


### PR DESCRIPTION
The reason here is that it's too easy to accidentally autocomplete into new Thing(bla) which can often be incorrect because we probably intended to call init on the Thing. This popped up with Data a lot, because it is so easy to wrongly use new Data rather than Data.init which performs the proper initialization

resolves https://github.com/swiftlang/swift-java/issues/359