### PR TITLE
remove prints from sample swift code, impacts benchmarks

### DIFF
--- a/Samples/SwiftAndJavaJarSampleLib/Sources/MySwiftLibrary/MySwiftClass.swift
+++ b/Samples/SwiftAndJavaJarSampleLib/Sources/MySwiftLibrary/MySwiftClass.swift
@@ -31,35 +31,24 @@ public class MySwiftClass {
   public init(len: Int, cap: Int) {
     self.len = len
     self.cap = cap
-
-    p("\(MySwiftClass.self).len = \(self.len)")
-    p("\(MySwiftClass.self).cap = \(self.cap)")
-    let addr = unsafeBitCast(self, to: UInt64.self)
-    p("initializer done, self = 0x\(String(addr, radix: 16, uppercase: true))")
   }
 
   deinit {
-    let addr = unsafeBitCast(self, to: UInt64.self)
-    p("Deinit, self = 0x\(String(addr, radix: 16, uppercase: true))")
   }
 
   public var counter: Int32 = 0
 
   public func voidMethod() {
-    p("")
   }
 
   public func takeIntMethod(i: Int) {
-    p("i:\(i)")
   }
 
   public func echoIntMethod(i: Int) -> Int {
-    p("i:\(i)")
     return i
   }
 
   public func makeIntMethod() -> Int {
-    p("make int -> 12")
     return 12
   }
 

--- a/Samples/SwiftAndJavaJarSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -24,15 +24,12 @@ import Darwin.C
 #endif
 
 public func helloWorld() {
-  p("\(#function)")
 }
 
 public func globalTakeInt(i: Int) {
-  p("i:\(i)")
 }
 
 public func globalTakeIntInt(i: Int, j: Int) {
-  p("i:\(i), j:\(j)")
 }
 
 public func globalCallMeRunnable(run: () -> ()) {

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
@@ -21,16 +21,9 @@ public class MySwiftClass {
   public init(len: Int, cap: Int) {
     self.len = len
     self.cap = cap
-
-    p("\(MySwiftClass.self).len = \(self.len)")
-    p("\(MySwiftClass.self).cap = \(self.cap)")
-    let addr = unsafeBitCast(self, to: UInt64.self)
-    p("initializer done, self = 0x\(String(addr, radix: 16, uppercase: true))")
   }
 
   deinit {
-    let addr = unsafeBitCast(self, to: UInt64.self)
-    p("Deinit, self = 0x\(String(addr, radix: 16, uppercase: true))")
   }
 
   public var counter: Int32 = 0
@@ -40,20 +33,16 @@ public class MySwiftClass {
   }
 
   public func voidMethod() {
-    p("")
   }
 
   public func takeIntMethod(i: Int) {
-    p("i:\(i)")
   }
 
   public func echoIntMethod(i: Int) -> Int {
-    p("i:\(i)")
     return i
   }
 
   public func makeIntMethod() -> Int {
-    p("make int -> 12")
     return 12
   }
 
@@ -62,14 +51,11 @@ public class MySwiftClass {
   }
 
   public func takeUnsignedChar(arg: UInt16) {
-    p("\(UInt32.self) = \(arg)")
   }
 
   public func takeUnsignedInt(arg: UInt32) {
-    p("\(UInt32.self) = \(arg)")
   }
 
   public func takeUnsignedLong(arg: UInt64) {
-    p("\(UInt64.self) = \(arg)")
   }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -26,11 +26,9 @@ import Darwin.C
 import Foundation
 
 public func helloWorld() {
-  p("\(#function)")
 }
 
 public func globalTakeInt(i: Int) {
-  p("i:\(i)")
 }
 
 public func globalMakeInt() -> Int {
@@ -42,7 +40,6 @@ public func globalWriteString(string: String) -> Int {
 }
 
 public func globalTakeIntInt(i: Int, j: Int) {
-  p("i:\(i), j:\(j)")
 }
 
 public func globalCallMeRunnable(run: () -> ()) {
@@ -92,16 +89,12 @@ public func globalReceiveSomeDataProtocol(data: some DataProtocol) -> Int {
 public func globalReceiveOptional(o1: Int?, o2: (some DataProtocol)?) -> Int {
   switch (o1, o2) {
   case (nil, nil):
-    p("<nil>, <nil>")
     return 0
   case (let v1?, nil):
-    p("\(v1), <nil>")
     return 1
   case (nil, let v2?):
-    p("<nil>, \(v2)")
     return 2
   case (let v1?, let v2?):
-    p("\(v1), \(v2)")
     return 3
   }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftStruct.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftStruct.swift
@@ -27,20 +27,16 @@ public struct MySwiftStruct {
   }
 
   public func voidMethod() {
-    p("")
   }
 
   public func takeIntMethod(i: Int) {
-    p("i:\(i)")
   }
 
   public func echoIntMethod(i: Int) -> Int {
-    p("i:\(i)")
     return i
   }
 
   public func makeIntMethod() -> Int {
-    p("make int -> 12")
     return 12
   }
 

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
@@ -45,13 +45,11 @@ public class MySwiftClass {
   }
 
   public static func method() {
-    p("Hello from static method in a class!")
   }
 
   public init(x: Int64, y: Int64) {
     self.x = x
     self.y = y
-    p("\(self)")
   }
 
   public init() {
@@ -68,7 +66,6 @@ public class MySwiftClass {
   }
 
   deinit {
-    p("deinit called!")
   }
 
   public func sum() -> Int64 {

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -70,20 +70,16 @@ public class MySwiftClass {
   public var counter: Int32 = 0
 
   public func voidMethod() {
-    p("")
   }
 
   public func takeIntMethod(i: Int) {
-    p("i:\(i)")
   }
 
   public func echoIntMethod(i: Int) -> Int {
-    p("i:\(i)")
     return i
   }
 
   public func makeIntMethod() -> Int {
-    p("make int -> 12")
     return 12
   }
 


### PR DESCRIPTION
These are messy when we call these methods in benchmarks