### PR TITLE
Add overrideStaticBlockLibraryLoading configuration option

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -256,20 +256,37 @@ extension FFMSwift2JavaGenerator {
     printNominal(&printer, decl) { printer in
       // We use a static field to abuse the initialization order such that by the time we get type metadata,
       // we already have loaded the library where it will be obtained from.
-      printer.printParts(
-        """
-        @SuppressWarnings("unused")
-        private static final boolean INITIALIZED_LIBS = initializeLibs();
-        static boolean initializeLibs() {
-            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_CORE);
-            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_RUNTIME_FUNCTIONS);
-            SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
-            return true;
+      if let overrideLoading = self.config.overrideStaticBlockLibraryLoading {
+        if !overrideLoading.isEmpty {
+          let body = overrideLoading.map { "    \($0)" }.joined(separator: "\n")
+          printer.printParts(
+            """
+            @SuppressWarnings("unused")
+            private static final boolean INITIALIZED_LIBS = initializeLibs();
+            static boolean initializeLibs() {
+            \(body)
+                return true;
+            }
+            """
+          )
+          printer.print("")
         }
-        """
-      )
-      printer.print("")
+      } else {
+        printer.printParts(
+          """
+          @SuppressWarnings("unused")
+          private static final boolean INITIALIZED_LIBS = initializeLibs();
+          static boolean initializeLibs() {
+              SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_CORE);
+              SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+              SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_RUNTIME_FUNCTIONS);
+              SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
+              return true;
+          }
+          """
+        )
+        printer.print("")
+      }
 
       // Type metadata (common to all nominal types)
       printer.printParts(
@@ -479,12 +496,35 @@ extension FFMSwift2JavaGenerator {
         """
         static final SymbolLookup SYMBOL_LOOKUP = getSymbolLookup();
         private static SymbolLookup getSymbolLookup() {
-            if (SwiftLibraries.AUTO_LOAD_LIBS) {
-                SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_CORE);
-                SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-                SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_RUNTIME_FUNCTIONS);
-                SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
-            }
+        """
+      )
+
+      if let overrideLoading = config.overrideStaticBlockLibraryLoading {
+        if !overrideLoading.isEmpty {
+          let body = overrideLoading.map { "        \($0)" }.joined(separator: "\n")
+          printer.print(
+            """
+                if (SwiftLibraries.AUTO_LOAD_LIBS) {
+            \(body)
+                }
+            """
+          )
+        }
+      } else {
+        printer.print(
+          """
+              if (SwiftLibraries.AUTO_LOAD_LIBS) {
+                  SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_CORE);
+                  SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+                  SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_RUNTIME_FUNCTIONS);
+                  SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
+              }
+          """
+        )
+      }
+
+      printer.print(
+        """
 
             if (PlatformUtils.isMacOS()) {
                 return SymbolLookup.libraryLookup(System.mapLibraryName(LIB_NAME), LIBRARY_ARENA)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -112,13 +112,32 @@ extension JNISwift2JavaGenerator {
       printer.print(
         """
         static final String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
-
-        static {
-          System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-          System.loadLibrary(LIB_NAME);
-        }
         """
       )
+
+      if let overrideLoading = config.overrideStaticBlockLibraryLoading {
+        if !overrideLoading.isEmpty {
+          let body = overrideLoading.map { "    \($0)" }.joined(separator: "\n")
+          printer.print(
+            """
+
+            static {
+            \(body)
+            }
+            """
+          )
+        }
+      } else {
+        printer.print(
+          """
+
+          static {
+            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+            System.loadLibrary(LIB_NAME);
+          }
+          """
+        )
+      }
 
       for decl in analysis.importedGlobalFuncs {
         self.logger.trace("Print global function: \(decl)")
@@ -201,16 +220,38 @@ extension JNISwift2JavaGenerator {
       printer.print(
         """
         static final String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
-
-        @SuppressWarnings("unused")
-        private static final boolean INITIALIZED_LIBS = initializeLibs();
-        static boolean initializeLibs() {
-            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            System.loadLibrary(LIB_NAME);
-            return true;
-        }
         """
       )
+
+      if let overrideLoading = config.overrideStaticBlockLibraryLoading {
+        if !overrideLoading.isEmpty {
+          let body = overrideLoading.map { "        \($0)" }.joined(separator: "\n")
+          printer.print(
+            """
+
+            @SuppressWarnings("unused")
+            private static final boolean INITIALIZED_LIBS = initializeLibs();
+            static boolean initializeLibs() {
+            \(body)
+                return true;
+            }
+            """
+          )
+        }
+      } else {
+        printer.print(
+          """
+
+          @SuppressWarnings("unused")
+          private static final boolean INITIALIZED_LIBS = initializeLibs();
+          static boolean initializeLibs() {
+              System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+              System.loadLibrary(LIB_NAME);
+              return true;
+          }
+          """
+        )
+      }
 
       let nestedTypes = self.analysis.importedTypes.filter { _, type in
         type.parent == decl.swiftNominal

--- a/Sources/SwiftJavaConfigurationShared/Configuration.swift
+++ b/Sources/SwiftJavaConfigurationShared/Configuration.swift
@@ -38,6 +38,14 @@ public struct Configuration: Codable {
   /// (e.g. the module is `MyLibrary` but the dylib is `MyLibrarySwiftJava` or something else).
   public var nativeLibraryName: String?
 
+  /// When non-nil, overrides the library loading statements emitted in the
+  /// `static {}` / `initializeLibs()` block of generated Java classes.
+  /// Each string is emitted as a verbatim Java statement.
+  ///
+  /// When `nil` (the default), the standard loading calls are emitted.
+  /// When set to an empty array `[]`, no library loading code is emitted at all.
+  public var overrideStaticBlockLibraryLoading: [String]?
+
   public var inputSwiftDirectory: String?
 
   public var outputSwiftDirectory: String?

--- a/Tests/JExtractSwiftTests/JNI/JNIModuleTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIModuleTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import JExtractSwiftLib
+import SwiftJavaConfigurationShared
 import Testing
 
 @Suite
@@ -274,6 +275,55 @@ struct JNIModuleTests {
           }
         }
         """,
+      ]
+    )
+  }
+
+  @Test
+  func generatesModuleJavaClass_overrideStaticBlockLibraryLoading_empty() throws {
+    let input = "public func helloWorld()"
+    var config = Configuration()
+    config.overrideStaticBlockLibraryLoading = []
+
+    try assertOutput(
+      input: input,
+      config: config,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        static final String LIB_NAME = "SwiftModule";
+        """
+      ],
+      notExpectedChunks: [
+        "System.loadLibrary",
+        "initializeLibs",
+      ]
+    )
+  }
+
+  @Test
+  func generatesModuleJavaClass_overrideStaticBlockLibraryLoading_custom() throws {
+    let input = "public func helloWorld()"
+    var config = Configuration()
+    config.overrideStaticBlockLibraryLoading = [
+      "System.loadLibrary(\"SomeSpecialName\");"
+    ]
+
+    try assertOutput(
+      input: input,
+      config: config,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        static {
+            System.loadLibrary("SomeSpecialName");
+        }
+        """
+      ],
+      notExpectedChunks: [
+        "SwiftLibraries.LIB_NAME_SWIFT_JAVA"
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import JExtractSwiftLib
+import SwiftJavaConfigurationShared
 import Testing
 
 @Suite
@@ -203,6 +204,29 @@ struct JNIStructTests {
           selfPointer$.pointee.doSomething(x: Int64(fromJNI: x, in: environment))
         }
         """
+      ]
+    )
+  }
+
+  @Test
+  func generatesStructJavaClass_overrideStaticBlockLibraryLoading_empty() throws {
+    var config = Configuration()
+    config.overrideStaticBlockLibraryLoading = []
+
+    try assertOutput(
+      input: source,
+      config: config,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        public final class MyStruct implements JNISwiftInstance {
+          static final String LIB_NAME = "SwiftModule";
+        """
+      ],
+      notExpectedChunks: [
+        "System.loadLibrary",
+        "initializeLibs",
       ]
     )
   }


### PR DESCRIPTION
Replace the boolean `disableAutomaticLibraryLoading` with a more flexible `overrideStaticBlockLibraryLoading: [String]?`.

Developers can customize if they want any automatic loading or none at all etc. You can pass `[]` to disable it, or pass your custom loading logic -- if you have additional dependencies swift-java doesn't know about