### PR TITLE
Better `@JavaClass` detection for JExtract

### DIFF
--- a/Sources/JExtractSwiftLib/Convenience/SwiftSyntax+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/SwiftSyntax+Extensions.swift
@@ -134,7 +134,7 @@ extension AttributeListSyntax.Element {
       // FIXME: Handle #if.
       return false
     }
-    let attrName = attr.attributeName.description
+    guard let attrName = attr.attributeName.as(IdentifierTypeSyntax.self)?.name.text else { return false }
     switch attrName {
     case "JavaClass", "JavaInterface", "JavaField", "JavaStaticField", "JavaMethod", "JavaStaticMethod",
       "JavaImplementation":

--- a/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaTranslator.swift
@@ -208,7 +208,7 @@ extension Swift2JavaTranslator {
   /// Returns a source file that contains all the available dependency classes.
   private func buildDependencyClassesSourceFile() -> SwiftJavaInputFile {
     let contents = self.dependenciesClasses.map {
-      "public class \($0) {}"
+      "@JavaClass public class \($0) {}"
     }
     .joined(separator: "\n")
 

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftType.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftType.swift
@@ -245,9 +245,8 @@ extension SwiftNominalType: CustomStringConvertible {
 }
 
 extension SwiftNominalType {
-  // TODO: Better way to detect Java wrapped classes.
   var isSwiftJavaWrapper: Bool {
-    nominalTypeDecl.name.hasPrefix("Java")
+    nominalTypeDecl.syntax?.attributes.contains(where: \.isJava) ?? false
   }
 
   var isProtocol: Bool {


### PR DESCRIPTION
Instead of just detecting a `@JavaClass` wrapper by the prefix of `Java` in the name, we check if the `JavaClass` macro is attached to the class.

This allows us to use Java wrappers that are not prefixed with Java in Jextract method.