### PR TITLE
Fix local test failure in GenericsWrapJavaTests

### DIFF
--- a/Tests/SwiftJavaToolLibTests/WrapJavaTests/GenericsWrapJavaTests.swift
+++ b/Tests/SwiftJavaToolLibTests/WrapJavaTests/GenericsWrapJavaTests.swift
@@ -333,7 +333,6 @@ final class GenericsWrapJavaTests: XCTestCase {
         """
         @JavaStaticMethod
         public func ofNullable<T: AnyJavaObject>(_ arg0: T?) -> Optional<T>! where ObjectType == Optional<T>
-        }
         """,
         """
         @JavaStaticMethod(typeErasedResult: "T!")


### PR DESCRIPTION
On my local, `test_wrapJava_genericMethodTypeErasure_ofNullableOptional_staticMethods` fails, even though it appears to pass in CI. This suggests the failure might be environment-specific.

```
error: -[SwiftJavaToolLibTests.GenericsWrapJavaTests test_wrapJava_genericMethodTypeErasure_ofNullableOptional_staticMethods] : XCTAssertTrue failed - Expected chunk: 
@JavaStaticMethod
public func ofNullable<T: AnyJavaObject>(_ arg0: T?) -> Optional<T>! where ObjectType == Optional<T>
}
not found in:
// ---------------------------------------------------------------------------
// Auto-generated by Java-to-Swift wrapper generator.
import SwiftJava
import SwiftJavaJNICore

@JavaClass("com.example.Optional")
open class Optional<T: AnyJavaObject>: JavaObject {

}
extension JavaClass {
  /// Java method `ofNullable`.
  ///
  /// ### Java method signature
  /// ```java
  /// public static <T> com.example.Optional<T> com.example.Optional.ofNullable(T)
  /// ```
@JavaStaticMethod
  public func ofNullable<T: AnyJavaObject>(_ arg0: T?) -> Optional<T>! where ObjectType == Optional<T>

  /// Java method `nonNull`.
  ///
  /// ### Java method signature
  /// ```java
  /// public static <T> T com.example.Optional.nonNull(T)
  /// ```
@JavaStaticMethod(typeErasedResult: "T!")
  public func nonNull<T: AnyJavaObject>(_ arg0: T?) -> T! where ObjectType == Optional<T>
}
```

In my research, the presence of the closing brace `}` seems to be the cause of the mismatch.
While the exact reason for this discrepancy across environments is unclear, but the brace is not critical to the intent of this test.
Therefore, I want to delete this.
