### PR TITLE
Don't generate int returning functions for now

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -612,6 +612,10 @@ extension JNISwift2JavaGenerator {
               outParameters: []
             )
 
+          case .int, .uint:
+            // Returning arch depending integers is not supported yet.
+            throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
+
           default:
             guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config),
               javaType.implementsJavaValue


### PR DESCRIPTION
Returning `Int` is not supported in JNI yet, and will fail to compile because of the support we added in parameter position. 

I might have time to look at it some point, but for now, let's just make the generated code compile.

