### PR TITLE
Allow config if to auto load native libraries with -Dswift-java.auto-load-libraries=false

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -194,8 +194,8 @@ extension FFMSwift2JavaGenerator {
         @SuppressWarnings("unused")
         private static final boolean INITIALIZED_LIBS = initializeLibs();
         static boolean initializeLibs() {
-            System.loadLibrary(SwiftLibraries.STDLIB_DYLIB_NAME);
-            System.loadLibrary("SwiftKitSwift");
+            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_CORE);
+            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFTKITSWIFT);
             System.loadLibrary(LIB_NAME);
             return true;
         }
@@ -343,10 +343,11 @@ extension FFMSwift2JavaGenerator {
         """
         static final SymbolLookup SYMBOL_LOOKUP = getSymbolLookup();
         private static SymbolLookup getSymbolLookup() {
-            // Ensure Swift and our Lib are loaded during static initialization of the class.
-            System.loadLibrary("swiftCore");
-            System.loadLibrary("SwiftKitSwift");
-            System.loadLibrary(LIB_NAME);
+            if (SwiftLibraries.AUTO_LOAD_LIBS) {
+                System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_CORE);
+                System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFTKITSWIFT);
+                System.loadLibrary(LIB_NAME);
+            }
 
             if (PlatformUtils.isMacOS()) {
                 return SymbolLookup.libraryLookup(System.mapLibraryName(LIB_NAME), LIBRARY_ARENA)

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftLibraries.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftLibraries.java
@@ -24,18 +24,28 @@ import java.nio.file.StandardCopyOption;
 
 public final class SwiftLibraries {
 
-    public static final String STDLIB_DYLIB_NAME = "swiftCore";
-    public static final String SWIFTKITSWIFT_DYLIB_NAME = "SwiftKitSwift";
+    // Library names of core Swift and SwiftKit
+    public static final String LIB_NAME_SWIFT_CORE = "swiftCore";
+    public static final String LIB_NAME_SWIFT_CONCURRENCY = "swift_Concurrency";
+    public static final String LIB_NAME_SWIFTKITSWIFT = "SwiftKitSwift";
 
-    private static final String STDLIB_MACOS_DYLIB_PATH = "/usr/lib/swift/libswiftCore.dylib";
+    /** 
+     * Allows for configuration if jextracted types should automatically attempt to load swiftCore and the library type is from.
+     * <p/>
+     * If all libraries you need to load are available in paths passed to {@code -Djava.library.path} this should work correctly,
+     * however if attempting to load libraries from e.g. the jar as a resource, you may want to disable this.
+     */
+    public static final boolean AUTO_LOAD_LIBS = System.getProperty("swift-java.auto-load-libraries") == null ? 
+            true
+            : Boolean.getBoolean("swiftkit.auto-load-libraries");
 
     @SuppressWarnings("unused")
     private static final boolean INITIALIZED_LIBS = loadLibraries(false);
 
     public static boolean loadLibraries(boolean loadSwiftKit) {
-        System.loadLibrary(STDLIB_DYLIB_NAME);
+        System.loadLibrary(LIB_NAME_SWIFTKITSWIFT);
         if (loadSwiftKit) {
-            System.loadLibrary(SWIFTKITSWIFT_DYLIB_NAME);
+            System.loadLibrary(LIB_NAME_SWIFTKITSWIFT);
         }
         return true;
     }


### PR DESCRIPTION
This way we can disable the automatic loading of libraries by passing `-Dswift-java.auto-load-libraries=false` to the jvm.

We may also consider a runtime API to do this?