### PR TITLE
link log library on android for CSwiftJavaJNI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -386,6 +386,9 @@ let package = Package(
       swiftSettings: [
         .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"], .when(platforms: [.macOS, .linux, .windows]))
+      ],
+      linkerSettings: [
+        .linkedLibrary("log", .when(platforms: [.android]))
       ]
     ),
 


### PR DESCRIPTION
The Android support C++ shim uses `android/log.h`, which we need to make sure is linked.