### PR TITLE
Lower minimum macOS version to v13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
 let package = Package(
   name: "swift-java",
   platforms: [
-    .macOS(.v15)
+    .macOS(.v13)
   ],
   products: [
     // ==== SwiftJava (i.e. calling Java directly Swift utilities)


### PR DESCRIPTION
My swift package had a minimum deployment version of macOS v13, which conflicted with swift-java's v15.

However, swift-java has no issue when this is changed to v13, likely just unchanged from package initialisation!

Thank you.