### PR TITLE
jextract/jni: Support enums that have no cases

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
@@ -45,3 +45,9 @@ public enum NestedEnum {
     public init() {}
   }
 }
+
+public enum NamespaceEnum {
+  public enum Nested {
+    public static func something() {}
+  }
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/NestedTypesTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/NestedTypesTest.java
@@ -42,4 +42,11 @@ public class NestedTypesTest {
             assertTrue(one.isPresent());
         }
     }
+
+    @Test
+    void testNamespaceEnum() {
+        try (var arena = SwiftArena.ofConfined()) {
+            NamespaceEnum.Nested.something();
+        }
+    }
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -374,7 +374,11 @@ extension JNISwift2JavaGenerator {
   }
 
   private func printEnumCaseInterface(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
-    printer.print("public sealed interface Case {}")
+    if decl.cases.isEmpty {
+      printer.print("public interface Case {}")
+    } else {
+      printer.print("public sealed interface Case {}")
+    }
     printer.println()
 
     let requiresSwiftArena = decl.cases.compactMap {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -296,7 +296,7 @@ extension JNISwift2JavaGenerator {
     ) { printer in
       let selfPointer = self.printSelfJLongToUnsafeMutablePointer(
         &printer,
-        swiftParentName: type.swiftNominal.name,
+        swiftParentName: type.swiftNominal.qualifiedName,
         selfPointerParam
       )
       printer.printBraceBlock("switch (\(selfPointer).pointee)") { printer in


### PR DESCRIPTION
Currently, when the Swift enum has no cases, the generated Java code results in a compilation error.

```
error: sealed class must have subclasses
  public sealed interface Case {}
                ^
```

In Swift, it is a common idiom to use enums with no cases as namespaces.
In cases where no enum cases exist, I will remove `sealed` to ensure that no compilation errors occur.