### PR TITLE
Improve test output readability, reducing redundant logs

### DIFF
--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -110,8 +110,8 @@ func assertOutput(
 
     var diffLineNumbers: [Int] = []
     guard let matchingOutputOffset else {
-      let `output.contains(expectedChunk)` = output.contains(expectedChunk)
-      #expect(`output.contains(expectedChunk)`, """
+      let outputContainsExpectedChunk = output.contains(expectedChunk)
+      #expect(outputContainsExpectedChunk, """
       \("error: Output did not contain expected chunk!".red)
       ==== Expected output -----------------------------------------------  
       \(expectedChunk.yellow)


### PR DESCRIPTION
This is a minor improvement to the readability of test results.

Currently, using `#expect(output.contains(expectedChunk))` causes the entire content of output to be displayed.
Since this content is already being printed to the console just before the check, it creates redundant and cluttered output, which makes it difficult to analyze results from the CLI.

I have adjusted the `#expect` calls to include the necessary context without letting the macro evaluate and print the full variable content.

## Images

- CLI
<img width="979" height="382" alt="スクリーンショット 2026-02-05 15 01 53" src="https://github.com/user-attachments/assets/b84c1944-4897-4c6b-a5e3-4eb498e89562" />

- Xcode
<img width="1090" height="321" alt="スクリーンショット 2026-02-05 15 02 04" src="https://github.com/user-attachments/assets/52efa715-e0ab-4a6f-a2a1-5b08a3215fbf" />
