### PR TITLE
build: fix warning about kotlin not supporting jdk 25

### DIFF
--- a/BuildLogic/build.gradle.kts
+++ b/BuildLogic/build.gradle.kts
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 repositories {
     gradlePluginPortal()
     mavenCentral()
@@ -23,4 +25,14 @@ dependencies {
 
 plugins {
     `kotlin-dsl`
+}
+
+kotlin {
+    jvmToolchain(25)
+
+    compilerOptions {
+        // Kotlin does not yet support  JDK 25, so we use 24 for kotlin specifically
+        // in order to avoid this warning: "Kotlin does not yet support 25 JDK target, falling back to Kotlin JVM_24 JVM target"
+        jvmTarget.set(JvmTarget.JVM_24)
+    }
 }


### PR DESCRIPTION
it would fall back to 24, however also pollute logs with warnings about this: "Kotlin does not yet support 25 JDK target, falling back to Kotlin JVM_24 JVM target" so we can set this explicitly.

I looked at https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support and I think this may be good enough...?