### PR TITLE
Preparing release 0.1.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let swiftJavaJNICoreDep: Package.Dependency
 if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   swiftJavaJNICoreDep = .package(path: localPath)
 } else {
-  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", from: "0.3.0")
+  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", from: "0.4.0")
 }
 
 let package = Package(


### PR DESCRIPTION
Qualify 0.1.2 release

The 0.1.1 is dead on arrival because I forgot to bump the jni-core dependency, which is now we have a script doing those things 😉 