### PR TITLE
jextract: Implement identifier escaping for functions and enum cases

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Enums.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Enums.swift
@@ -16,3 +16,7 @@ public enum EnumWithValueCases {
   case firstCase(UInt)
   case secondCase
 }
+
+public enum EnumWithBacktick {
+  case `let`
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/EnumTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/EnumTest.java
@@ -15,20 +15,25 @@
 package com.example.swift;
 
 import org.junit.jupiter.api.Test;
-import org.swift.swiftkit.core.ConfinedSwiftMemorySession;
 import org.swift.swiftkit.core.SwiftArena;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class EnumWithValueCasesTest {
+public class EnumTest {
     @Test
-    void fn() {
+    void enumWithValueCases() {
         try (var arena = SwiftArena.ofConfined()) {
             EnumWithValueCases e = EnumWithValueCases.firstCase(48, arena);
             EnumWithValueCases.FirstCase c = (EnumWithValueCases.FirstCase) e.getCase();
             assertNotNull(c);
+        }
+    }
+
+    @Test
+    void enumWithBacktick() {
+        try (var arena = SwiftArena.ofConfined()) {
+            EnumWithBacktick e = EnumWithBacktick.default_(arena);
+            assertTrue(e.getAsDefault().isPresent());
         }
     }
 }

--- a/Sources/JExtractSwiftLib/Convenience/String+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/String+Extensions.swift
@@ -87,6 +87,14 @@ extension String {
 
     return .class(package: javaPackageName, name: javaClassName)
   }
+
+  /// Unescapes the name if it is surrounded by backticks.
+  var unescapedSwiftName: String {
+    if count >= 2 && hasPrefix("`") && hasSuffix("`") {
+      return String(dropFirst().dropLast())
+    }
+    return self
+  }
 }
 
 extension Array where Element == String {

--- a/Sources/JExtractSwiftLib/JavaIdentifierFactory.swift
+++ b/Sources/JExtractSwiftLib/JavaIdentifierFactory.swift
@@ -68,7 +68,11 @@ package struct JavaIdentifierFactory {
       case .setter, .subscriptSetter: decl.javaSetterName
       case .function, .initializer, .enumCase: decl.name
       }
-    return baseName + paramsSuffix(decl, baseName: baseName)
+    var methodName = baseName + paramsSuffix(decl, baseName: baseName)
+    if Self.javaKeywords.contains(methodName) {
+      methodName += "_"
+    }
+    return methodName
   }
 
   private func paramsSuffix(_ decl: ImportedFunc, baseName: String) -> String {
@@ -86,4 +90,22 @@ package struct JavaIdentifierFactory {
       return labels.map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined()
     }
   }
+
+  static let javaKeywords: Set<String> = [
+    /// https://docs.oracle.com/javase/specs/jls/se25/html/jls-3.html#jls-3.9
+    "abstract", "continue", "for", "new", "switch",
+    "assert", "default", "if", "package", "synchronized",
+    "boolean", "do", "goto", "private", "this",
+    "break", "double", "implements", "protected", "throw",
+    "byte", "else", "import", "public", "throws",
+    "case", "enum", "instanceof", "return", "transient",
+    "catch", "extends", "int", "short", "try",
+    "char", "final", "interface", "static", "void",
+    "class", "finally", "long", "strictfp", "volatile",
+    "const", "float", "native", "super", "while",
+    "_",
+
+    /// literals
+    "true", "false", "null",
+  ]
 }

--- a/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
@@ -186,7 +186,7 @@ final class Swift2JavaVisitor {
     let imported = ImportedFunc(
       module: translator.swiftModuleName,
       swiftDecl: node,
-      name: node.name.text,
+      name: node.name.text.unescapedSwiftName,
       apiKind: .function,
       functionSignature: signature,
     )
@@ -227,7 +227,7 @@ final class Swift2JavaVisitor {
           lookupContext: translator.lookupContext,
         )
 
-        let caseName = caseElement.name.text.trimmingCharacters(in: .init(charactersIn: "`"))
+        let caseName = caseElement.name.text.unescapedSwiftName
         let caseFunction = ImportedFunc(
           module: translator.swiftModuleName,
           swiftDecl: node,

--- a/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
@@ -227,16 +227,17 @@ final class Swift2JavaVisitor {
           lookupContext: translator.lookupContext,
         )
 
+        let caseName = caseElement.name.text.trimmingCharacters(in: .init(charactersIn: "`"))
         let caseFunction = ImportedFunc(
           module: translator.swiftModuleName,
           swiftDecl: node,
-          name: caseElement.name.text,
+          name: caseName,
           apiKind: .enumCase,
           functionSignature: signature,
         )
 
         let importedCase = ImportedEnumCase(
-          name: caseElement.name.text,
+          name: caseName,
           parameters: parameters ?? [],
           swiftDecl: node,
           enumType: SwiftNominalType(nominalTypeDecl: typeContext.swiftNominal),

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -374,4 +374,22 @@ struct JNIEnumTests {
       ]
     )
   }
+
+  @Test
+  func removeBacktick() throws {
+    try assertOutput(
+      input: """
+        public enum MyEnum {
+          case `let`
+        }
+        """,
+      .jni,
+      .java,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        "public static MyEnum let(SwiftArena swiftArena) {",
+        "public record Let() implements Case {",
+      ],
+    )
+  }
 }

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -374,22 +374,4 @@ struct JNIEnumTests {
       ]
     )
   }
-
-  @Test
-  func removeBacktick() throws {
-    try assertOutput(
-      input: """
-        public enum MyEnum {
-          case `let`
-        }
-        """,
-      .jni,
-      .java,
-      detectChunkByInitialLines: 1,
-      expectedChunks: [
-        "public static MyEnum let(SwiftArena swiftArena) {",
-        "public record Let() implements Case {",
-      ],
-    )
-  }
 }

--- a/Tests/JExtractSwiftTests/JavaKeywordTests.swift
+++ b/Tests/JExtractSwiftTests/JavaKeywordTests.swift
@@ -36,7 +36,7 @@ struct JavaKeywordTests {
         """,
         """
         public void final_() {
-        """
+        """,
       ]
     )
 
@@ -47,7 +47,7 @@ struct JavaKeywordTests {
       expectedChunks: [
         """
         @_cdecl("swiftjava_SwiftModule_Foo_final")
-        """,
+        """
       ]
     )
   }
@@ -110,7 +110,7 @@ struct JavaKeywordTests {
       expectedChunks: [
         """
         @_cdecl("Java_com_example_swift_MyEnumWithValue__00024getAsInstanceof__J")
-        """,
+        """
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JavaKeywordTests.swift
+++ b/Tests/JExtractSwiftTests/JavaKeywordTests.swift
@@ -14,4 +14,128 @@
 
 import Testing
 
-// TODO: 
+@Suite
+struct JavaKeywordTests {
+  @Test
+  func functionName() throws {
+    let text =
+      """
+      public struct Foo {
+        public func final()
+      }
+      """
+
+    try assertOutput(
+      input: text,
+      .ffm,
+      .java,
+      expectedChunks: [
+        """
+        private static final MemorySegment ADDR =
+          SwiftModule.findOrThrow("swiftjava_SwiftModule_Foo_final");
+        """,
+        """
+        public void final_() {
+        """
+      ]
+    )
+
+    try assertOutput(
+      input: text,
+      .ffm,
+      .swift,
+      expectedChunks: [
+        """
+        @_cdecl("swiftjava_SwiftModule_Foo_final")
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func enumCase() throws {
+    let text =
+      """
+      public enum MyEnum {
+        case null
+      }
+      """
+
+    try assertOutput(
+      input: text,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        public static MyEnum null_(SwiftArena swiftArena) {
+        """,
+        """
+        public record Null() implements Case {
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func enumCaseWithAssociatedValue() throws {
+    let text =
+      """
+      public enum MyEnumWithValue {
+        case instanceof(String)
+        case none
+      }
+      """
+
+    try assertOutput(
+      input: text,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        public static MyEnumWithValue instanceof_(java.lang.String arg0, SwiftArena swiftArena) {
+        """,
+        """
+        public record Instanceof(java.lang.String arg0) implements Case {
+        """,
+        """
+        private static native Instanceof._NativeParameters $getAsInstanceof(long selfPointer);
+        """,
+      ]
+    )
+
+    try assertOutput(
+      input: text,
+      .jni,
+      .swift,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_MyEnumWithValue__00024getAsInstanceof__J")
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func enumCaseWithBacktick() throws {
+    let text =
+      """
+      public enum MyEnum {
+        case `default`
+      }
+      """
+
+    try assertOutput(
+      input: text,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        public static MyEnum default_(SwiftArena swiftArena) {
+        """,
+        """
+        public record Default() implements Case {
+        """,
+      ]
+    )
+  }
+}

--- a/Tests/JExtractSwiftTests/JavaKeywordTests.swift
+++ b/Tests/JExtractSwiftTests/JavaKeywordTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/JExtractSwiftTests/JavaKeywordTests.swift
+++ b/Tests/JExtractSwiftTests/JavaKeywordTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Copyright (c) 2024 Apple Inc. and the Swift.org project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,12 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum EnumWithValueCases {
-  case firstCase(UInt)
-  case secondCase
-}
+import Testing
 
-public enum EnumWithBacktick {
-  case `let`
-  case `default`
-}
+// TODO: 

--- a/Tests/JExtractSwiftTests/SwiftEscapedNameTests.swift
+++ b/Tests/JExtractSwiftTests/SwiftEscapedNameTests.swift
@@ -29,7 +29,7 @@ struct SwiftEscapedNameTests {
       detectChunkByInitialLines: 1,
       expectedChunks: [
         "public void guard() {",
-        "private static native void $guard(long selfPointer);"
+        "private static native void $guard(long selfPointer);",
       ],
     )
   }

--- a/Tests/JExtractSwiftTests/SwiftEscapedNameTests.swift
+++ b/Tests/JExtractSwiftTests/SwiftEscapedNameTests.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@Suite
+struct SwiftEscapedNameTests {
+  @Test
+  func function() throws {
+    try assertOutput(
+      input: """
+        public struct MyStruct {
+          public func `guard`()
+        }
+        """,
+      .jni,
+      .java,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        "public void guard() {",
+        "private static native void $guard(long selfPointer);"
+      ],
+    )
+  }
+
+  @Test
+  func enumCase() throws {
+    try assertOutput(
+      input: """
+        public enum MyEnum {
+          case `let`
+        }
+        """,
+      .jni,
+      .java,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        "public static MyEnum let(SwiftArena swiftArena) {",
+        "public record Let() implements Case {",
+      ],
+    )
+  }
+}


### PR DESCRIPTION
Implements escaping for identifiers to prevent compilation errors when Swift function names use backticks or conflict with Java reserved keywords.

- Automatically removes backticks from escaped Swift identifiers (e.g., \`default\` → default).
- Appends an underscore as a suffix if an identifier conflicts with a Java reserved keyword (e.g., `default` → `default_`).

In this PR, these are applied to function names and enum cases.
I have skipped class names for now because the implementation is more complex, and such naming conflicts are considered rare at the class level.