### PR TITLE
Do not require JAVA_HOME at build time

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,10 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
-import Foundation
 import PackageDescription
 
 let swiftJavaJNICoreDep: Package.Dependency
-if let localPath = ProcessInfo.processInfo.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
+if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   print("Using upstream 'swift-java-jni-core' from override path SWIFT_JAVA_JNI_CORE_PATH = \(localPath)")
   swiftJavaJNICoreDep = .package(path: localPath)
 } else {


### PR DESCRIPTION
This purely-subtractive PR is a companion to https://github.com/swiftlang/swift-java-jni-core/pull/8, and eliminates all the `JAVA_HOME` hunting and `unsafeFlags` from the `Package.swift`.

The tests can be run against the peer checkout of `swift-java-jni-core` with:

```
SWIFT_JAVA_JNI_CORE_PATH=${PWD}/../swift-java-jni-core swift test
```
