### PR TITLE
jextract/jni: Skip discriminator generation if enum has no cases

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
@@ -45,3 +45,9 @@ public enum NestedEnum {
     public init() {}
   }
 }
+
+public enum NamespaceEnum {
+  public enum Nested {
+    public static func something() {}
+  }
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/NestedTypesTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/NestedTypesTest.java
@@ -42,4 +42,11 @@ public class NestedTypesTest {
             assertTrue(one.isPresent());
         }
     }
+
+    @Test
+    void testNamespaceEnum() {
+        try (var arena = SwiftArena.ofConfined()) {
+            NamespaceEnum.Nested.something();
+        }
+    }
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -360,6 +360,10 @@ extension JNISwift2JavaGenerator {
   }
 
   private func printEnumDiscriminator(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
+    if decl.cases.isEmpty {
+      return
+    }
+
     printer.printBraceBlock("public enum Discriminator") { printer in
       printer.print(
         decl.cases.map { $0.name.uppercased() }.joined(separator: ",\n")
@@ -374,6 +378,10 @@ extension JNISwift2JavaGenerator {
   }
 
   private func printEnumCaseInterface(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
+    if decl.cases.isEmpty {
+      return
+    }
+
     printer.print("public sealed interface Case {}")
     printer.println()
 

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -286,6 +286,10 @@ extension JNISwift2JavaGenerator {
   }
 
   private func printEnumDiscriminator(_ printer: inout CodePrinter, _ type: ImportedNominalType) {
+    if type.cases.isEmpty {
+      return
+    }
+
     let selfPointerParam = JavaParameter(name: "selfPointer", type: .long)
     printCDecl(
       &printer,


### PR DESCRIPTION
Currently, when the Swift enum has no cases, the generated Java code results in a compilation error.

```
error: sealed class must have subclasses
  public sealed interface Case {}
                ^
```

In Swift, it is a common idiom to use enums with no cases as namespaces.

I have updated the generator to skip the generation of any case-related code when an enum contains no cases.