### PR TITLE
Ignore operator functions

### DIFF
--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftStruct.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftStruct.swift
@@ -83,4 +83,9 @@ public struct MySwiftStruct {
     get { return subscriptArray[index] }
     set { subscriptArray[index] = newValue }
   }
+  
+  // operator functions are ignored.
+  public static func ==(lhs: MySwiftStruct, rhs: MySwiftStruct) -> Bool {
+    return false
+  }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftStruct.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftStruct.swift
@@ -60,4 +60,9 @@ public struct MySwiftStruct {
     get { return subscriptArray[Int(index)] }
     set { subscriptArray[Int(index)] = newValue }
   }
+
+  // operator functions are ignored.
+  public static func ==(lhs: MySwiftStruct, rhs: MySwiftStruct) -> Bool {
+    return false
+  }
 }

--- a/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
@@ -129,6 +129,14 @@ final class Swift2JavaVisitor {
       return
     }
 
+    switch node.name.tokenKind {
+    case .binaryOperator, .prefixOperator, .postfixOperator:
+      self.log.debug("Skip importing: '\(node.qualifiedNameForDebug)'; Operators are not supported.")
+      return
+    default:
+      break
+    }
+
     self.log.debug("Import function: '\(node.qualifiedNameForDebug)'")
 
     let signature: SwiftFunctionSignature


### PR DESCRIPTION
- Fix #531

According to the [documentation](https://github.com/swiftlang/swift-java/blob/main/Sources/SwiftJavaDocumentation/Documentation.docc/SupportedFeatures.md), operators are currently unsupported.
I’ve updated the jextract to skip them.