### PR TITLE
Fix `Int?` argument issues on 32-bit environments

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let swiftJavaJNICoreDep: Package.Dependency
 if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   swiftJavaJNICoreDep = .package(path: localPath)
 } else {
-  swiftJavaJNICoreDep = .package(url: "https://github.com/sidepelican/swift-java-jni-core", branch: "fixed_witdh_integer")
+  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", branch: "main")
 }
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let swiftJavaJNICoreDep: Package.Dependency
 if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   swiftJavaJNICoreDep = .package(path: localPath)
 } else {
-  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", branch: "main")
+  swiftJavaJNICoreDep = .package(url: "https://github.com/sidepelican/swift-java-jni-core", branch: "fixed_witdh_integer")
 }
 
 let package = Package(

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Optionals.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Optionals.swift
@@ -44,6 +44,10 @@ public func optionalLong(input: Int64?) -> Int64? {
   input
 }
 
+public func optionalPlatformDependentInt(input: Int?) -> Int? {
+  input
+}
+
 public func optionalFloat(input: Float?) -> Float? {
   input
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/OptionalsTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/OptionalsTest.java
@@ -64,6 +64,12 @@ public class OptionalsTest {
     }
 
     @Test
+    void optionalPlatformDependentInt() {
+        assertEquals(OptionalLong.empty(), MySwiftLibrary.optionalPlatformDependentInt(OptionalLong.empty()));
+        assertEquals(OptionalLong.of(123), MySwiftLibrary.optionalPlatformDependentInt(OptionalLong.of(123)));
+    }
+
+    @Test
     void optionalFloat() {
         assertEquals(Optional.empty(), MySwiftLibrary.optionalFloat(Optional.empty()));
         assertEquals(Optional.of(3.14f), MySwiftLibrary.optionalFloat(Optional.of(3.14f)));

--- a/Sources/JExtractSwiftLib/JNI/JNIJavaTypeTranslator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNIJavaTypeTranslator.swift
@@ -59,12 +59,13 @@ enum JNIJavaTypeTranslator {
   }
 
   static func checkStep(
-    for knownKind: SwiftKnownTypeDeclKind,
+    parameterType: SwiftKnownTypeDeclKind,
+    parameterName: String,
     from knownTypes: SwiftKnownTypes
   ) -> JNISwift2JavaGenerator.NativeSwiftConversionCheck? {
-    switch knownKind {
-    case .int: .check32BitIntOverflow(typeWithMinAndMax: knownTypes.int32)
-    case .uint: .check32BitIntOverflow(typeWithMinAndMax: knownTypes.uint32)
+    switch parameterType {
+    case .int: .check32BitIntOverflow(parameterName: parameterName, typeWithMinAndMax: knownTypes.int32)
+    case .uint: .check32BitIntOverflow(parameterName: parameterName, typeWithMinAndMax: knownTypes.uint32)
 
     case .bool, .int8, .uint8, .int16, .uint16, .int32, .uint32, .int64, .uint64,
       .float, .double, .void, .string,

--- a/Sources/JExtractSwiftLib/JNI/JNIJavaTypeTranslator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNIJavaTypeTranslator.swift
@@ -58,33 +58,6 @@ enum JNIJavaTypeTranslator {
     }
   }
 
-  static func indirectConversionStepSwiftType(
-    for knownKind: SwiftKnownTypeDeclKind,
-    from knownTypes: SwiftKnownTypes
-  ) -> SwiftType? {
-    switch knownKind {
-    case .int: knownTypes.int64
-    case .uint: knownTypes.uint64
-
-    case .bool, .int8, .uint8, .int16, .uint16, .int32, .uint32, .int64, .uint64,
-      .float, .double, .void, .string,
-      .unsafeRawPointer, .unsafeMutableRawPointer,
-      .unsafePointer, .unsafeMutablePointer,
-      .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer,
-      .unsafeBufferPointer, .unsafeMutableBufferPointer,
-      .optional,
-      .foundationData, .foundationDataProtocol,
-      .essentialsData, .essentialsDataProtocol,
-      .array,
-      .dictionary,
-      .set,
-      .foundationDate, .essentialsDate,
-      .foundationUUID, .essentialsUUID,
-      .swiftJavaError:
-      nil
-    }
-  }
-
   static func checkStep(
     for knownKind: SwiftKnownTypeDeclKind,
     from knownTypes: SwiftKnownTypes

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -185,7 +185,6 @@ extension JNISwift2JavaGenerator {
           selfParameter: NativeParameter(
             parameters: [JavaParameter(name: "selfPointer", type: .long)],
             conversion: .extractSwiftValue(.placeholder, swiftType: .nominal(enumCase.enumType), allowNil: false),
-            indirectConversion: nil,
             conversionCheck: nil
           ),
           selfTypeParameter: !isGenericParent
@@ -193,7 +192,6 @@ extension JNISwift2JavaGenerator {
             : .init(
               parameters: [JavaParameter(name: "selfTypePointer", type: .long)],
               conversion: .extractMetatypeValue(.placeholder),
-              indirectConversion: nil,
               conversionCheck: nil
             ),
           parameters: [],

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -152,7 +152,6 @@ extension JNISwift2JavaGenerator {
                 ),
                 placeholder: .initFromJNI(.placeholder, swiftType: self.knownTypes.string)
               ),
-              indirectConversion: nil,
               conversionCheck: nil
             )
 
@@ -163,23 +162,15 @@ extension JNISwift2JavaGenerator {
               throw JavaTranslationError.unsupportedSwiftType(type)
             }
 
-            let indirectStepType = JNIJavaTypeTranslator.indirectConversionStepSwiftType(
-              for: knownType.kind,
-              from: knownTypes
-            )
             let indirectCheck = JNIJavaTypeTranslator.checkStep(for: knownType.kind, from: knownTypes)
 
             return NativeParameter(
               parameters: [
                 JavaParameter(name: parameterName, type: javaType)
               ],
-              conversion: indirectStepType != nil
-                ? .labelessAssignmentOfVariable(.placeholder, swiftType: type)
-                : .initFromJNI(.placeholder, swiftType: type),
-              indirectConversion: indirectStepType.flatMap { .initFromJNI(.placeholder, swiftType: $0) },
+              conversion: .initFromJNI(.placeholder, swiftType: type),
               conversionCheck: indirectCheck
             )
-
           }
         }
 
@@ -201,7 +192,6 @@ extension JNISwift2JavaGenerator {
               ),
               wrapperName: nominalTypeName
             ),
-            indirectConversion: nil,
             conversionCheck: nil
           )
         }
@@ -212,7 +202,6 @@ extension JNISwift2JavaGenerator {
             JavaParameter(name: parameterName, type: .long)
           ],
           conversion: .pointee(.extractSwiftValue(.placeholder, swiftType: type)),
-          indirectConversion: nil,
           conversionCheck: nil
         )
 
@@ -222,7 +211,6 @@ extension JNISwift2JavaGenerator {
             JavaParameter(name: parameterName, type: .void)
           ],
           conversion: .placeholder,
-          indirectConversion: nil,
           conversionCheck: nil
         )
 
@@ -250,7 +238,6 @@ extension JNISwift2JavaGenerator {
               syntheticFunction: syntheticFunction,
               closureName: parameterName
             ),
-            indirectConversion: nil,
             conversionCheck: nil
           )
         }
@@ -279,7 +266,6 @@ extension JNISwift2JavaGenerator {
             parameters: parameters,
             result: result
           ),
-          indirectConversion: nil,
           conversionCheck: nil
         )
 
@@ -309,7 +295,6 @@ extension JNISwift2JavaGenerator {
             JavaParameter(name: parameterName, type: .long)
           ],
           conversion: .extractMetatypeValue(.placeholder),
-          indirectConversion: nil,
           conversionCheck: nil
         )
 
@@ -356,7 +341,6 @@ extension JNISwift2JavaGenerator {
       return NativeParameter(
         parameters: allJNIParameters,
         conversion: .tupleConstruct(elements: elementConversions),
-        indirectConversion: nil,
         conversionCheck: nil
       )
     }
@@ -422,7 +406,6 @@ extension JNISwift2JavaGenerator {
           protocolTypes: protocolTypes,
           allowsJavaImplementations: allowsJavaImplementations
         ),
-        indirectConversion: nil,
         conversionCheck: nil
       )
     }
@@ -466,7 +449,6 @@ extension JNISwift2JavaGenerator {
                 discriminatorName: discriminatorName,
                 valueName: valueName
               ),
-              indirectConversion: nil,
               conversionCheck: nil
             )
           }
@@ -482,7 +464,6 @@ extension JNISwift2JavaGenerator {
               JavaParameter(name: parameterName, type: javaType)
             ],
             conversion: .optionalMap(.initializeSwiftJavaWrapper(.placeholder, wrapperName: nominalTypeName)),
-            indirectConversion: nil,
             conversionCheck: nil
           )
         }
@@ -499,7 +480,6 @@ extension JNISwift2JavaGenerator {
               )
             )
           ),
-          indirectConversion: nil,
           conversionCheck: nil
         )
 
@@ -667,7 +647,6 @@ extension JNISwift2JavaGenerator {
               JavaParameter(name: parameterName, type: javaType)
             ],
             conversion: .getJValue(.placeholder),
-            indirectConversion: nil,
             conversionCheck: nil
           )
         }
@@ -725,22 +704,11 @@ extension JNISwift2JavaGenerator {
               throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
             }
 
-            if let indirectReturnType = JNIJavaTypeTranslator.indirectConversionStepSwiftType(
-              for: knownType.kind,
-              from: knownTypes
-            ) {
-              return NativeResult(
-                javaType: javaType,
-                conversion: .getJNIValue(.labelessInitializer(.placeholder, swiftType: indirectReturnType)),
-                outParameters: []
-              )
-            } else {
-              return NativeResult(
-                javaType: javaType,
-                conversion: .getJNIValue(.placeholder),
-                outParameters: []
-              )
-            }
+            return NativeResult(
+              javaType: javaType,
+              conversion: .getJNIValue(.placeholder),
+              outParameters: []
+            )
           }
         }
 
@@ -894,7 +862,6 @@ extension JNISwift2JavaGenerator {
               JavaParameter(name: parameterName, type: .array(javaType))
             ],
             conversion: .initFromJNI(.placeholder, swiftType: knownTypes.arraySugar(elementType)),
-            indirectConversion: nil,
             conversionCheck: nil
           )
         }
@@ -926,7 +893,6 @@ extension JNISwift2JavaGenerator {
               )
             ]
           ),
-          indirectConversion: nil,
           conversionCheck: nil
         )
 
@@ -945,7 +911,6 @@ extension JNISwift2JavaGenerator {
           JavaParameter(name: parameterName, type: .long)
         ],
         conversion: .initFromJNI(.placeholder, swiftType: knownTypes.dictionarySugar(keyType, valueType)),
-        indirectConversion: nil,
         conversionCheck: nil
       )
     }
@@ -975,7 +940,6 @@ extension JNISwift2JavaGenerator {
           JavaParameter(name: parameterName, type: .long)
         ],
         conversion: .initFromJNI(.placeholder, swiftType: knownTypes.set(elementType)),
-        indirectConversion: nil,
         conversionCheck: nil
       )
     }
@@ -1009,14 +973,11 @@ extension JNISwift2JavaGenerator {
     var parameters: [JavaParameter]
 
     /// Represents how to convert the JNI parameter to a Swift parameter
-    let conversion: NativeSwiftConversionStep
-
-    /// Represents swift type for conversion checks. This will introduce a new name$indirect variable used in required checks.
-    /// e.g Int64 for Int overflow check on 32-bit platforms
-    let indirectConversion: NativeSwiftConversionStep?
+    var conversion: NativeSwiftConversionStep
 
     /// Represents check operations executed in if/guard conditional block for check during conversion
-    let conversionCheck: NativeSwiftConversionCheck?
+    /// e.g Int64 for Int overflow check on 32-bit platforms
+    var conversionCheck: NativeSwiftConversionCheck?
   }
 
   struct NativeResult {
@@ -1145,14 +1106,9 @@ extension JNISwift2JavaGenerator {
     /// `{ (args) -> return body }`
     indirect case closure(args: [String] = [], body: NativeSwiftConversionStep)
 
-    indirect case labelessAssignmentOfVariable(NativeSwiftConversionStep, swiftType: SwiftType)
-
     indirect case aggregate(variable: String, [NativeSwiftConversionStep])
 
     indirect case replacingPlaceholder(NativeSwiftConversionStep, placeholder: NativeSwiftConversionStep)
-
-    /// `SwiftType(inner)`
-    indirect case labelessInitializer(NativeSwiftConversionStep, swiftType: SwiftType)
 
     /// Constructs a Swift tuple from individually-converted elements.
     /// E.g. `(label0: conv0, conv1)` for `(label0: Int, String)`
@@ -1694,9 +1650,6 @@ extension JNISwift2JavaGenerator {
         }
         return printer.finalize()
 
-      case .labelessAssignmentOfVariable(let name, let swiftType):
-        return "\(swiftType)(\(JNISwift2JavaGenerator.indirectVariableName(for: name.render(&printer, placeholder))))"
-
       case .aggregate(let variable, let steps):
         precondition(!steps.isEmpty, "Aggregate must contain steps")
         printer.print("let \(variable) = \(placeholder)")
@@ -1708,10 +1661,6 @@ extension JNISwift2JavaGenerator {
       case .replacingPlaceholder(let inner, let newPlaceholder):
         let newPlaceholder = newPlaceholder.render(&printer, placeholder)
         return inner.render(&printer, newPlaceholder)
-
-      case .labelessInitializer(let inner, let swiftType):
-        let inner = inner.render(&printer, placeholder)
-        return "\(swiftType)(\(inner))"
 
       case .tupleConstruct(let elements):
         let parts = elements.enumerated().map { idx, element in

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -162,7 +162,11 @@ extension JNISwift2JavaGenerator {
               throw JavaTranslationError.unsupportedSwiftType(type)
             }
 
-            let indirectCheck = JNIJavaTypeTranslator.checkStep(for: knownType.kind, from: knownTypes)
+            let indirectCheck = JNIJavaTypeTranslator.checkStep(
+              parameterType: knownType.kind,
+              parameterName: parameterName,
+              from: knownTypes
+            )
 
             return NativeParameter(
               parameters: [
@@ -439,6 +443,12 @@ extension JNISwift2JavaGenerator {
               throw JavaTranslationError.unsupportedSwiftType(swiftType)
             }
 
+            let indirectCheck = JNIJavaTypeTranslator.checkStep(
+              parameterType: knownType,
+              parameterName: valueName,
+              from: knownTypes
+            )
+
             return NativeParameter(
               parameters: [
                 JavaParameter(name: discriminatorName, type: .byte),
@@ -449,7 +459,7 @@ extension JNISwift2JavaGenerator {
                 discriminatorName: discriminatorName,
                 valueName: valueName
               ),
-              conversionCheck: nil
+              conversionCheck: indirectCheck
             )
           }
         }
@@ -1700,13 +1710,13 @@ extension JNISwift2JavaGenerator {
   }
 
   enum NativeSwiftConversionCheck {
-    case check32BitIntOverflow(typeWithMinAndMax: SwiftType)
+    case check32BitIntOverflow(parameterName: String, typeWithMinAndMax: SwiftType)
 
     // Returns the check string
     func render(_ printer: inout CodePrinter, _ placeholder: String) -> String {
       switch self {
-      case .check32BitIntOverflow(let minMaxSource):
-        return "\(placeholder) >= \(minMaxSource).min && \(placeholder) <= \(minMaxSource).max"
+      case .check32BitIntOverflow(let parameterName, let minMaxSource):
+        return "\(parameterName) >= \(minMaxSource).min && \(parameterName) <= \(minMaxSource).max"
       }
     }
   }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -886,7 +886,7 @@ extension JNISwift2JavaGenerator {
                       .constant("pointer$"),
                       swiftType: elementType,
                       allowNil: false,
-                      convertLongFromJNI: false
+                      convertFromJNI: false
                     )
                   )
                 )
@@ -1035,7 +1035,7 @@ extension JNISwift2JavaGenerator {
       NativeSwiftConversionStep,
       swiftType: SwiftType,
       allowNil: Bool = false,
-      convertLongFromJNI: Bool = true
+      convertFromJNI: Bool = true
     )
 
     indirect case extractMetatypeValue(NativeSwiftConversionStep)
@@ -1223,11 +1223,11 @@ extension JNISwift2JavaGenerator {
         // TODO: Remove the _openExistential when we decide to only support language mode v6+
         printer.print(
           """
-          guard let \(inner)TypeMetadataPointer$ = UnsafeRawPointer(bitPattern: Int(Int64(fromJNI: \(typeMetadataVariableName), in: environment))) else {
+          guard let \(inner)TypeMetadataPointer$ = UnsafeRawPointer(bitPattern: Int(fromJNI: \(typeMetadataVariableName), in: environment)) else {
             fatalError("\(typeMetadataVariableName) memory address was null")
           }
           let \(inner)DynamicType$: Any.Type = unsafeBitCast(\(inner)TypeMetadataPointer$, to: Any.Type.self)
-          guard let \(inner)RawPointer$ = UnsafeMutableRawPointer(bitPattern: Int(Int64(fromJNI: \(inner), in: environment))) else {
+          guard let \(inner)RawPointer$ = UnsafeMutableRawPointer(bitPattern: Int(fromJNI: \(inner), in: environment)) else {
             fatalError("\(inner) memory address was null")
           }
           #if hasFeature(ImplicitOpenExistentials)
@@ -1242,14 +1242,14 @@ extension JNISwift2JavaGenerator {
         )
         return existentialName
 
-      case .extractSwiftValue(let inner, let swiftType, let allowNil, let convertLongFromJNI):
+      case .extractSwiftValue(let inner, let swiftType, let allowNil, let convertFromJNI):
         let inner = inner.render(&printer, placeholder)
         let pointerName = "\(inner)$"
         if !allowNil {
           printer.print(#"assert(\#(inner) != 0, "\#(inner) memory address was null")"#)
         }
-        if convertLongFromJNI {
-          printer.print("let \(inner)Bits$ = Int(Int64(fromJNI: \(inner), in: environment))")
+        if convertFromJNI {
+          printer.print("let \(inner)Bits$ = Int(fromJNI: \(inner), in: environment)")
         } else {
           printer.print("let \(inner)Bits$ = Int(\(inner))")
         }
@@ -1270,7 +1270,7 @@ extension JNISwift2JavaGenerator {
         let pointerName = "\(inner)$"
         printer.print(
           """
-          let \(inner)Bits$ = Int(Int64(fromJNI: \(inner), in: environment))
+          let \(inner)Bits$ = Int(fromJNI: \(inner), in: environment)
           guard let \(pointerName) = UnsafeRawPointer(bitPattern: \(inner)Bits$) else {
             fatalError("\(inner) metadata address was null")
           }
@@ -1286,7 +1286,7 @@ extension JNISwift2JavaGenerator {
           """
           let \(pointerName) = UnsafeMutablePointer<\(swiftType)>.allocate(capacity: 1)
           \(pointerName).initialize(to: \(inner))
-          let \(bitsName) = Int64(Int(bitPattern: \(pointerName)))
+          let \(bitsName) = Int(bitPattern: \(pointerName))
           """
         )
         return bitsName
@@ -1478,7 +1478,7 @@ extension JNISwift2JavaGenerator {
             """
             environment.interface.SetLongField(environment, \(outArgumentName), _JNIMethodIDCache._OutSwiftGenericInstance.selfPointer, \(inner))
             let metadataPointer = unsafeBitCast(\(swiftFunctionResultType).self, to: UnsafeRawPointer.self)
-            let metadataPointerBits$ = Int64(Int(bitPattern: metadataPointer))
+            let metadataPointerBits$ = Int(bitPattern: metadataPointer)
             environment.interface.SetLongField(environment, \(outArgumentName), _JNIMethodIDCache._OutSwiftGenericInstance.selfTypePointer, metadataPointerBits$.getJNIValue(in: environment))
             """
           )

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -809,7 +809,7 @@ extension JNISwift2JavaGenerator {
       printer.print(
         """
         let metadataPointer = unsafeBitCast(\(type.swiftNominal.qualifiedName).self, to: UnsafeRawPointer.self)
-        return Int64(Int(bitPattern: metadataPointer)).getJNIValue(in: environment)
+        return Int(bitPattern: metadataPointer).getJNIValue(in: environment)
         """
       )
     }
@@ -990,7 +990,7 @@ extension JNISwift2JavaGenerator {
         fatalError("Missing JNIEnv in downcall to \\(#function)")
       }
       assert(\(selfPointerParam.name) != 0, "\(selfPointerParam.name) memory address was null")
-      let selfPointerBits$ = Int(Int64(fromJNI: \(selfPointerParam.name), in: env$))
+      let selfPointerBits$ = Int(fromJNI: \(selfPointerParam.name), in: env$)
       guard let \(newSelfParamName) = UnsafeMutablePointer<\(swiftParentName)>(bitPattern: selfPointerBits$) else {
         fatalError("selfPointer memory address was null in call to \\(#function)!")
       }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -1014,7 +1014,7 @@ extension JNISwift2JavaGenerator {
     printer.print(
       """
       assert(selfPointer != 0, "selfPointer memory address was null")
-      let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+      let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
       let selfPointer$ = UnsafeMutablePointer<\(concreteSwiftType)>(bitPattern: selfPointerBits$)
       guard let selfPointer$ else {
         fatalError("selfPointer memory address was null in call to \\(#function)!")

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -570,7 +570,6 @@ extension JNISwift2JavaGenerator {
 
     // Regular parameters.
     var arguments: [String] = [String]()
-    var indirectVariables: [(name: String, lowered: String)] = []
     var int32OverflowChecks: [String] = []
 
     for (idx, parameter) in nativeSignature.parameters.enumerated() {
@@ -578,26 +577,14 @@ extension JNISwift2JavaGenerator {
       let lowered = parameter.conversion.render(&printer, javaParameterName)
       arguments.append(lowered)
 
-      parameter.indirectConversion.flatMap {
-        indirectVariables.append((javaParameterName, $0.render(&printer, javaParameterName)))
-      }
-
       switch parameter.conversionCheck {
       case .check32BitIntOverflow:
         int32OverflowChecks.append(
-          parameter.conversionCheck!.render(
-            &printer,
-            JNISwift2JavaGenerator.indirectVariableName(for: javaParameterName)
-          )
+          parameter.conversionCheck!.render(&printer, javaParameterName)
         )
       case nil:
         break
       }
-    }
-
-    // Make indirect variables
-    for (name, lowered) in indirectVariables {
-      printer.print("let \(JNISwift2JavaGenerator.indirectVariableName(for: name)) = \(lowered)")
     }
 
     if !int32OverflowChecks.isEmpty {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
@@ -128,9 +128,3 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
     }
   }
 }
-
-extension JNISwift2JavaGenerator {
-  static func indirectVariableName(for parameterName: String) -> String {
-    "\(parameterName)$indirect"
-  }
-}

--- a/Sources/SwiftJava/BridgedValues/JavaBoxing.swift
+++ b/Sources/SwiftJava/BridgedValues/JavaBoxing.swift
@@ -238,7 +238,7 @@ extension Int: JavaBoxable {
     let cls = environment.interface.FindClass(environment, "java/lang/Long")
     let methodID = environment.interface.GetMethodID(environment, cls, "<init>", "(J)V")
     var args = [jvalue()]
-    args[0].j = Int64(self).getJNIValue(in: environment)
+    args[0].j = self.getJNIValue(in: environment)
     return environment.interface.NewObjectA(environment, cls, methodID, &args)
   }
 
@@ -247,7 +247,7 @@ extension Int: JavaBoxable {
     let cls = environment.interface.GetObjectClass(environment, obj)
     let methodID = environment.interface.GetMethodID(environment, cls, "longValue", "()J")
     let result = environment.interface.CallLongMethodA(environment, obj, methodID, nil)
-    return Int(Int64(fromJNI: result, in: environment))
+    return Int(fromJNI: result, in: environment)
   }
 }
 
@@ -256,7 +256,7 @@ extension UInt: JavaBoxable {
     let cls = environment.interface.FindClass(environment, "java/lang/Long")
     let methodID = environment.interface.GetMethodID(environment, cls, "<init>", "(J)V")
     var args = [jvalue()]
-    args[0].j = Int64(bitPattern: UInt64(self)).getJNIValue(in: environment)
+    args[0].j = self.getJNIValue(in: environment)
     return environment.interface.NewObjectA(environment, cls, methodID, &args)
   }
 
@@ -265,7 +265,7 @@ extension UInt: JavaBoxable {
     let cls = environment.interface.GetObjectClass(environment, obj)
     let methodID = environment.interface.GetMethodID(environment, cls, "longValue", "()J")
     let result = environment.interface.CallLongMethodA(environment, obj, methodID, nil)
-    return UInt(UInt64(fromJNI: result, in: environment))
+    return UInt(fromJNI: result, in: environment)
   }
 }
 

--- a/Sources/SwiftJava/BridgedValues/SwiftDictionaryMap+JNI.swift
+++ b/Sources/SwiftJava/BridgedValues/SwiftDictionaryMap+JNI.swift
@@ -21,18 +21,18 @@ open class SwiftDictionaryMapJava: JavaObject {
 @JavaImplementation("org.swift.swiftkit.core.collections.SwiftDictionaryMap")
 extension SwiftDictionaryMapJava {
 
-  private static func box(from pointer: Int64) -> AnySwiftDictionaryBox {
-    let rawPointer = UnsafeRawPointer(bitPattern: Int(pointer))!
+  private static func box(from pointer: Int) -> AnySwiftDictionaryBox {
+    let rawPointer = UnsafeRawPointer(bitPattern: pointer)!
     return Unmanaged<AnySwiftDictionaryBox>.fromOpaque(rawPointer).takeUnretainedValue()
   }
 
   @JavaMethod("$size")
-  public static func _size(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> Int32 {
+  public static func _size(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> Int32 {
     Int32(box(from: pointer).size())
   }
 
   @JavaMethod("$get")
-  public static func _get(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64, key: JavaObject?) -> JavaObject? {
+  public static func _get(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int, key: JavaObject?) -> JavaObject? {
     let jKey = key?.javaThis
     let box = box(from: pointer)
     guard let result = box.get(key: jKey, environment: environment) else {
@@ -42,34 +42,34 @@ extension SwiftDictionaryMapJava {
   }
 
   @JavaMethod("$containsKey")
-  public static func _containsKey(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64, key: JavaObject?) -> Bool {
+  public static func _containsKey(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int, key: JavaObject?) -> Bool {
     let jKey = key?.javaThis
     return box(from: pointer).containsKey(key: jKey, environment: environment)
   }
 
   @JavaMethod("$keys")
-  public static func _keys(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> JavaObject? {
+  public static func _keys(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> JavaObject? {
     guard let result = box(from: pointer).keys(environment: environment) else { return nil }
     return JavaObject(javaThis: result, environment: environment)
   }
 
   @JavaMethod("$values")
-  public static func _values(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> JavaObject? {
+  public static func _values(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> JavaObject? {
     guard let result = box(from: pointer).values(environment: environment) else { return nil }
     return JavaObject(javaThis: result, environment: environment)
   }
 
   @JavaMethod("$destroy")
-  public static func _destroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) {
+  public static func _destroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) {
     let rawPointer = UnsafeRawPointer(bitPattern: Int(pointer))!
     Unmanaged<AnySwiftDictionaryBox>.fromOpaque(rawPointer).release()
   }
 
   @JavaMethod("$typeMetadataAddress")
-  public static func _typeMetadataAddress(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> Int64 {
+  public static func _typeMetadataAddress(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> Int {
     let dictionary = box(from: pointer).dictionaryAsAny()
     let metatype = type(of: dictionary)
     let metadataPointer = unsafeBitCast(metatype, to: UnsafeRawPointer.self)
-    return Int64(Int(bitPattern: metadataPointer))
+    return Int(bitPattern: metadataPointer)
   }
 }

--- a/Sources/SwiftJava/BridgedValues/SwiftSet+JNI.swift
+++ b/Sources/SwiftJava/BridgedValues/SwiftSet+JNI.swift
@@ -21,39 +21,39 @@ open class SwiftSetJava: JavaObject {
 @JavaImplementation("org.swift.swiftkit.core.collections.SwiftSet")
 extension SwiftSetJava {
 
-  private static func setBox(from pointer: Int64) -> AnySwiftSetBox {
-    let rawPointer = UnsafeRawPointer(bitPattern: Int(pointer))!
+  private static func setBox(from pointer: Int) -> AnySwiftSetBox {
+    let rawPointer = UnsafeRawPointer(bitPattern: pointer)!
     return Unmanaged<AnySwiftSetBox>.fromOpaque(rawPointer).takeUnretainedValue()
   }
 
   @JavaMethod("$size")
-  public static func _setSize(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> Int32 {
+  public static func _setSize(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> Int32 {
     Int32(setBox(from: pointer).size())
   }
 
   @JavaMethod("$contains")
-  public static func _setContains(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64, element: JavaObject?) -> Bool {
+  public static func _setContains(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int, element: JavaObject?) -> Bool {
     let jElement = element?.javaThis
     return setBox(from: pointer).contains(element: jElement, environment: environment)
   }
 
   @JavaMethod("$toArray")
-  public static func _setToArray(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> JavaObject? {
+  public static func _setToArray(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> JavaObject? {
     guard let result = setBox(from: pointer).toArray(environment: environment) else { return nil }
     return JavaObject(javaThis: result, environment: environment)
   }
 
   @JavaMethod("$destroy")
-  public static func _setDestroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) {
+  public static func _setDestroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) {
     let rawPointer = UnsafeRawPointer(bitPattern: Int(pointer))!
     Unmanaged<AnySwiftSetBox>.fromOpaque(rawPointer).release()
   }
 
   @JavaMethod("$typeMetadataAddress")
-  public static func _setTypeMetadataAddress(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> Int64 {
+  public static func _setTypeMetadataAddress(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> Int {
     let set = setBox(from: pointer).setAsAny()
     let metatype = type(of: set)
     let metadataPointer = unsafeBitCast(metatype, to: UnsafeRawPointer.self)
-    return Int64(Int(bitPattern: metadataPointer))
+    return Int(bitPattern: metadataPointer)
   }
 }

--- a/Sources/SwiftJava/SwiftObjects.swift
+++ b/Sources/SwiftJava/SwiftObjects.swift
@@ -23,8 +23,8 @@ open class SwiftObjects: JavaObject {
 @JavaImplementation("org.swift.swiftkit.core.SwiftObjects")
 extension SwiftObjects {
   @JavaMethod
-  public static func getRawDiscriminator(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int64, selfTypePointer: Int64) -> Int32 {
-    guard let selfType$ = UnsafeRawPointer(bitPattern: Int(selfTypePointer)) else {
+  public static func getRawDiscriminator(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int, selfTypePointer: Int) -> Int32 {
+    guard let selfType$ = UnsafeRawPointer(bitPattern: selfTypePointer) else {
       fatalError("selfType metadata address was null")
     }
     let typeMetadata = unsafeBitCast(selfType$, to: Any.Type.self)
@@ -33,7 +33,7 @@ extension SwiftObjects {
     }
 
     func perform<T: _RawDiscriminatorRepresentable>(as type: T.Type) -> Int32 {
-      guard let self$ = UnsafeMutablePointer<T>(bitPattern: Int(selfPointer)) else {
+      guard let self$ = UnsafeMutablePointer<T>(bitPattern: selfPointer) else {
         fatalError("self memory address was null")
       }
       return self$.pointee._rawDiscriminator
@@ -42,14 +42,14 @@ extension SwiftObjects {
   }
 
   @JavaMethod
-  public static func toString(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int64, selfTypePointer: Int64) -> String {
-    guard let selfType$ = UnsafeRawPointer(bitPattern: Int(selfTypePointer)) else {
+  public static func toString(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int, selfTypePointer: Int) -> String {
+    guard let selfType$ = UnsafeRawPointer(bitPattern: selfTypePointer) else {
       fatalError("selfType metadata address was null")
     }
     let typeMetadata = unsafeBitCast(selfType$, to: Any.Type.self)
 
     func perform<T>(as type: T.Type) -> String {
-      guard let self$ = UnsafeMutablePointer<T>(bitPattern: Int(selfPointer)) else {
+      guard let self$ = UnsafeMutablePointer<T>(bitPattern: selfPointer) else {
         fatalError("self memory address was null")
       }
       return String(describing: self$.pointee)
@@ -58,14 +58,14 @@ extension SwiftObjects {
   }
 
   @JavaMethod
-  public static func toDebugString(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int64, selfTypePointer: Int64) -> String {
-    guard let selfType$ = UnsafeRawPointer(bitPattern: Int(selfTypePointer)) else {
+  public static func toDebugString(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int, selfTypePointer: Int) -> String {
+    guard let selfType$ = UnsafeRawPointer(bitPattern: selfTypePointer) else {
       fatalError("selfType metadata address was null")
     }
     let typeMetadata = unsafeBitCast(selfType$, to: Any.Type.self)
 
     func perform<T>(as type: T.Type) -> String {
-      guard let self$ = UnsafeMutablePointer<T>(bitPattern: Int(selfPointer)) else {
+      guard let self$ = UnsafeMutablePointer<T>(bitPattern: selfPointer) else {
         fatalError("self memory address was null")
       }
       return String(reflecting: self$.pointee)
@@ -74,14 +74,14 @@ extension SwiftObjects {
   }
 
   @JavaMethod
-  public static func destroy(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int64, selfTypePointer: Int64) {
-    guard let selfType$ = UnsafeRawPointer(bitPattern: Int(selfTypePointer)) else {
+  public static func destroy(environment: UnsafeMutablePointer<JNIEnv?>!, selfPointer: Int, selfTypePointer: Int) {
+    guard let selfType$ = UnsafeRawPointer(bitPattern: selfTypePointer) else {
       fatalError("selfType metadata address was null")
     }
     let typeMetadata = unsafeBitCast(selfType$, to: Any.Type.self)
 
     func perform<T>(as type: T.Type) {
-      guard let self$ = UnsafeMutablePointer<T>(bitPattern: Int(selfPointer)) else {
+      guard let self$ = UnsafeMutablePointer<T>(bitPattern: selfPointer) else {
         fatalError("self memory address was null")
       }
       self$.deinitialize(count: 1)

--- a/Tests/JExtractSwiftTests/JNI/JNIArrayTest.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIArrayTest.swift
@@ -184,7 +184,7 @@ struct JNIArrayTest {
           )).map( { (object$) in
             let object$$ = UnsafeMutablePointer<MySwiftClass>.allocate(capacity: 1)
             object$$.initialize(to: object$)
-            let object$Bits$ = Int64(Int(bitPattern: object$$))
+            let object$Bits$ = Int(bitPattern: object$$)
             return object$Bits$
           }
           ).getJNILocalRefValue(in: environment)

--- a/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIAsyncTests.swift
@@ -315,7 +315,7 @@ struct JNIAsyncTests {
         @_cdecl("Java_com_example_swift_SwiftModule__00024async__JLjava_util_concurrent_CompletableFuture_2")
         public func Java_com_example_swift_SwiftModule__00024async__JLjava_util_concurrent_CompletableFuture_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, c: jlong, result_future: jobject?) {
           assert(c != 0, "c memory address was null")
-          let cBits$ = Int(Int64(fromJNI: c, in: environment))
+          let cBits$ = Int(fromJNI: c, in: environment)
           let c$ = UnsafeMutablePointer<MyClass>(bitPattern: cBits$)
           guard let c$ else {
             fatalError("c memory address was null in call to \\(#function)!")
@@ -334,7 +334,7 @@ struct JNIAsyncTests {
                 environment = try! JavaVirtualMachine.shared().environment()
                 let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
                 result$.initialize(to: swiftResult$)
-                let resultBits$ = Int64(Int(bitPattern: result$))
+                let resultBits$ = Int(bitPattern: result$)
                 let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(resultBits$.getJNILocalRefValue(in: environment), in: environment)
                 _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
               }
@@ -351,7 +351,7 @@ struct JNIAsyncTests {
               environment = try! JavaVirtualMachine.shared().environment()
               let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
               result$.initialize(to: swiftResult$)
-              let resultBits$ = Int64(Int(bitPattern: result$))
+              let resultBits$ = Int(bitPattern: result$)
               let boxedResult$ = SwiftJavaRuntimeSupport._JNIBoxedConversions.box(resultBits$.getJNILocalRefValue(in: environment), in: environment)
               _ = environment.interface.CallBooleanMethodA(environment, globalFuture, _JNIMethodIDCache.CompletableFuture.complete, [jvalue(l: boxedResult$)])
             }

--- a/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
@@ -221,7 +221,7 @@ struct JNIClassTests {
         public func Java_com_example_swift_MyClass__00024init__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, x: jlong, y: jlong) -> jlong {
           let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
           result$.initialize(to: MyClass.init(x: Int64(fromJNI: x, in: environment), y: Int64(fromJNI: y, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """,
@@ -230,7 +230,7 @@ struct JNIClassTests {
         public func Java_com_example_swift_MyClass__00024init__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jlong {
           let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
           result$.initialize(to: MyClass.init())
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """,
@@ -275,7 +275,7 @@ struct JNIClassTests {
         @_cdecl("Java_com_example_swift_MyClass__00024doSomething__JJ")
         public func Java_com_example_swift_MyClass__00024doSomething__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, x: jlong, selfPointer: jlong) {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyClass>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -324,14 +324,14 @@ struct JNIClassTests {
         @_cdecl("Java_com_example_swift_MyClass__00024copy__J")
         public func Java_com_example_swift_MyClass__00024copy__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong) -> jlong {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyClass>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
           }
           let result$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
           result$.initialize(to: selfPointer$.pointee.copy())
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """
@@ -376,13 +376,13 @@ struct JNIClassTests {
         @_cdecl("Java_com_example_swift_MyClass__00024isEqual__JJ")
         public func Java_com_example_swift_MyClass__00024isEqual__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, other: jlong, selfPointer: jlong) -> jboolean {
           assert(other != 0, "other memory address was null")
-          let otherBits$ = Int(Int64(fromJNI: other, in: environment))
+          let otherBits$ = Int(fromJNI: other, in: environment)
           let other$ = UnsafeMutablePointer<MyClass>(bitPattern: otherBits$)
           guard let other$ else {
             fatalError("other memory address was null in call to \\(#function)!")
           }
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyClass>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -233,7 +233,7 @@ struct JNIEnumTests {
         public func Java_com_example_swift_MyEnum__00024first__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jlong {
           let result$ = UnsafeMutablePointer<MyEnum>.allocate(capacity: 1)
           result$.initialize(to: MyEnum.first)
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """,
@@ -242,7 +242,7 @@ struct JNIEnumTests {
         public func Java_com_example_swift_MyEnum__00024second__Ljava_lang_String_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg0: jstring?) -> jlong {
           let result$ = UnsafeMutablePointer<MyEnum>.allocate(capacity: 1)
           result$.initialize(to: MyEnum.second(String(fromJNI: arg0, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """,
@@ -251,7 +251,7 @@ struct JNIEnumTests {
         public func Java_com_example_swift_MyEnum__00024third__JI(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, x: jlong, y: jint) -> jlong {
           let result$ = UnsafeMutablePointer<MyEnum>.allocate(capacity: 1)
           result$.initialize(to: MyEnum.third(x: Int64(fromJNI: x, in: environment), y: Int32(fromJNI: y, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """,

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericCombinationTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericCombinationTests.swift
@@ -83,11 +83,11 @@ struct JNIGenericCombinationTests {
             if let innerResult$ = SwiftModule.makeStringIDOptional(String(fromJNI: value, in: environment)) {
               let resultWrapped$ = UnsafeMutablePointer<MyID<String>>.allocate(capacity: 1)
               resultWrapped$.initialize(to: innerResult$)
-              let resultWrappedBits$ = Int64(Int(bitPattern: resultWrapped$))
+              let resultWrappedBits$ = Int(bitPattern: resultWrapped$)
               do {
                environment.interface.SetLongField(environment, resultWrappedOut, _JNIMethodIDCache._OutSwiftGenericInstance.selfPointer, resultWrappedBits$.getJNIValue(in: environment))
                let metadataPointer = unsafeBitCast(MyID<String>.self, to: UnsafeRawPointer.self)
-               let metadataPointerBits$ = Int64(Int(bitPattern: metadataPointer))
+               let metadataPointerBits$ = Int(bitPattern: metadataPointer)
                environment.interface.SetLongField(environment, resultWrappedOut, _JNIMethodIDCache._OutSwiftGenericInstance.selfTypePointer, metadataPointerBits$.getJNIValue(in: environment))
               }
               var flag$ = Int8(1)
@@ -135,7 +135,7 @@ struct JNIGenericCombinationTests {
           """
           @_cdecl("Java_com_example_swift_SwiftModule__00024takeStringIDOptional__J")
           public func Java_com_example_swift_SwiftModule__00024takeStringIDOptional__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, value: jlong) {
-            let valueBits$ = Int(Int64(fromJNI: value, in: environment))
+            let valueBits$ = Int(fromJNI: value, in: environment)
             let value$ = UnsafeMutablePointer<MyID<String>>(bitPattern: valueBits$)
             SwiftModule.takeStringIDOptional(value$?.pointee)
           }
@@ -201,20 +201,20 @@ struct JNIGenericCombinationTests {
             let tupleResult$ = SwiftModule.makeIDs(String(fromJNI: stringValue, in: environment), Int64(fromJNI: intValue, in: environment))
             let result_0$$ = UnsafeMutablePointer<MyID<String>>.allocate(capacity: 1)
             result_0$$.initialize(to: tupleResult$.0)
-            let result_0$Bits$ = Int64(Int(bitPattern: result_0$$))
+            let result_0$Bits$ = Int(bitPattern: result_0$$)
             do {
               environment.interface.SetLongField(environment, result_0$Out, _JNIMethodIDCache._OutSwiftGenericInstance.selfPointer, result_0$Bits$.getJNIValue(in: environment))
               let metadataPointer = unsafeBitCast(MyID<String>.self, to: UnsafeRawPointer.self)
-              let metadataPointerBits$ = Int64(Int(bitPattern: metadataPointer))
+              let metadataPointerBits$ = Int(bitPattern: metadataPointer)
               environment.interface.SetLongField(environment, result_0$Out, _JNIMethodIDCache._OutSwiftGenericInstance.selfTypePointer, metadataPointerBits$.getJNIValue(in: environment))
             }
             let result_1$$ = UnsafeMutablePointer<MyID<Int64>>.allocate(capacity: 1)
             result_1$$.initialize(to: tupleResult$.1)
-            let result_1$Bits$ = Int64(Int(bitPattern: result_1$$))
+            let result_1$Bits$ = Int(bitPattern: result_1$$)
             do {
               environment.interface.SetLongField(environment, result_1$Out, _JNIMethodIDCache._OutSwiftGenericInstance.selfPointer, result_1$Bits$.getJNIValue(in: environment))
               let metadataPointer = unsafeBitCast(MyID<Int64>.self, to: UnsafeRawPointer.self)
-              let metadataPointerBits$ = Int64(Int(bitPattern: metadataPointer))
+              let metadataPointerBits$ = Int(bitPattern: metadataPointer)
               environment.interface.SetLongField(environment, result_1$Out, _JNIMethodIDCache._OutSwiftGenericInstance.selfTypePointer, metadataPointerBits$.getJNIValue(in: environment))
             }
             return 
@@ -259,13 +259,13 @@ struct JNIGenericCombinationTests {
           @_cdecl("Java_com_example_swift_SwiftModule__00024takeValues__JJ_3Ljava_lang_String_2_3J")
           public func Java_com_example_swift_SwiftModule__00024takeValues__JJ_3Ljava_lang_String_2_3J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, tuple_0: jlong, tuple_1: jlong, result_0$: jobjectArray?, result_1$: jlongArray?) {
             assert(tuple_0 != 0, "tuple_0 memory address was null")
-            let tuple_0Bits$ = Int(Int64(fromJNI: tuple_0, in: environment))
+            let tuple_0Bits$ = Int(fromJNI: tuple_0, in: environment)
             let tuple_0$ = UnsafeMutablePointer<MyID<String>>(bitPattern: tuple_0Bits$)
             guard let tuple_0$ else {
               fatalError("tuple_0 memory address was null in call to \(#function)!")
             }
             assert(tuple_1 != 0, "tuple_1 memory address was null")
-            let tuple_1Bits$ = Int(Int64(fromJNI: tuple_1, in: environment))
+            let tuple_1Bits$ = Int(fromJNI: tuple_1, in: environment)
             let tuple_1$ = UnsafeMutablePointer<MyID<Int64>>(bitPattern: tuple_1Bits$)
             guard let tuple_1$ else {
               fatalError("tuple_1 memory address was null in call to \(#function)!")

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
@@ -120,7 +120,7 @@ struct JNIGenericTypeTests {
         extension MyID: _SwiftModule_MyID_opener {
           static func _get_description(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong) -> jstring? {
             assert(selfPointer != 0, "selfPointer memory address was null")
-            let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+            let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
             let selfPointer$ = UnsafeMutablePointer<MyID>(bitPattern: selfPointerBits$)
             guard let selfPointer$ else {
               fatalError("selfPointer memory address was null in call to \(#function)!")
@@ -133,7 +133,7 @@ struct JNIGenericTypeTests {
         """
         @_cdecl("Java_com_example_swift_MyID__00024getDescription__JJ")
         public func Java_com_example_swift_MyID__00024getDescription__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong, selfTypePointer: jlong) -> jstring? {
-          let selfTypePointerBits$ = Int(Int64(fromJNI: selfTypePointer, in: environment))
+          let selfTypePointerBits$ = Int(fromJNI: selfTypePointer, in: environment)
           guard let selfTypePointer$ = UnsafeRawPointer(bitPattern: selfTypePointerBits$) else {
             fatalError("selfTypePointer metadata address was null")
           }
@@ -188,11 +188,11 @@ struct JNIGenericTypeTests {
         public func Java_com_example_swift_SwiftModule__00024makeStringID__Ljava_lang_String_2Lorg_swift_swiftkit_core__1OutSwiftGenericInstance_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, value: jstring?, resultOut: jobject?) {
           let result$ = UnsafeMutablePointer<MyID<String>>.allocate(capacity: 1)
           result$.initialize(to: SwiftModule.makeStringID(String(fromJNI: value, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           do {
             environment.interface.SetLongField(environment, resultOut, _JNIMethodIDCache._OutSwiftGenericInstance.selfPointer, resultBits$.getJNIValue(in: environment))
             let metadataPointer = unsafeBitCast(MyID<String>.self, to: UnsafeRawPointer.self)
-            let metadataPointerBits$ = Int64(Int(bitPattern: metadataPointer))
+            let metadataPointerBits$ = Int(bitPattern: metadataPointer)
             environment.interface.SetLongField(environment, resultOut, _JNIMethodIDCache._OutSwiftGenericInstance.selfTypePointer, metadataPointerBits$.getJNIValue(in: environment))
           }
           return
@@ -202,7 +202,7 @@ struct JNIGenericTypeTests {
         @_cdecl("Java_com_example_swift_SwiftModule__00024takeIntID__J")
         public func Java_com_example_swift_SwiftModule__00024takeIntID__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, value: jlong) -> jlong {
           assert(value != 0, "value memory address was null")
-          let valueBits$ = Int(Int64(fromJNI: value, in: environment))
+          let valueBits$ = Int(fromJNI: value, in: environment)
           let value$ = UnsafeMutablePointer<MyID<Int>>(bitPattern: valueBits$)
           guard let value$ else {
             fatalError("value memory address was null in call to \\(#function)!")

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
@@ -207,7 +207,7 @@ struct JNIGenericTypeTests {
           guard let value$ else {
             fatalError("value memory address was null in call to \\(#function)!")
           }
-          return Int64(SwiftModule.takeIntID(value$.pointee)).getJNILocalRefValue(in: environment)
+          return SwiftModule.takeIntID(value$.pointee).getJNILocalRefValue(in: environment)
         }
         """,
       ]

--- a/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
@@ -65,18 +65,17 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyStruct__00024init__J")
         public func Java_com_example_swift_MyStruct__00024init__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, normalInt: jlong) -> jlong {
-          let normalInt$indirect = Int64(fromJNI: normalInt, in: environment)
           #if _pointerBitWidth(_32)
-          guard normalInt$indirect >= Int32.min && normalInt$indirect <= Int32.max else {
+          guard normalInt >= Int32.min && normalInt <= Int32.max else {
             environment.throwJavaException(javaException: .integerOverflow)
             return Int64.jniPlaceholderValue
-        """,
-        """
-        #endif
-        let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
-        result$.initialize(to: MyStruct.init(normalInt: Int(normalInt$indirect)))
-        let resultBits$ = Int64(Int(bitPattern: result$))
-        return resultBits$.getJNILocalRefValue(in: environment)
+          }
+          #endif
+          let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
+          result$.initialize(to: MyStruct.init(normalInt: Int(fromJNI: normalInt, in: environment)))
+          let resultBits$ = Int64(Int(bitPattern: result$))
+          return resultBits$.getJNILocalRefValue(in: environment)
+        }
         """,
       ]
     )
@@ -91,18 +90,17 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyStruct__00024init__J")
         public func Java_com_example_swift_MyStruct__00024init__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, unsignedInt: jlong) -> jlong {
-          let unsignedInt$indirect = UInt64(fromJNI: unsignedInt, in: environment)
           #if _pointerBitWidth(_32)
-          guard unsignedInt$indirect >= UInt32.min && unsignedInt$indirect <= UInt32.max else {
+          guard unsignedInt >= UInt32.min && unsignedInt <= UInt32.max else {
             environment.throwJavaException(javaException: .integerOverflow)
             return Int64.jniPlaceholderValue
-        """,
-        """
-        #endif
-        let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
-        result$.initialize(to: MyStruct.init(unsignedInt: UInt(unsignedInt$indirect)))
-        let resultBits$ = Int64(Int(bitPattern: result$))
-        return resultBits$.getJNILocalRefValue(in: environment)
+          }
+          #endif
+          let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
+          result$.initialize(to: MyStruct.init(unsignedInt: UInt(fromJNI: unsignedInt, in: environment)))
+          let resultBits$ = Int64(Int(bitPattern: result$))
+          return resultBits$.getJNILocalRefValue(in: environment)
+        }
         """,
       ]
     )
@@ -117,21 +115,20 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyStruct__00024setUnsignedInt__JJ")
         public func Java_com_example_swift_MyStruct__00024setUnsignedInt__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, newValue: jlong, selfPointer: jlong) {
-          let newValue$indirect = UInt64(fromJNI: newValue, in: environment)
           #if _pointerBitWidth(_32)
-            guard newValue$indirect >= UInt32.min && newValue$indirect <= UInt32.max else {
-              environment.throwJavaException(javaException: .integerOverflow)
-              return
-        """,
-        """
-        #endif
-        assert(selfPointer != 0, "selfPointer memory address was null")
-        let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
-        let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
-        guard let selfPointer$ else {
-          fatalError("selfPointer memory address was null in call to \\(#function)!")
+          guard newValue >= UInt32.min && newValue <= UInt32.max else {
+            environment.throwJavaException(javaException: .integerOverflow)
+            return
+          }
+          #endif
+          assert(selfPointer != 0, "selfPointer memory address was null")
+          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
+          guard let selfPointer$ else {
+            fatalError("selfPointer memory address was null in call to \\(#function)!")
+          }
+          selfPointer$.pointee.unsignedInt = UInt(fromJNI: newValue, in: environment)
         }
-        selfPointer$.pointee.unsignedInt = UInt(newValue$indirect)
         """,
       ]
     )
@@ -152,7 +149,8 @@ struct JNIIntConversionChecksTests {
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
           }
-          return UInt64(selfPointer$.pointee.unsignedInt).getJNILocalRefValue(in: environment)
+          return selfPointer$.pointee.unsignedInt.getJNILocalRefValue(in: environment)
+        }
         """
       ]
     )
@@ -167,21 +165,20 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyStruct__00024setNormalInt__JJ")
         public func Java_com_example_swift_MyStruct__00024setNormalInt__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, newValue: jlong, selfPointer: jlong) {
-        let newValue$indirect = Int64(fromJNI: newValue, in: environment)
-        #if _pointerBitWidth(_32)
-        guard newValue$indirect >= Int32.min && newValue$indirect <= Int32.max else {
-          environment.throwJavaException(javaException: .integerOverflow)
-          return
-        """,
-        """
-        #endif
-        assert(selfPointer != 0, "selfPointer memory address was null")
-        let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
-        let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
-        guard let selfPointer$ else {
-          fatalError("selfPointer memory address was null in call to \\(#function)!")
+          #if _pointerBitWidth(_32)
+          guard newValue >= Int32.min && newValue <= Int32.max else {
+            environment.throwJavaException(javaException: .integerOverflow)
+            return
+          }
+          #endif
+          assert(selfPointer != 0, "selfPointer memory address was null")
+          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
+          guard let selfPointer$ else {
+            fatalError("selfPointer memory address was null in call to \\(#function)!")
+          }
+          selfPointer$.pointee.normalInt = Int(fromJNI: newValue, in: environment)
         }
-        selfPointer$.pointee.normalInt = Int(newValue$indirect)
         """,
       ]
     )
@@ -196,21 +193,20 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyStruct__00024dummyFunc__JJ")
         public func Java_com_example_swift_MyStruct__00024dummyFunc__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg: jlong, selfPointer: jlong) -> jlong {
-          let arg$indirect = Int64(fromJNI: arg, in: environment)
           #if _pointerBitWidth(_32)
-          guard arg$indirect >= Int32.min && arg$indirect <= Int32.max else {
+          guard arg >= Int32.min && arg <= Int32.max else {
             environment.throwJavaException(javaException: .integerOverflow)
             return Int64.jniPlaceholderValue
-        """,
-        """
-        #endif
-        assert(selfPointer != 0, "selfPointer memory address was null")
-        let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
-        let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
-        guard let selfPointer$ else {
-          fatalError("selfPointer memory address was null in call to \\(#function)!")
+          }
+          #endif
+          assert(selfPointer != 0, "selfPointer memory address was null")
+          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
+          guard let selfPointer$ else {
+            fatalError("selfPointer memory address was null in call to \\(#function)!")
+          }
+          return selfPointer$.pointee.dummyFunc(arg: Int(fromJNI: arg, in: environment)).getJNILocalRefValue(in: environment)
         }
-        return Int64(selfPointer$.pointee.dummyFunc(arg: Int(arg$indirect))).getJNILocalRefValue(in: environment)
         """,
       ]
     )
@@ -225,21 +221,21 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyStruct__00024dummyFunc__JJ")
         public func Java_com_example_swift_MyStruct__00024dummyFunc__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg: jlong, selfPointer: jlong) -> jlong {
-          let arg$indirect = UInt64(fromJNI: arg, in: environment)
           #if _pointerBitWidth(_32)
-          guard arg$indirect >= UInt32.min && arg$indirect <= UInt32.max else {
+          guard arg >= UInt32.min && arg <= UInt32.max else {
             environment.throwJavaException(javaException: .integerOverflow)
             return Int64.jniPlaceholderValue
-        """,
-        """
-        assert(selfPointer != 0, "selfPointer memory address was null")
-        let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
-        let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
-        guard let selfPointer$ else {
-          fatalError("selfPointer memory address was null in call to \\(#function)!")
+          }
+          #endif
+          assert(selfPointer != 0, "selfPointer memory address was null")
+          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
+          guard let selfPointer$ else {
+            fatalError("selfPointer memory address was null in call to \\(#function)!")
+          }
+          return selfPointer$.pointee.dummyFunc(arg: UInt(fromJNI: arg, in: environment)).getJNILocalRefValue(in: environment)
         }
-        return UInt64(selfPointer$.pointee.dummyFunc(arg: UInt(arg$indirect))).getJNILocalRefValue(in: environment)
-        """,
+        """
       ]
     )
   }
@@ -253,18 +249,17 @@ struct JNIIntConversionChecksTests {
         """
         @_cdecl("Java_com_example_swift_MyEnum__00024secondCase__J")
         public func Java_com_example_swift_MyEnum__00024secondCase__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg0: jlong) -> jlong {
-          let arg0$indirect = UInt64(fromJNI: arg0, in: environment)
           #if _pointerBitWidth(_32)
-          guard arg0$indirect >= UInt32.min && arg0$indirect <= UInt32.max else {
+          guard arg0 >= UInt32.min && arg0 <= UInt32.max else {
             environment.throwJavaException(javaException: .integerOverflow)
             return Int64.jniPlaceholderValue
-        """,
-        """
-        #endif
-        let result$ = UnsafeMutablePointer<MyEnum>.allocate(capacity: 1)
-        result$.initialize(to: MyEnum.secondCase(UInt(arg0$indirect)))
-        let resultBits$ = Int64(Int(bitPattern: result$))
-        return resultBits$.getJNILocalRefValue(in: environment)
+          }
+          #endif
+          let result$ = UnsafeMutablePointer<MyEnum>.allocate(capacity: 1)
+          result$.initialize(to: MyEnum.secondCase(UInt(fromJNI: arg0, in: environment)))
+          let resultBits$ = Int64(Int(bitPattern: result$))
+          return resultBits$.getJNILocalRefValue(in: environment)
+        }
         """,
       ]
     )

--- a/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
@@ -73,10 +73,10 @@ struct JNIIntConversionChecksTests {
           #endif
           let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
           result$.initialize(to: MyStruct.init(normalInt: Int(fromJNI: normalInt, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
-        """,
+        """
       ]
     )
   }
@@ -98,10 +98,10 @@ struct JNIIntConversionChecksTests {
           #endif
           let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
           result$.initialize(to: MyStruct.init(unsignedInt: UInt(fromJNI: unsignedInt, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
-        """,
+        """
       ]
     )
   }
@@ -122,14 +122,14 @@ struct JNIIntConversionChecksTests {
           }
           #endif
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
           }
           selfPointer$.pointee.unsignedInt = UInt(fromJNI: newValue, in: environment)
         }
-        """,
+        """
       ]
     )
   }
@@ -144,7 +144,7 @@ struct JNIIntConversionChecksTests {
         @_cdecl("Java_com_example_swift_MyStruct__00024getUnsignedInt__J")
         public func Java_com_example_swift_MyStruct__00024getUnsignedInt__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong) -> jlong {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -172,14 +172,14 @@ struct JNIIntConversionChecksTests {
           }
           #endif
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
           }
           selfPointer$.pointee.normalInt = Int(fromJNI: newValue, in: environment)
         }
-        """,
+        """
       ]
     )
   }
@@ -200,14 +200,14 @@ struct JNIIntConversionChecksTests {
           }
           #endif
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
           }
           return selfPointer$.pointee.dummyFunc(arg: Int(fromJNI: arg, in: environment)).getJNILocalRefValue(in: environment)
         }
-        """,
+        """
       ]
     )
   }
@@ -228,7 +228,7 @@ struct JNIIntConversionChecksTests {
           }
           #endif
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -257,10 +257,10 @@ struct JNIIntConversionChecksTests {
           #endif
           let result$ = UnsafeMutablePointer<MyEnum>.allocate(capacity: 1)
           result$.initialize(to: MyEnum.secondCase(UInt(fromJNI: arg0, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
-        """,
+        """
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
@@ -55,6 +55,12 @@ struct JNIIntConversionChecksTests {
       case secondCase(UInt)
     }
     """
+  private let optionalFuncSource = """
+    public struct MyStruct {
+      public func dummyFunc(arg: Int?) {
+      }
+    }
+    """
 
   @Test func generatesInitWithSignedCheck() throws {
     try assertOutput(
@@ -261,6 +267,35 @@ struct JNIIntConversionChecksTests {
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """
+      ]
+    )
+  }
+
+  @Test func generatesOptionalFuncWithUnsignedCheck() throws {
+    try assertOutput(
+      input: optionalFuncSource,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 3,
+      expectedChunks: [
+        #"""
+        @_cdecl("Java_com_example_swift_MyStruct__00024dummyFunc__BJJ")
+        public func Java_com_example_swift_MyStruct__00024dummyFunc__BJJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg_discriminator: jbyte, arg_value: jlong, selfPointer: jlong) {
+          #if _pointerBitWidth(_32)
+          guard arg_value >= Int32.min && arg_value <= Int32.max else {
+            environment.throwJavaException(javaException: .integerOverflow)
+            return
+          }
+          #endif
+          assert(selfPointer != 0, "selfPointer memory address was null")
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
+          let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
+          guard let selfPointer$ else {
+            fatalError("selfPointer memory address was null in call to \(#function)!")
+          }
+          selfPointer$.pointee.dummyFunc(arg: arg_discriminator == 1 ? Int(fromJNI: arg_value, in: environment) : nil)
+        }
+        """#
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
@@ -180,13 +180,13 @@ struct JNIOptionalTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024optionalClass__J_3B")
         public func Java_com_example_swift_SwiftModule__00024optionalClass__J_3B(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg: jlong, result_discriminator$: jbyteArray?) -> jlong {
-          let argBits$ = Int(Int64(fromJNI: arg, in: environment))
+          let argBits$ = Int(fromJNI: arg, in: environment)
           let arg$ = UnsafeMutablePointer<MyClass>(bitPattern: argBits$)
           let result$: jlong
           if let innerResult$ = SwiftModule.optionalClass(arg$?.pointee) {
             let resultWrapped$ = UnsafeMutablePointer<MyClass>.allocate(capacity: 1)
             resultWrapped$.initialize(to: innerResult$)
-            let resultWrappedBits$ = Int64(Int(bitPattern: resultWrapped$))
+            let resultWrappedBits$ = Int(bitPattern: resultWrapped$)
             result$ = resultWrappedBits$.getJNILocalRefValue(in: environment)
             var flag$ = Int8(1)
             environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)

--- a/Tests/JExtractSwiftTests/JNI/JNIProtocolTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIProtocolTests.swift
@@ -137,7 +137,7 @@ struct JNIProtocolTests {
           if environment.interface.IsInstanceOf(environment, x, _JNIMethodIDCache.JNISwiftInstance.class) != 0 {
             ...
             let xpointer$DynamicType$: Any.Type = unsafeBitCast(xpointer$TypeMetadataPointer$, to: Any.Type.self)
-            guard let xpointer$RawPointer$ = UnsafeMutableRawPointer(bitPattern: Int(Int64(fromJNI: xpointer$, in: environment))) else {
+            guard let xpointer$RawPointer$ = UnsafeMutableRawPointer(bitPattern: Int(fromJNI: xpointer$, in: environment)) else {
               fatalError("xpointer$ memory address was null")
             }
             #if hasFeature(ImplicitOpenExistentials)
@@ -271,11 +271,11 @@ struct JNIProtocolTests {
           if environment.interface.IsInstanceOf(environment, x, _JNIMethodIDCache.JNISwiftInstance.class) != 0 {
             let xpointer$ = environment.interface.CallLongMethodA(environment, x, _JNIMethodIDCache.JNISwiftInstance.memoryAddress, [])
             let xtypeMetadata$ = environment.interface.CallLongMethodA(environment, x, _JNIMethodIDCache.JNISwiftInstance.typeMetadataAddress, [])
-            guard let xpointer$TypeMetadataPointer$ = UnsafeRawPointer(bitPattern: Int(Int64(fromJNI: xtypeMetadata$, in: environment))) else {
+            guard let xpointer$TypeMetadataPointer$ = UnsafeRawPointer(bitPattern: Int(fromJNI: xtypeMetadata$, in: environment)) else {
               fatalError("xtypeMetadata$ memory address was null")
             }
             let xpointer$DynamicType$: Any.Type = unsafeBitCast(xpointer$TypeMetadataPointer$, to: Any.Type.self)
-            guard let xpointer$RawPointer$ = UnsafeMutableRawPointer(bitPattern: Int(Int64(fromJNI: xpointer$, in: environment))) else {
+            guard let xpointer$RawPointer$ = UnsafeMutableRawPointer(bitPattern: Int(fromJNI: xpointer$, in: environment)) else {
               fatalError("xpointer$ memory address was null")
             }
             #if hasFeature(ImplicitOpenExistentials)

--- a/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
@@ -150,7 +150,7 @@ struct JNIStructTests {
         public func Java_com_example_swift_MyStruct__00024init__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, x: jlong, y: jlong) -> jlong {
           let result$ = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
           result$.initialize(to: MyStruct.init(x: Int64(fromJNI: x, in: environment), y: Int64(fromJNI: y, in: environment)))
-          let resultBits$ = Int64(Int(bitPattern: result$))
+          let resultBits$ = Int(bitPattern: result$)
           return resultBits$.getJNILocalRefValue(in: environment)
         }
         """
@@ -195,7 +195,7 @@ struct JNIStructTests {
         @_cdecl("Java_com_example_swift_MyStruct__00024doSomething__JJ")
         public func Java_com_example_swift_MyStruct__00024doSomething__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, x: jlong, selfPointer: jlong) {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")

--- a/Tests/JExtractSwiftTests/JNI/JNISubscriptsTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNISubscriptsTests.swift
@@ -101,7 +101,7 @@ struct JNISubscriptsTests {
         @_cdecl("Java_com_example_swift_MyStruct__00024getSubscript__J")
         public func Java_com_example_swift_MyStruct__00024getSubscript__J(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong) -> jdouble {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -112,7 +112,7 @@ struct JNISubscriptsTests {
         @_cdecl("Java_com_example_swift_MyStruct__00024setSubscript__DJ")
         public func Java_com_example_swift_MyStruct__00024setSubscript__DJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, newValue: jdouble, selfPointer: jlong) {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -134,7 +134,7 @@ struct JNISubscriptsTests {
         @_cdecl("Java_com_example_swift_MyStruct__00024getSubscript__IJ")
         public func Java_com_example_swift_MyStruct__00024getSubscript__IJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, index: jint, selfPointer: jlong) -> jint {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -145,7 +145,7 @@ struct JNISubscriptsTests {
         @_cdecl("Java_com_example_swift_MyStruct__00024setSubscript__IIJ")
         public func Java_com_example_swift_MyStruct__00024setSubscript__IIJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, index: jint, newValue: jint, selfPointer: jlong) {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<MyStruct>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")

--- a/Tests/JExtractSwiftTests/SpecializationTests.swift
+++ b/Tests/JExtractSwiftTests/SpecializationTests.swift
@@ -263,7 +263,7 @@ struct SpecializationTests {
         @_cdecl("Java_com_example_swift_FishBox__00024observeTheFish__JJ")
         public func Java_com_example_swift_FishBox__00024observeTheFish__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong, selfTypePointer: jlong) {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<Box<Fish>>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
@@ -276,12 +276,12 @@ struct SpecializationTests {
         @_cdecl("Java_com_example_swift_FishBox__00024count__JJ")
         public func Java_com_example_swift_FishBox__00024count__JJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong, selfTypePointer: jlong) -> jlong {
           assert(selfPointer != 0, "selfPointer memory address was null")
-          let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
+          let selfPointerBits$ = Int(fromJNI: selfPointer, in: environment)
           let selfPointer$ = UnsafeMutablePointer<Box<Fish>>(bitPattern: selfPointerBits$)
           guard let selfPointer$ else {
             fatalError("selfPointer memory address was null in call to \\(#function)!")
           }
-          return Int64(selfPointer$.pointee.count()).getJNILocalRefValue(in: environment)
+          return selfPointer$.pointee.count().getJNILocalRefValue(in: environment)
         }
         """,
       ],

--- a/Tests/SwiftJavaMacrosTests/JavaImplementationMacroTests.swift
+++ b/Tests/SwiftJavaMacrosTests/JavaImplementationMacroTests.swift
@@ -180,12 +180,12 @@ class JavaImplementationMacroTests: XCTestCase {
       @JavaImplementation("org.swift.swiftkit.core.collections.SwiftDictionaryMap")
       extension SwiftDictionaryMapJava {
         @JavaMethod("$size")
-        public static func _size(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> Int32 {
+        public static func _size(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> Int32 {
           return 42
         }
 
         @JavaMethod("$destroy")
-        public static func _destroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) {
+        public static func _destroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) {
           // cleanup
         }
       }
@@ -193,10 +193,10 @@ class JavaImplementationMacroTests: XCTestCase {
       expandedSource: """
 
         extension SwiftDictionaryMapJava {
-          public static func _size(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) -> Int32 {
+          public static func _size(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) -> Int32 {
               return 42
           }
-          public static func _destroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int64) {
+          public static func _destroy(environment: UnsafeMutablePointer<JNIEnv?>!, pointer: Int) {
             // cleanup
           }
         }
@@ -205,8 +205,8 @@ class JavaImplementationMacroTests: XCTestCase {
         @used
         #endif
         @_cdecl("Java_org_swift_swiftkit_core_collections_SwiftDictionaryMap__00024size")
-        public func __macro_local_5_sizefMu_(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, pointer: Int64.JNIType) -> Int32.JNIType {
-          return SwiftDictionaryMapJava._size(environment: environment, pointer: Int64(fromJNI: pointer, in: environment!))
+        public func __macro_local_5_sizefMu_(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, pointer: Int.JNIType) -> Int32.JNIType {
+          return SwiftDictionaryMapJava._size(environment: environment, pointer: Int(fromJNI: pointer, in: environment!))
           .getJNILocalRefValue(in: environment)
         }
 
@@ -214,8 +214,8 @@ class JavaImplementationMacroTests: XCTestCase {
         @used
         #endif
         @_cdecl("Java_org_swift_swiftkit_core_collections_SwiftDictionaryMap__00024destroy")
-        public func __macro_local_8_destroyfMu_(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, pointer: Int64.JNIType) {
-          return SwiftDictionaryMapJava._destroy(environment: environment, pointer: Int64(fromJNI: pointer, in: environment!))
+        public func __macro_local_8_destroyfMu_(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, pointer: Int.JNIType) {
+          return SwiftDictionaryMapJava._destroy(environment: environment, pointer: Int(fromJNI: pointer, in: environment!))
         }
         """,
       macros: Self.javaImplementationMacros


### PR DESCRIPTION
This PR fixes issues related to `Int?` arguments on 32-bit architectures.
The generated code contained numerous errors. (The failing CI run: https://github.com/swiftlang/swift-java/actions/runs/23786261629/job/69318324924 )

## Background

During my investigation, I realized that the dynamic nature of `Int.JNIType` was significantly complicating the logic.
I have already submitted a PR to address this: https://github.com/swiftlang/swift-java-jni-core/pull/16

In this PR, I have removed the various implementation pieces that were previously used to manually wrap `Int` into `Int64`.
With the unified `JNIType`, these are no longer necessary, and removing them resolves the original problem.

## Verification

I have verified that the generated code compiles correctly for 32-bit by running the following command in SwiftJavaExtractJNISampleApp:

`./gradlew assemble -PswiftSdk=armv7-unknown-linux-android28`

While the compilation is successful, I do not have a 32-bit Android runtime environment, so I haven't been able to verify the actual execution results.