### PR TITLE
Disable SPI docs for jni dependent targets

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,9 +2,7 @@ version: 1
 builder:
   configs:
     - documentation_targets: [
-      SwiftJavaDocumentation,
-      JavaKit,
-      SwiftKitSwift
+      SwiftJavaDocumentation
     ]
       # Drop this version pinning once 6.2 is released and docs are built with 6.2 by default to prevent it staying on 6.2 forever.
       swift_version: 6.2


### PR DESCRIPTION
docc plugin can't handle targets which need additional libraries, so we're blocked on generating docs for them in SPI until https://github.com/swiftlang/swift-docc-plugin/issues/112 is resolved