### PR TITLE
Suppress warning for "inferred to have type '()',"

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -1227,12 +1227,14 @@ extension JNISwift2JavaGenerator {
             } else {
               "await"
             }
-          printer.print("let swiftResult$ = \(tryAwaitString) \(placeholderWithoutTry)")
-          printer.print("environment = try! JavaVirtualMachine.shared().environment()")
-          let inner = nativeFunctionSignature.result.conversion.render(&printer, "swiftResult$")
           if swiftFunctionResultType.isVoid {
+            printer.print("\(tryAwaitString) \(placeholderWithoutTry)")
+            printer.print("environment = try! JavaVirtualMachine.shared().environment()")
             printer.print("_ = environment.interface.CallBooleanMethodA(environment, globalFuture, \(completeMethodID), [jvalue(l: nil)])")
           } else {
+            printer.print("let swiftResult$ = \(tryAwaitString) \(placeholderWithoutTry)")
+            printer.print("environment = try! JavaVirtualMachine.shared().environment()")
+            let inner = nativeFunctionSignature.result.conversion.render(&printer, "swiftResult$")
             let result: String
             if nativeFunctionSignature.result.javaType.requiresBoxing {
               printer.print("let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(\(inner), in: environment)")

--- a/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
@@ -69,7 +69,7 @@ struct JNIAsyncTests {
                   let deferEnvironment = try! JavaVirtualMachine.shared().environment()
                   deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
                 }
-                let swiftResult$ = await SwiftModule.asyncVoid()
+                await SwiftModule.asyncVoid()
                 environment = try! JavaVirtualMachine.shared().environment()
                 _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
               }
@@ -82,7 +82,7 @@ struct JNIAsyncTests {
                 let deferEnvironment = try! JavaVirtualMachine.shared().environment()
                 deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
-              let swiftResult$ = await SwiftModule.asyncVoid()
+              await SwiftModule.asyncVoid()
               environment = try! JavaVirtualMachine.shared().environment()
               _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
             }
@@ -144,7 +144,7 @@ struct JNIAsyncTests {
                   deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
                 }
                 do {
-                  let swiftResult$ = try await SwiftModule.async()
+                  try await SwiftModule.async()
                   environment = try! JavaVirtualMachine.shared().environment()
                   _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
                 }
@@ -164,7 +164,7 @@ struct JNIAsyncTests {
                 deferEnvironment.interface.DeleteGlobalRef(deferEnvironment, globalFuture)
               }
               do {
-                let swiftResult$ = try await SwiftModule.async()
+                try await SwiftModule.async()
                 environment = try! JavaVirtualMachine.shared().environment()
                 _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
               }


### PR DESCRIPTION
This is a minor improvement to silence a compiler warning in the generated code like below.

```
/Users/iceman/github/swift-java/Samples/SwiftJavaExtractJNISampleApp/.build/plugins/outputs/swiftjavaextractjnisampleapp/MySwiftLibrary/destination/JExtractSwiftPlugin/Sources/MySwiftLibraryModule+SwiftJava.swift:864:13: warning: constant 'swiftResult$' inferred to have type '()', which may be unexpected
 862 |       } // printTaskBody(printer:) @ JExtractSwiftLib/JNISwift2JavaGenerator+NativeTranslation.swift:1151
 863 |       do {
 864 |         let swiftResult$ = try await MySwiftLibrary.asyncThrows()
     |             |- warning: constant 'swiftResult$' inferred to have type '()', which may be unexpected
     |             `- note: add an explicit type annotation to silence this warning
 865 |         environment = try! JavaVirtualMachine.shared().environment()
 866 |         _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: nil)])
```

Since the generator already checks for `.isVoid` at this location, I have slightly adjusted the logic to avoid assigning the result.