### PR TITLE
jextract/jni: use deferEnvironment instead of environment interface

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -973,7 +973,7 @@ extension JNISwift2JavaGenerator {
             // Defer might on any thread, so we need to attach environment.
             printer.print("let deferEnvironment = try! JavaVirtualMachine.shared().environment()")
             for globalRef in globalRefs {
-              printer.print("environment.interface.DeleteGlobalRef(deferEnvironment, \(globalRef))")
+              printer.print("deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, \(globalRef))")
             }
           }
           if isThrowing {

--- a/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
@@ -66,7 +66,7 @@ struct JNIAsyncTests {
                 var environment = environment!
                 defer {
                   let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                  environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                  deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
                 }
                 let swiftResult$ = await SwiftModule.asyncVoid()
                 environment = try! JavaVirtualMachine.shared().environment()
@@ -79,7 +79,7 @@ struct JNIAsyncTests {
               var environment = try! JavaVirtualMachine.shared().environment()
               defer {
                 let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               let swiftResult$ = await SwiftModule.asyncVoid()
               environment = try! JavaVirtualMachine.shared().environment()
@@ -140,7 +140,7 @@ struct JNIAsyncTests {
                 var environment = environment!
                 defer {
                   let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                  environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                  deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
                 }
                 do {
                   let swiftResult$ = await try SwiftModule.async()
@@ -160,7 +160,7 @@ struct JNIAsyncTests {
               var environment = try! JavaVirtualMachine.shared().environment()
               defer {
                 let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               do {
                 let swiftResult$ = await try SwiftModule.async()
@@ -228,7 +228,7 @@ struct JNIAsyncTests {
               var environment = environment!
               defer {
                 let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               let swiftResult$ = await SwiftModule.async(i: Int64(fromJNI: i, in: environment))
               environment = try! JavaVirtualMachine.shared().environment()
@@ -242,7 +242,7 @@ struct JNIAsyncTests {
               var environment = try! JavaVirtualMachine.shared().environment()
               defer {
                 let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               let swiftResult$ = await SwiftModule.async(i: Int64(fromJNI: i, in: environment))
               environment = try! JavaVirtualMachine.shared().environment()
@@ -319,7 +319,7 @@ struct JNIAsyncTests {
                 var environment = environment!
                 defer {
                   let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                  environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                  deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
                 }
                 let swiftResult$ = await SwiftModule.async(c: c$.pointee)
                 environment = try! JavaVirtualMachine.shared().environment()
@@ -336,7 +336,7 @@ struct JNIAsyncTests {
               var environment = try! JavaVirtualMachine.shared().environment()
               defer {
                 let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-                environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+                deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               let swiftResult$ = await SwiftModule.async(c: c$.pointee)
               environment = try! JavaVirtualMachine.shared().environment()
@@ -397,8 +397,8 @@ struct JNIAsyncTests {
           ...
           defer {
             let deferEnvironment = try! JavaVirtualMachine.shared().environment()
-            environment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
-            environment.interface.DeleteGlobalRef(deferEnvironment, s)
+            deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
+            deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, s)
           }
           ...
           environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: swiftResult$.getJNIValue(in: environment))])


### PR DESCRIPTION
in defer that's destroying refs to objects.

Slightly cleaner, though where we get the .interface doesn't matter as much 