### PR TITLE
Allow // comments in swift-java.config "JSON with comments"

### DIFF
--- a/Tests/SwiftJavaConfigurationSharedTests/SwiftJavaConfigurationTests.swift
+++ b/Tests/SwiftJavaConfigurationSharedTests/SwiftJavaConfigurationTests.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024-2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftJavaConfigurationShared
+import Testing
+
+@Suite
+struct SwiftJavaConfigurationTests {
+
+  @Test
+  func parseJSONWithComments() throws {
+    let config = try readConfiguration(string: 
+      """
+      // some comments
+      {
+        // anywhere is ok
+        "classpath": ""
+      }
+      """, configPath: nil)
+  }
+}
+


### PR DESCRIPTION
Grew tired of not being able to comment in config files, so now we support line comments with `//`