### PR TITLE
fix: optional method name in wrap-java

### DIFF
--- a/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
+++ b/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
@@ -343,7 +343,7 @@ struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
 
       case .product(let product):
         guard let swiftJava = product.sourceModules.first(where: { $0.name == "SwiftJava" }) else {
-          return nil
+          continue
         }
 
         // We are inside Sources/SwiftJava

--- a/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
@@ -682,7 +682,8 @@ extension JavaClassTranslator {
     // --- Handle other effects
     let throwsStr = javaMethod.throwsCheckedException ? "throws" : ""
     let swiftMethodName = javaMethod.getName().escapedSwiftName
-    
+    let swiftOptionalMethodName = "\(javaMethod.getName())Optional".escapedSwiftName
+
     // Compute the parameters for '@...JavaMethod(...)'
     let methodAttribute: AttributeSyntax
       if implementedInSwift {
@@ -743,7 +744,7 @@ extension JavaClassTranslator {
         """
         \(methodAttribute)\(raw: accessModifier)\(raw: overrideOpt)func \(raw: swiftMethodName)\(raw: genericParameterClauseStr)(\(raw: parametersStr))\(raw: throwsStr)\(raw: resultTypeStr)\(raw: whereClause)
         
-        \(raw: accessModifier)\(raw: overrideOpt)func \(raw: swiftMethodName)Optional\(raw: genericParameterClauseStr)(\(raw: parameters.map(\.clause.description).joined(separator: ", ")))\(raw: throwsStr) -> \(raw: resultOptional)\(raw: whereClause) {
+        \(raw: accessModifier)\(raw: overrideOpt)func \(raw: swiftOptionalMethodName)\(raw: genericParameterClauseStr)(\(raw: parameters.map(\.clause.description).joined(separator: ", ")))\(raw: throwsStr) -> \(raw: resultOptional)\(raw: whereClause) {
           \(body)
         }
         """


### PR DESCRIPTION
If you try to wrap a Swift method with a reserved name like `init?`, then the output would be:

```swift
public func `init` Optional(_ string: String) -> JavaMyClass? {
```
which is invalid.

This fixes it to generate
```swift
public func initOptional(_ string: String) -> JavaMyClass? {
```
instead.