### PR TITLE
Fix wrong order, or redundant try/await in generated code which caused warnings

### DIFF
--- a/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
@@ -144,7 +144,7 @@ struct JNIAsyncTests {
                   deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
                 }
                 do {
-                  let swiftResult$ = await try SwiftModule.async()
+                  let swiftResult$ = try await SwiftModule.async()
                   environment = try! JavaVirtualMachine.shared().environment()
                   _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
                 }
@@ -164,7 +164,7 @@ struct JNIAsyncTests {
                 deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               do {
-                let swiftResult$ = await try SwiftModule.async()
+                let swiftResult$ = try await SwiftModule.async()
                 environment = try! JavaVirtualMachine.shared().environment()
                 _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
               }


### PR DESCRIPTION
Fixes #471
&
Fixes #470.

The JNI Swift generator emitted `await try` for async throwing calls,
which produces Swift compiler warnings. This change ensures `try await`
is emitted correctly.
