### PR TITLE
Update JavaIterator implementation

### DIFF
--- a/Sources/SwiftJava/JavaExtensions/JavaIterator+Iterator.swift
+++ b/Sources/SwiftJava/JavaExtensions/JavaIterator+Iterator.swift
@@ -15,10 +15,10 @@
 extension JavaIterator: IteratorProtocol {
   public typealias Element = E
 
-  public func next() -> E? {
+  @_implements(IteratorProtocol,next())
+  public mutating func swiftNext() -> E? {
     if hasNext() {
-      let nextResult: JavaObject? = next()
-      return nextResult.map { $0.as(E.self)! }
+      return next() as E
     }
 
     return nil

--- a/Sources/SwiftJava/generated/JavaIterator.swift
+++ b/Sources/SwiftJava/generated/JavaIterator.swift
@@ -3,12 +3,30 @@ import SwiftJavaJNICore
 
 @JavaInterface("java.util.Iterator")
 public struct JavaIterator<E: AnyJavaObject> {
+  /// Java method `remove`.
+  ///
+  /// ### Java method signature
+  /// ```java
+  /// public default void java.util.Iterator.remove()
+  /// ```
   @JavaMethod
   public func remove()
 
+  /// Java method `hasNext`.
+  ///
+  /// ### Java method signature
+  /// ```java
+  /// public abstract boolean java.util.Iterator.hasNext()
+  /// ```
   @JavaMethod
   public func hasNext() -> Bool
 
-  @JavaMethod
-  public func next() -> JavaObject!
+  /// Java method `next`.
+  ///
+  /// ### Java method signature
+  /// ```java
+  /// public abstract E java.util.Iterator.next()
+  /// ```
+  @JavaMethod(typeErasedResult: "E!")
+  public func next() -> E!
 }

--- a/Tests/SwiftJavaTests/BasicRuntimeTests.swift
+++ b/Tests/SwiftJavaTests/BasicRuntimeTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import JavaNet
+import JavaUtil
 import SwiftJava
 import XCTest // NOTE: Workaround for https://github.com/swiftlang/swift-java/issues/43
 
@@ -95,6 +96,17 @@ class BasicRuntimeTests: XCTestCase {
     }.value
 
     XCTAssertEqual(string, "https://swift.org")
+  }
+
+  func testListIterator() throws {
+    let environment = try jvm.environment()
+
+    let javaList = try XCTUnwrap(ArrayList<JavaInteger>(environment: environment).as(List<JavaInteger>.self))
+    _ = javaList.add(JavaInteger(0, environment: environment))
+    _ = javaList.add(JavaInteger(1, environment: environment))
+    _ = javaList.add(JavaInteger(2, environment: environment))
+
+    XCTAssertEqual(javaList.map { $0.intValue() }, [0, 1, 2])
   }
 }
 


### PR DESCRIPTION
This is a first, very small step toward the improvements in #599.
I have updated the implementation of `JavaIterator.swift` using the wrap-java command and fixed the parts that required attention.