### PR TITLE
jextract: Use fully qualified `java.lang.String` to avoid shadowing

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator.swift
@@ -545,7 +545,7 @@ extension FFMSwift2JavaGenerator {
   func printClassConstants(printer: inout CodePrinter) {
     printer.print(
       """
-      static final String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
+      static final java.lang.String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
       static final Arena LIBRARY_ARENA = Arena.ofAuto();
       """
     )
@@ -584,7 +584,7 @@ extension FFMSwift2JavaGenerator {
     printer.print(
       """
       @Override
-      public String toString() {
+      public java.lang.String toString() {
           return getClass().getSimpleName()
               + "("
               + SwiftRuntime.nameOfSwiftType($swiftType().$memorySegment(), true)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -111,7 +111,7 @@ extension JNISwift2JavaGenerator {
     printModuleClass(&printer) { printer in
       printer.print(
         """
-        static final String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
+        static final java.lang.String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
         """
       )
 
@@ -219,7 +219,7 @@ extension JNISwift2JavaGenerator {
     printNominal(&printer, decl) { printer in
       printer.print(
         """
-        static final String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
+        static final java.lang.String LIB_NAME = "\(config.nativeLibraryName ?? swiftModuleName)";
         """
       )
 
@@ -373,11 +373,11 @@ extension JNISwift2JavaGenerator {
 
       printer.print(
         """
-        public String toString() {
+        public java.lang.String toString() {
           return SwiftObjects.toString(this.$memoryAddress(), this.$typeMetadataAddress());
         }
 
-        public String toDebugString() {
+        public java.lang.String toDebugString() {
           return SwiftObjects.toDebugString(this.$memoryAddress(), this.$typeMetadataAddress());
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
@@ -63,7 +63,7 @@ struct JNIClassTests {
         """,
         """
         public final class MyClass implements JNISwiftInstance {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
 
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -47,7 +47,7 @@ struct JNIEnumTests {
         """,
         """
         public final class MyEnum implements JNISwiftInstance {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
 
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();

--- a/Tests/JExtractSwiftTests/JNI/JNIModuleTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIModuleTests.swift
@@ -57,7 +57,7 @@ struct JNIModuleTests {
         import org.swift.swiftkit.core.annotations.*;
 
         public final class SwiftModule {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
 
           static {
             System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
@@ -292,7 +292,7 @@ struct JNIModuleTests {
       .java,
       expectedChunks: [
         """
-        static final String LIB_NAME = "SwiftModule";
+        static final java.lang.String LIB_NAME = "SwiftModule";
         """
       ],
       notExpectedChunks: [

--- a/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
@@ -57,7 +57,7 @@ struct JNIStructTests {
       expectedChunks: [
         """
         public final class MyStruct implements JNISwiftInstance {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
 
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();
@@ -221,7 +221,7 @@ struct JNIStructTests {
       expectedChunks: [
         """
         public final class MyStruct implements JNISwiftInstance {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
         """
       ],
       notExpectedChunks: [

--- a/Tests/JExtractSwiftTests/JNI/JNIToStringTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIToStringTests.swift
@@ -32,7 +32,7 @@ struct JNIToStringTests {
       detectChunkByInitialLines: 1,
       expectedChunks: [
         """
-        public String toString() {
+        public java.lang.String toString() {
           return SwiftObjects.toString(this.$memoryAddress(), this.$typeMetadataAddress());
         }
         """
@@ -49,7 +49,7 @@ struct JNIToStringTests {
       detectChunkByInitialLines: 1,
       expectedChunks: [
         """
-        public String toDebugString() {
+        public java.lang.String toDebugString() {
           return SwiftObjects.toDebugString(this.$memoryAddress(), this.$typeMetadataAddress());
         }
         """

--- a/Tests/JExtractSwiftTests/SendableTests.swift
+++ b/Tests/JExtractSwiftTests/SendableTests.swift
@@ -32,7 +32,7 @@ final class SendableTests {
         """
         @ThreadSafe // Sendable
         public final class SendableStruct extends FFMSwiftInstance implements SwiftValue {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
           static final Arena LIBRARY_ARENA = Arena.ofAuto();
         """
       ]
@@ -50,7 +50,7 @@ final class SendableTests {
         """
         @ThreadSafe // Sendable
         public final class SendableStruct implements JNISwiftInstance {
-          static final String LIB_NAME = "SwiftModule";
+          static final java.lang.String LIB_NAME = "SwiftModule";
         """
       ]
     )


### PR DESCRIPTION
When generating Java code for next Swift type a nested Java record named `String` is created.

```swift
public enum MyEnum {
    ...
    case string(String)
}
```

```java
public final class JSON implements JNISwiftInstance {
  public record String(java.lang.String arg0) implements Case {
    record _NativeParameters(java.lang.String arg0) {}
  }
```

This causes the standard `java.lang.String` to be shadowed within that scope, leading to uncompilable source code where the generator expects the standard JDK `String` but finds the newly generated one instead.

To prevent this, the generator now uses the fully qualified name.

## Note

This applies to other types as well (such as `AtomicBoolean`), but I am only addressing String in this PR for now.