### PR TITLE
Fix passed JExtractGenerationMode not being used by JExtractCommand.

### DIFF
--- a/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
@@ -40,7 +40,7 @@ extension SwiftJava {
     @OptionGroup var commonOptions: SwiftJava.CommonOptions
 
     @Option(help: "The mode of generation to use for the output files. Used with jextract mode.")
-    var mode: JExtractGenerationMode = .ffm
+    var mode: JExtractGenerationMode?
 
     @Option(help: "The name of the Swift module into which the resulting Swift types will be generated.")
     var swiftModule: String
@@ -86,7 +86,11 @@ extension SwiftJava.JExtractCommand {
     if let javaPackage {
       config.javaPackage = javaPackage
     }
-    config.mode = mode
+    if let mode {
+      config.mode = mode
+    } else if config.mode == nil {
+      config.mode = .ffm
+    }
     config.swiftModule = self.effectiveSwiftModule
     config.outputJavaDirectory = outputJava
     config.outputSwiftDirectory = outputSwift


### PR DESCRIPTION
When calling JExtractCommand, the value passed for --mode is not passed to Configuration, therefore the default value FFM is used.

Resolves: #402 