### PR TITLE
[SwiftJava] Fix Android build by making JNINativeInterface_ public

### DIFF
--- a/Sources/SwiftJava/JavaEnvironment.swift
+++ b/Sources/SwiftJava/JavaEnvironment.swift
@@ -15,7 +15,7 @@
 import CSwiftJavaJNI
 
 #if canImport(Android)
-typealias JNINativeInterface_ = JNINativeInterface
+public typealias JNINativeInterface_ = JNINativeInterface
 #endif
 
 extension UnsafeMutablePointer<JNIEnv?> {


### PR DESCRIPTION
The typealias has to be `public` since it's referenced by `public var interface: JNINativeInterface_`