### PR TITLE
Improve JAVA_HOME detection with SDKMAN and PATH Fallback

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,14 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
 
   if ProcessInfo.processInfo.environment["SPI_PROCESSING"] == "1" && ProcessInfo.processInfo.environment["SPI_BUILD"] == nil {
     // Just ignore that we're missing a JAVA_HOME when building in Swift Package Index during general processing where no Java is needed. However, do _not_ suppress the error during SPI's compatibility build stage where Java is required.
@@ -78,6 +86,46 @@ func getJavaHomeFromLibexecJavaHome() -> String? {
         print("Error running java_home: \(error)")
         return nil
     }
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 
 let javaHome = findJavaHome()

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -34,6 +34,14 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
 }
 
@@ -75,5 +83,45 @@ extension PluginContext {
   func cachedClasspathFile(swiftModule: String) -> URL {
     self.pluginWorkDirectoryURL
       .appending(path: "\(swiftModule)", directoryHint: .notDirectory)
+  }
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
   }
 }

--- a/Samples/JavaDependencySampleApp/Package.swift
+++ b/Samples/JavaDependencySampleApp/Package.swift
@@ -3,9 +3,7 @@
 
 import CompilerPluginSupport
 import PackageDescription
-
-import class Foundation.FileManager
-import class Foundation.ProcessInfo
+import Foundation
 
 // Note: the JAVA_HOME environment variable must be set to point to where
 // Java is installed, e.g.,
@@ -26,7 +24,55 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 let javaHome = findJavaHome()
 

--- a/Samples/JavaKitSampleApp/Package.swift
+++ b/Samples/JavaKitSampleApp/Package.swift
@@ -3,9 +3,7 @@
 
 import CompilerPluginSupport
 import PackageDescription
-
-import class Foundation.FileManager
-import class Foundation.ProcessInfo
+import Foundation
 
 // Note: the JAVA_HOME environment variable must be set to point to where
 // Java is installed, e.g.,
@@ -26,7 +24,55 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 let javaHome = findJavaHome()
 

--- a/Samples/JavaSieve/Package.swift
+++ b/Samples/JavaSieve/Package.swift
@@ -2,9 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
-
-import class Foundation.FileManager
-import class Foundation.ProcessInfo
+import Foundation
 
 // Note: the JAVA_HOME environment variable must be set to point to where
 // Java is installed, e.g.,
@@ -25,7 +23,55 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 let javaHome = findJavaHome()
 

--- a/Samples/SwiftAndJavaJarSampleLib/Package.swift
+++ b/Samples/SwiftAndJavaJarSampleLib/Package.swift
@@ -3,9 +3,7 @@
 
 import CompilerPluginSupport
 import PackageDescription
-
-import class Foundation.FileManager
-import class Foundation.ProcessInfo
+import Foundation
 
 // Note: the JAVA_HOME environment variable must be set to point to where
 // Java is installed, e.g.,
@@ -26,7 +24,55 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 let javaHome = findJavaHome()
 

--- a/Samples/SwiftJavaExtractFFMSampleApp/Package.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Package.swift
@@ -3,9 +3,7 @@
 
 import CompilerPluginSupport
 import PackageDescription
-
-import class Foundation.FileManager
-import class Foundation.ProcessInfo
+import Foundation
 
 // Note: the JAVA_HOME environment variable must be set to point to where
 // Java is installed, e.g.,
@@ -26,7 +24,55 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 let javaHome = findJavaHome()
 

--- a/Samples/SwiftJavaExtractJNISampleApp/Package.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Package.swift
@@ -3,9 +3,7 @@
 
 import CompilerPluginSupport
 import PackageDescription
-
-import class Foundation.FileManager
-import class Foundation.ProcessInfo
+import Foundation
 
 // Note: the JAVA_HOME environment variable must be set to point to where
 // Java is installed, e.g.,
@@ -26,7 +24,55 @@ func findJavaHome() -> String {
     return home
   }
 
+  if let home = getJavaHomeFromSDKMAN() {
+    return home
+  }
+
+  if let home = getJavaHomeFromPath() {
+    return home
+  }
+
   fatalError("Please set the JAVA_HOME environment variable to point to where Java is installed.")
+}
+
+func getJavaHomeFromSDKMAN() -> String? {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".sdkman/candidates/java/current")
+
+  let javaBin = home.appendingPathComponent("bin/java").path
+  if FileManager.default.isExecutableFile(atPath: javaBin) {
+    return home.path
+  }
+  return nil
+}
+
+func getJavaHomeFromPath() -> String? {
+  let task = Process()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+  task.arguments = ["java"]
+
+  let pipe = Pipe()
+  task.standardOutput = pipe
+
+  do {
+    try task.run()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let javaPath = String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !javaPath.isEmpty
+    else { return nil }
+
+    let resolved = URL(fileURLWithPath: javaPath).resolvingSymlinksInPath()
+    return resolved
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .path
+  } catch {
+    return nil
+  }
 }
 let javaHome = findJavaHome()
 

--- a/Sources/SwiftJavaToolLib/JavaHomeSupport.swift
+++ b/Sources/SwiftJavaToolLib/JavaHomeSupport.swift
@@ -100,8 +100,6 @@ public func getJavaHomeFromLibexecJavaHome() -> String? {
   }
 }
 
-// MARK: - Additional Java discovery fallbacks
-
 func getJavaHomeFromSDKMAN() -> String? {
   let home = FileManager.default.homeDirectoryForCurrentUser
     .appendingPathComponent(".sdkman/candidates/java/current")


### PR DESCRIPTION
Adds extra fallbacks to locate a JDK when JAVA_HOME is not set.

In addition to existing behavior, the tool now:
- Detects Java installed via SDKMAN
- Falls back to java on PATH (resolving symlinks)

Tested on Linux (x86_64).

Fixes #393 