### PR TITLE
Java module system/Jigsaw support for SwiftKitCore(JNI) and SwiftKitFFM

### DIFF
--- a/SwiftKitCore/src/main/java/module-info.java
+++ b/SwiftKitCore/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module org.swift.swiftkit.swiftkitcore {
+  requires jdk.jfr;
+
+  exports org.swift.swiftkit.core;
+  exports org.swift.swiftkit.core.util;
+  exports org.swift.swiftkit.core.annotations;
+  exports org.swift.swiftkit.core.ref;
+}

--- a/SwiftKitFFM/src/main/java/module-info.java
+++ b/SwiftKitFFM/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module org.swift.swiftkit.swiftkitffm {
+  requires org.swift.swiftkit.swiftkitcore;
+
+  exports org.swift.swiftkit.ffm;
+}


### PR DESCRIPTION
Hi:

Java 9 introduces Jigsaw/Java module system. 
& 25 introduces syntax of import module
```java
import module org.swift.swiftkit.swiftkitcore;
```
so it would be nice to have the Java modularize support.

potential risk:
Not clear the impact of Android port.

thx