### PR TITLE
Avoid jextracting +SwiftJava files

### DIFF
--- a/Sources/JExtractSwiftLib/Swift2Java.swift
+++ b/Sources/JExtractSwiftLib/Swift2Java.swift
@@ -124,8 +124,15 @@ public struct SwiftToJava {
   }
   
   func canExtract(from file: URL) -> Bool {
-    file.lastPathComponent.hasSuffix(".swift") ||
-    file.lastPathComponent.hasSuffix(".swiftinterface")
+    guard file.lastPathComponent.hasSuffix(".swift") || 
+          file.lastPathComponent.hasSuffix(".swiftinterface") else {
+      return false
+    }
+    if file.lastPathComponent.hasSuffix("+SwiftJava.swift") {
+      return false
+    }
+
+    return true
   }
 
 }


### PR DESCRIPTION
Otherwise we may end up in infinite reimporting loop when generating into source directory which has comitted swift java sources