### PR TITLE
wrap-java: account for generic use inside parameterized types in params

### DIFF
--- a/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
@@ -616,6 +616,16 @@ extension JavaClassTranslator {
         if parameterizedType.isEqualTo(typeParam.as(Type.self)) {
           return true
         }
+
+        // Also check if the type param is used as a type argument inside a parameterized parameter type
+        if let parameterizedParamType = parameterizedType.as(ParameterizedType.self) {
+          for actualTypeParam in parameterizedParamType.getActualTypeArguments() {
+            guard let actualTypeParam else { continue }
+            if actualTypeParam.isEqualTo(typeParam.as(Type.self)) {
+              return true
+            }
+          }
+        }
       }
     }
 

--- a/Tests/SwiftJavaToolLibTests/WrapJavaTests/GenericsWrapJavaTests.swift
+++ b/Tests/SwiftJavaToolLibTests/WrapJavaTests/GenericsWrapJavaTests.swift
@@ -408,5 +408,40 @@ final class GenericsWrapJavaTests: XCTestCase {
       ]
     )
   }
+
+
+  func testWrapJavaGenericMethod_parameterizedParameterType() async throws {
+    let classpathURL = try await compileJava(
+      """
+      package com.example;
+
+      class Resolver<T> { }
+      class Serializer<T> { }
+
+      class Store {
+        public <ValueType> Store 
+        bootstrapStore(
+            String name,
+            Resolver<ValueType> resolver, 
+            Serializer<ValueType> serializer
+        ) { return null; }
+      }
+      """)
+
+    try assertWrapJavaOutput(
+      javaClassNames: [
+        "com.example.Resolver",
+        "com.example.Serializer",
+        "com.example.Store"
+      ],
+      classpath: [classpathURL],
+      expectedChunks: [
+        """
+        @JavaMethod
+        open func bootstrapStore<ValueType: AnyJavaObject>(_ arg0: String, _ arg1: Resolver<ValueType>?, _ arg2: Serializer<ValueType>?) -> Store!
+        """,
+      ]
+    )
+  }
   
 }


### PR DESCRIPTION
We would accidentally drop the genric because we'd not detect it was used in a generic type in the parameters to a function. This corrects this situation