### PR TITLE
[jextract] Remove withVaList from generated code

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -19,6 +19,8 @@
 
 #if os(Linux)
   import Glibc
+#elseif os(Android)
+  import Android
 #else
   import Darwin.C
 #endif

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -830,9 +830,12 @@ extension JNISwift2JavaGenerator {
           if swiftFunctionResultType.isVoid {
             printer.print("environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])")
           } else {
-            printer.printBraceBlock("withVaList([SwiftJavaRuntimeSupport._JNIBoxedConversions.box(\(inner), in: environment)])") { printer in
-              printer.print("environment.interface.CallBooleanMethodV(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, $0)")
-            }
+            printer.print(
+              """
+              let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(\(inner), in: environment)
+              environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
+              """
+            )
           }
         }
 

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -251,16 +251,14 @@ extension JNISwift2JavaGenerator {
         """
       )
       let upcallArguments = zip(enumCase.parameterConversions, caseNames).map { conversion, caseName in
-        // '0' is treated the same as a null pointer.
-        let nullConversion = !conversion.native.javaType.isPrimitive ? " ?? 0" : ""
+        let nullConversion = !conversion.native.javaType.isPrimitive ? " ?? nil" : ""
         let result = conversion.native.conversion.render(&printer, caseName)
-        return "\(result)\(nullConversion)"
+        return "jvalue(\(conversion.native.javaType.jniFieldName): \(result)\(nullConversion))"
       }
       printer.print(
         """
-        return withVaList([\(upcallArguments.joined(separator: ", "))]) {
-          return environment.interface.NewObjectV(environment, class$, constructorID$, $0)
-        }
+        let newObjectArgs$: [jvalue] = [\(upcallArguments.joined(separator: ", "))]
+        return environment.interface.NewObjectA(environment, class$, constructorID$, newObjectArgs$)
         """
       )
     }

--- a/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
@@ -224,9 +224,8 @@ struct JNIAsyncTests {
               }
               let swiftResult$ = await SwiftModule.async(i: Int64(fromJNI: i, in: environment))
               environment = try JavaVirtualMachine.shared().environment()
-              withVaList([SwiftJavaRuntimeSupport._JNIBoxedConversions.box(swiftResult$.getJNIValue(in: environment), in: environment)]) {
-                environment.interface.CallBooleanMethodV(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, $0)
-              }
+              let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(swiftResult$.getJNIValue(in: environment), in: environment)
+              environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
             }
           }
           else {
@@ -238,9 +237,8 @@ struct JNIAsyncTests {
               }
               let swiftResult$ = await SwiftModule.async(i: Int64(fromJNI: i, in: environment))
               environment = try JavaVirtualMachine.shared().environment()
-              withVaList([SwiftJavaRuntimeSupport._JNIBoxedConversions.box(swiftResult$.getJNIValue(in: environment), in: environment)]) {
-                environment.interface.CallBooleanMethodV(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, $0)
-              }
+              let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(swiftResult$.getJNIValue(in: environment), in: environment)
+              environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
             }
           }
           return 
@@ -317,9 +315,8 @@ struct JNIAsyncTests {
               let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
               result$.initialize(to: swiftResult$)
               let resultBits$ = Int64(Int(bitPattern: result$))
-              withVaList([SwiftJavaRuntimeSupport._JNIBoxedConversions.box(resultBits$.getJNIValue(in: environment), in: environment)]) {
-                environment.interface.CallBooleanMethodV(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, $0)
-              }
+              let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(resultBits$.getJNIValue(in: environment), in: environment)
+              environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
             }
           }
           else {
@@ -334,9 +331,8 @@ struct JNIAsyncTests {
               let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
               result$.initialize(to: swiftResult$)
               let resultBits$ = Int64(Int(bitPattern: result$))
-              withVaList([SwiftJavaRuntimeSupport._JNIBoxedConversions.box(resultBits$.getJNIValue(in: environment), in: environment)]) {
-                environment.interface.CallBooleanMethodV(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, $0)
-              }
+              let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(resultBits$.getJNIValue(in: environment), in: environment)
+              environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
             }
           }
           return 

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -302,9 +302,8 @@ struct JNIEnumTests {
           let class$ = cache$.javaClass
           let method$ = _JNIMethodIDCache.Method(name: "<init>", signature: "(Ljava/lang/String;)V")
           let constructorID$ = cache$[method$]
-          return withVaList([_0.getJNIValue(in: environment) ?? 0]) {
-            return environment.interface.NewObjectV(environment, class$, constructorID$, $0)
-          }
+          let newObjectArgs$: [jvalue] = [jvalue(l: _0.getJNIValue(in: environment) ?? nil)]
+          return environment.interface.NewObjectA(environment, class$, constructorID$, newObjectArgs$)
         }
         """,
         """
@@ -318,9 +317,8 @@ struct JNIEnumTests {
           let class$ = cache$.javaClass
           let method$ = _JNIMethodIDCache.Method(name: "<init>", signature: "(JI)V")
           let constructorID$ = cache$[method$]
-          return withVaList([x.getJNIValue(in: environment), y.getJNIValue(in: environment)]) {
-            return environment.interface.NewObjectV(environment, class$, constructorID$, $0)
-          }
+          let newObjectArgs$: [jvalue] = [jvalue(j: x.getJNIValue(in: environment)), jvalue(i: y.getJNIValue(in: environment))]
+          return environment.interface.NewObjectA(environment, class$, constructorID$, newObjectArgs$)
         }
         """
       ])


### PR DESCRIPTION
Fixes an issue where withVaList did not work on Android, because the JNI headers were imported differently from the JDK.

Resolves https://github.com/swiftlang/swift-android-examples/issues/15