### PR TITLE
Import DataProtocol's decl along with Data

### DIFF
--- a/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
@@ -110,6 +110,7 @@ extension Swift2JavaTranslator {
       let dataProtocolDecl = (self.symbolTable[.foundationDataProtocol] ?? self.symbolTable[.essentialsDataProtocol])!
       if self.isUsing(where: { $0 == dataDecl || $0 == dataProtocolDecl }) {
         visitor.visit(nominalDecl: dataDecl.syntax!.asNominal!, in: nil, sourceFilePath: "Foundation/FAKE_FOUNDATION_DATA.swift")
+        visitor.visit(nominalDecl: dataProtocolDecl.syntax!.asNominal!, in: nil, sourceFilePath: "Foundation/FAKE_FOUNDATION_DATAPROTOCOL.swift")
       }
     }
 


### PR DESCRIPTION
Currently, using `Foundation.Data` in JNI mode prevents Java code from compiling.

```
/..../intermediates/swift/generatedJava/debug/Data.java:12: error: cannot find symbol
public final class Data implements JNISwiftInstance, DataProtocol {
                                                     ^
  symbol: class DataProtocol
```

This occurs because in
https://github.com/swiftlang/swift-java/blob/291fb8a9c6a3218bc30f1d3504b2609be0cf6744/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift#L109-L114

`dataDecl` uses `DataProtocol` but does not visit `dataProtocolDecl`.
In FFM mode, protocols were not yet supported, `DataProtocol` would automatically be eliminated without causing issues.

