### PR TITLE
chore: restrict GitHub workflow permissions - future-proof

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,8 @@
 name: pull_request
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167 for additional context

This approach aligns with security best practices, as detailed in the following documentation:

- https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/
