### PR TITLE
fix `init` naming mismatch

### DIFF
--- a/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
@@ -697,6 +697,11 @@ extension JavaClassTranslator {
           }
         // Do we need to record any generic information, in order to enable type-erasure for the upcalls?
         var parameters: [String] = []
+        // If the method name is "init", we need to explicitly specify it in the annotation
+        // because "init" is a Swift keyword and will be escaped in the function name via `init`
+        if javaMethod.getName() == "init" {
+          parameters.append("\"init\"")
+        }
         if hasTypeEraseGenericResultType {
           parameters.append("typeErasedResult: \"\(resultType)\"")
         }

--- a/Tests/SwiftJavaToolLibTests/WrapJavaTests/BasicWrapJavaTests.swift
+++ b/Tests/SwiftJavaToolLibTests/WrapJavaTests/BasicWrapJavaTests.swift
@@ -88,4 +88,36 @@ final class BasicWrapJavaTests: XCTestCase {
     )
   }
 
+  // Test that Java methods named "init" get @JavaMethod("init") annotation.
+  // Since "init" is a Swift keyword and gets escaped with backticks in the function name,
+  // we explicitly specify the Java method name in the annotation.
+  // See KeyAgreement.init() methods as a real-world example.
+  func test_wrapJava_initMethodAnnotation() async throws {
+    let classpathURL = try await compileJava(
+      """
+      package com.example;
+
+      class TestClass {
+        public void init(String arg) throws Exception {}
+        public void init() throws Exception {}
+      }
+      """)
+
+    try assertWrapJavaOutput(
+      javaClassNames: [
+        "com.example.TestClass"
+      ],
+      classpath: [classpathURL],
+      expectedChunks: [
+        """
+        @JavaMethod("init")
+        open func `init`(_ arg0: String) throws
+        """,
+        """
+        @JavaMethod("init")
+        open func `init`() throws
+        """,
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Java's `init` methods are bridged as is and made swift compatible via the backticks.
At runtime though, this is forgotten and the java methods are looked up _with_ the backticks.

This approach of fixing adds a `@JavaMethod("init")` annotation, which fixes the issue.

(Though I'm not sure if this shouldn't be fixed in the generated macro code. Open for suggestions!)