### PR TITLE
jextract/jni: fix support for optional strings in protocols

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/CallbackProtcol.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/CallbackProtcol.swift
@@ -33,6 +33,7 @@ public protocol CallbackProtocol {
   func withObjectArray(_ input: [MySwiftClass]) -> [MySwiftClass]
   func successfulThrowingFunction() throws
   func throwingFunction() throws
+  func withOptionalString(_ input: String?) -> String?
 }
 
 public struct CallbackOutput {
@@ -51,6 +52,7 @@ public struct CallbackOutput {
   public let int64Array: [Int64]
   public let stringArray: [String]
   public let objectArray: [MySwiftClass]
+  public let optionalString: String?
 }
 
 public func callProtocolVoid(_ callbacks: some CallbackProtocol) {
@@ -81,7 +83,8 @@ public func outputCallbacks(
   optionalObject: MySwiftClass?,
   int64Array: [Int64],
   stringArray: [String],
-  objectArray: [MySwiftClass]
+  objectArray: [MySwiftClass],
+  optionalString: String?
 ) -> CallbackOutput {
   CallbackOutput(
     bool: callbacks.withBool(bool),
@@ -98,6 +101,7 @@ public func outputCallbacks(
     optionalObject: callbacks.withOptionalObject(optionalObject),
     int64Array: callbacks.withInt64Array(int64Array),
     stringArray: callbacks.withStringArray(stringArray),
-    objectArray: callbacks.withObjectArray(objectArray)
+    objectArray: callbacks.withObjectArray(objectArray),
+    optionalString: callbacks.withOptionalString(optionalString)
   )
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ProtocolCallbacksTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ProtocolCallbacksTest.java
@@ -112,6 +112,11 @@ public class ProtocolCallbacksTest {
         public void successfulThrowingFunction() throws Exception {
 
         }
+
+        @Override
+        public Optional<String> withOptionalString(Optional<String> input) {
+            return input;
+        }
     }
 
     @Test
@@ -142,6 +147,7 @@ public class ProtocolCallbacksTest {
             var int64Array = new long[]{1, 2, 3};
             var stringArray = new String[]{"Hey", "there"};
             var objectArray = new MySwiftClass[]{MySwiftClass.init(1, 1, arena), MySwiftClass.init(2, 2, arena)};
+            var optionalString = Optional.of("Hey there!");
             var output = MySwiftLibrary.outputCallbacks(
                     callbacks,
                     true,
@@ -159,6 +165,7 @@ public class ProtocolCallbacksTest {
                     int64Array,
                     stringArray,
                     objectArray,
+                    optionalString,
                     arena
             );
 
@@ -185,6 +192,10 @@ public class ProtocolCallbacksTest {
             assertEquals(2, objectArrayOutput.length);
             assertEquals(1, objectArrayOutput[0].getX());
             assertEquals(2, objectArrayOutput[1].getX());
+
+            var optionalStringOutput = output.getOptionalString();
+            assertTrue(optionalStringOutput.isPresent());
+            assertEquals("Hey there!", optionalStringOutput.get());
         }
     }
 }

--- a/Sources/SwiftJava/Optional+JavaOptional.swift
+++ b/Sources/SwiftJava/Optional+JavaOptional.swift
@@ -26,6 +26,24 @@ extension Optional where Wrapped: AnyJavaObject {
   }
 }
 
+extension Optional where Wrapped == String {
+  public func toJavaOptional() -> JavaOptional<JavaString> {
+    if let self {
+      return try! JavaClass<JavaOptional<JavaString>>().of(JavaString(self).as(JavaObject.self)).as(JavaOptional<JavaString>.self)!
+    } else {
+      return try! JavaClass<JavaOptional<JavaString>>().empty().as(JavaOptional<JavaString>.self)!
+    }
+  }
+
+  public init(javaOptional: JavaOptional<JavaString>?) {
+    if let javaOptional {
+      self = javaOptional.isPresent() ? javaOptional.get().toString() : Optional<Wrapped>.none
+    } else {
+      self = nil
+    }
+  }
+}
+
 extension Optional where Wrapped == Double {
   public func toJavaOptional() -> JavaOptionalDouble {
     if let self {


### PR DESCRIPTION
Fixes support for protocols that accept or return optional strings:

```swift
protocol MyProtocol {
  func takeAndReturnString(_ string: String?) -> String?
}
```