### PR TITLE
jextract: fix conditional imports

### DIFF
--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftSymbolTable.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftSymbolTable.swift
@@ -176,12 +176,13 @@ extension SwiftSymbolTable {
         continue
       }
 
-      // Try to print only on main module from relation chain as it has every other module.
-      guard
-        !mainSymbolSourceModules.isDisjoint(with: alternativeModules.moduleNames)
-          || alternativeModules.isMainSourceOfSymbols
-      else {
-        if !alternativeModules.isMainSourceOfSymbols {
+      // Only the main source of symbols emits the conditional import block.
+      // Secondary modules (e.g. FoundationEssentials when Foundation is the main source)
+      // are skipped when their main source is already present, because the main source's
+      // block already covers the import. If no main source is present, fall back to a
+      // plain import so the module is still imported.
+      guard alternativeModules.isMainSourceOfSymbols else {
+        if mainSymbolSourceModules.isDisjoint(with: alternativeModules.moduleNames) {
           printer.print("import \(module)")
         }
         continue

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -33,6 +33,7 @@ func assertOutput(
   detectChunkByInitialLines _detectChunkByInitialLines: Int = 4,
   javaClassLookupTable: [String: String] = [:],
   expectedChunks: [String],
+  notExpectedChunks: [String] = [],
   fileID: String = #fileID,
   filePath: String = #filePath,
   line: Int = #line,
@@ -82,6 +83,15 @@ func assertOutput(
     }
   }
   output = printer.finalize()
+
+  let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
+  for notExpectedChunk in notExpectedChunks {
+    #expect(
+      !output.contains(notExpectedChunk),
+      "Output must not contain:\n\(notExpectedChunk)\n\nGot output:\n\(output)",
+      sourceLocation: sourceLocation
+    )
+  }
 
   let gotLines = output.split(separator: "\n").filter { l in
     l.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).count > 0

--- a/Tests/JExtractSwiftTests/FoundationImportTests.swift
+++ b/Tests/JExtractSwiftTests/FoundationImportTests.swift
@@ -19,7 +19,6 @@ import Testing
 struct FoundationImportTests {
   @Test("Import Foundation", arguments: [JExtractGenerationMode.jni, JExtractGenerationMode.ffm])
   func import_foundation(mode: JExtractGenerationMode) throws {
-
     try assertOutput(
       input: "import Foundation",
       mode,
@@ -33,7 +32,6 @@ struct FoundationImportTests {
 
   @Test("Import FoundationEssentials", arguments: [JExtractGenerationMode.jni, JExtractGenerationMode.ffm])
   func import_foundationEssentials(mode: JExtractGenerationMode) throws {
-
     try assertOutput(
       input: "import FoundationEssentials",
       mode,
@@ -47,8 +45,7 @@ struct FoundationImportTests {
 
   @Test("Import conditional foundation", arguments: [JExtractGenerationMode.jni, JExtractGenerationMode.ffm])
   func import_conditionalFoundation(mode: JExtractGenerationMode) throws {
-    let ifConfigImport =
-      """
+    let ifConfigImport = """
       #if canImport(FoundationEssentials)
       import FoundationEssentials
       #else
@@ -63,6 +60,12 @@ struct FoundationImportTests {
       detectChunkByInitialLines: 1,
       expectedChunks: [
         ifConfigImport
+      ],
+      notExpectedChunks: [
+        """
+        #if canImport(Foundation)
+        import Foundation
+        """
       ]
     )
   }


### PR DESCRIPTION
Fixes a bug where the generator would generate:
```
#if canImport(FoundationEssentials)
import FoundationEssentials
#else
import Foundation
#endif
#if canImport(Foundation)
import Foundation
#else
import FoundationEssentials
#endif
```