### PR TITLE
remove swift-format multiline trailing comma

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -18,7 +18,6 @@
   "maximumBlankLines" : 2,
   "spacesBeforeEndOfLineComments" : 1, 
   "multiElementCollectionTrailingCommas" : true,
-  "multilineTrailingCommaBehavior" : "alwaysUsed",
   "respectsExistingLineBreaks" : true,
   "prioritizeKeepingFunctionOutputTogether" : true,
   "rules" : {


### PR DESCRIPTION
I'd like to use it but we can't because it breaks some legit commits https://github.com/swiftlang/swift-format/issues/1178