### PR TITLE
wrap-java: add the ability to filter exclude specific methods

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -31,7 +31,7 @@ extension JNISwift2JavaGenerator {
       return // no need to write any empty files, yay
     }
 
-    logger.info("[swift-java] Write empty [\(self.expectedOutputSwiftFileNames.count)] 'expected' files in: \(swiftOutputDirectory)/")
+    logger.info("Write empty [\(self.expectedOutputSwiftFileNames.count)] 'expected' files in: \(swiftOutputDirectory)/")
 
     for expectedFileName in self.expectedOutputSwiftFileNames {
       logger.info("Write SwiftPM-'expected' empty file: \(expectedFileName.bold)")

--- a/Sources/SwiftJavaTool/Commands/WrapJavaCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/WrapJavaCommand.swift
@@ -339,10 +339,10 @@ extension SwiftJava.WrapJavaCommand {
       let anyIncludeFilterMatched = includes.contains { include in
         if javaClassName.starts(with: include) {
           // TODO: lower to trace level
-          log.info("Skip Java type: \(javaClassName) (does not match any include filter)")
           return true
         }
 
+        log.info("Skip Java type: \(javaClassName) (does not match any include filter)")
         return false
       }
 
@@ -362,4 +362,5 @@ extension SwiftJava.WrapJavaCommand {
     // The class matches import filters, if any, and was not excluded.
     return true
   }
+
 }

--- a/Sources/SwiftJavaTool/CommonOptions.swift
+++ b/Sources/SwiftJavaTool/CommonOptions.swift
@@ -65,7 +65,7 @@ extension SwiftJava {
     @Option(name: .long, help: "While scanning a classpath, inspect ONLY types included in these packages")
     var filterInclude: [String] = []
 
-    @Option(name: .long, help: "While scanning a classpath, skip types which match the filter prefix")
+    @Option(name: .long, help: "While scanning a classpath, skip types which match the filter prefix. You can exclude specific methods by using the `com.example.MyClass#method` format.")
     var filterExclude: [String] = []
 
     @Option(help: "A path to a custom swift-java.config to use")


### PR DESCRIPTION
Sometimes we can generally import a type but code emitted for some methods would be incorrect. While we should solve that, for now allow work around it using a `com.example.Clazz#ignoreMe` matching (and `ignoreMe*` prefix matching as well)