### PR TITLE
wrap-java: correct importing nested types

### DIFF
--- a/Sources/SwiftJava/String+Extensions.swift
+++ b/Sources/SwiftJava/String+Extensions.swift
@@ -15,8 +15,7 @@
 import Foundation
 
 extension String {
-  /// For a String that's of the form java.util.Vector, return the "Vector"
-  /// part.
+  /// For a String that's of the form java.util.Vector, return the "Vector" part.
   package var defaultSwiftNameForJavaClass: String {
     if let dotLoc = lastIndex(of: ".") {
       let afterDot = index(after: dotLoc)

--- a/Sources/SwiftJavaToolLib/JavaTranslator+Validation.swift
+++ b/Sources/SwiftJavaToolLib/JavaTranslator+Validation.swift
@@ -58,10 +58,10 @@ package extension JavaTranslator {
     package var description: String {
       switch self {
       case .multipleClassesMappedToSameName(let swiftToJavaMapping):
-              """
-              The following Java classes were mapped to the same Swift type name:
-                \(swiftToJavaMapping.map(mappingDescription(mapping:)).joined(separator: "\n"))
-              """
+        """
+        The following Java classes were mapped to the same Swift type name:
+          \(swiftToJavaMapping.map(mappingDescription(mapping:)).joined(separator: "\n"))
+        """
       }
     }
 
@@ -72,10 +72,6 @@ package extension JavaTranslator {
     }
   }
   func validateClassConfiguration() throws(ValidationError) {
-    // for a in translatedClasses {
-    //   print("MAPPING = \(a.key) -> \(a.value.swiftModule?.escapedSwiftName ?? "").\(a.value.swiftType.escapedSwiftName)")
-    // }
-
     // Group all classes by swift name
     let groupedDictionary: [SwiftTypeName: [(JavaFullyQualifiedTypeName, SwiftTypeName)]] = Dictionary(grouping: translatedClasses, by: { 
       // SwiftTypeName(swiftType: $0.value.swiftType, swiftModule: $0.value.swiftModule) 


### PR DESCRIPTION
We cannot just blindly visit all getClasses() because this includes types form super classes as well. This is useful in general, but in this context we specifically want types which are nested in this exact declaration, not its parens.