### PR TITLE
Fix Java package mapping for dependent modules

### DIFF
--- a/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
+++ b/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
@@ -19,6 +19,10 @@ private let SwiftJavaConfigFileName = "swift-java.config"
 
 @main
 struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
+  struct DependentConfigFile {
+    let swiftModuleName: String
+    let configURL: URL
+  }
 
   var pluginName: String = "swift-java"
   var verbose: Bool = getEnvironmentBool("SWIFT_JAVA_VERBOSE")
@@ -78,11 +82,10 @@ struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
       arguments += ["--static-build-config", resolvedURL.absoluteURL.path(percentEncoded: false)]
     }
 
-    let dependentConfigFilesArguments = dependentConfigFiles.flatMap { moduleAndConfigFile in
-      let (moduleName, configFile) = moduleAndConfigFile
+    let dependentConfigFilesArguments = dependentConfigFiles.flatMap { dependentConfigFile in
       return [
         "--depends-on",
-        "\(moduleName)=\(configFile.path(percentEncoded: false))",
+        "\(dependentConfigFile.swiftModuleName)=\(dependentConfigFile.configURL.path(percentEncoded: false))",
       ]
     }
     arguments += dependentConfigFilesArguments
@@ -270,8 +273,8 @@ struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
 
   /// Find the manifest files from other swift-java executions in any targets
   /// this target depends on.
-  func searchForDependentConfigFiles(in target: any Target) -> [(String, URL)] {
-    var dependentConfigFiles = [(String, URL)]()
+  func searchForDependentConfigFiles(in target: any Target) -> [DependentConfigFile] {
+    var dependentConfigFiles: [DependentConfigFile] = []
 
     func _searchForConfigFiles(in target: any Target) {
       // log("Search for config files in target: \(target.name)")
@@ -286,7 +289,9 @@ struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
         .path(percentEncoded: false)
 
       if FileManager.default.fileExists(atPath: dependencyConfigString) {
-        dependentConfigFiles.append((target.name, dependencyConfigURL))
+        dependentConfigFiles.append(
+          DependentConfigFile(swiftModuleName: target.name, configURL: dependencyConfigURL)
+        )
       }
     }
 

--- a/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
+++ b/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
@@ -19,6 +19,7 @@ private let SwiftJavaConfigFileName = "swift-java.config"
 
 @main
 struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
+
   struct DependentConfigFile {
     let swiftModuleName: String
     let configURL: URL

--- a/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
+++ b/Plugins/JExtractSwiftPlugin/JExtractSwiftPlugin.swift
@@ -84,7 +84,7 @@ struct JExtractSwiftBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
     }
 
     let dependentConfigFilesArguments = dependentConfigFiles.flatMap { dependentConfigFile in
-      return [
+      [
         "--depends-on",
         "\(dependentConfigFile.swiftModuleName)=\(dependentConfigFile.configURL.path(percentEncoded: false))",
       ]

--- a/Plugins/SwiftJavaPlugin/SwiftJavaPlugin.swift
+++ b/Plugins/SwiftJavaPlugin/SwiftJavaPlugin.swift
@@ -19,6 +19,10 @@ private let SwiftJavaConfigFileName = "swift-java.config"
 
 @main
 struct SwiftJavaBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
+  struct DependentConfigFile {
+    let swiftModuleName: String
+    let configURL: URL
+  }
 
   var pluginName: String = "swift-java"
   var verbose: Bool = getEnvironmentBool("SWIFT_JAVA_VERBOSE")
@@ -46,7 +50,7 @@ struct SwiftJavaBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
 
     /// Find the manifest files from other swift-java executions in any targets
     /// this target depends on.
-    var dependentConfigFiles: [(String, URL)] = []
+    var dependentConfigFiles: [DependentConfigFile] = []
     func searchForConfigFiles(in target: any Target) {
       // log("Search for config files in target: \(target.name)")
       let dependencyURL = target.directoryURL
@@ -60,7 +64,9 @@ struct SwiftJavaBuildToolPlugin: SwiftJavaPluginProtocol, BuildToolPlugin {
         .path(percentEncoded: false)
 
       if FileManager.default.fileExists(atPath: dependencyConfigString) {
-        dependentConfigFiles.append((target.name, dependencyConfigURL))
+        dependentConfigFiles.append(
+          DependentConfigFile(swiftModuleName: target.name, configURL: dependencyConfigURL)
+        )
       }
     }
 
@@ -223,12 +229,11 @@ extension SwiftJavaBuildToolPlugin {
     ]
   }
 
-  func argumentsDependedOnConfigs(_ dependentConfigFiles: [(String, URL)]) -> [String] {
-    dependentConfigFiles.flatMap { moduleAndConfigFile in
-      let (moduleName, configFile) = moduleAndConfigFile
+  func argumentsDependedOnConfigs(_ dependentConfigFiles: [DependentConfigFile]) -> [String] {
+    dependentConfigFiles.flatMap { dependentConfigFile in
       return [
         "--depends-on",
-        "\(moduleName)=\(configFile.path(percentEncoded: false))",
+        "\(dependentConfigFile.swiftModuleName)=\(dependentConfigFile.configURL.path(percentEncoded: false))",
       ]
     }
   }

--- a/Plugins/SwiftJavaPlugin/SwiftJavaPlugin.swift
+++ b/Plugins/SwiftJavaPlugin/SwiftJavaPlugin.swift
@@ -231,7 +231,7 @@ extension SwiftJavaBuildToolPlugin {
 
   func argumentsDependedOnConfigs(_ dependentConfigFiles: [DependentConfigFile]) -> [String] {
     dependentConfigFiles.flatMap { dependentConfigFile in
-      return [
+      [
         "--depends-on",
         "\(dependentConfigFile.swiftModuleName)=\(dependentConfigFile.configURL.path(percentEncoded: false))",
       ]

--- a/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
@@ -15,6 +15,19 @@
 import SwiftJavaJNICore
 
 extension JavaType {
+  var rawClassReference: String {
+    switch self {
+    case .class(let package, let name, _):
+      if let package, !package.isEmpty {
+        return "\(package).\(name)"
+      } else {
+        return name
+      }
+    default:
+      return description
+    }
+  }
+
   var jniTypeSignature: String {
     switch self {
     case .boolean: return "Z"

--- a/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
@@ -16,19 +16,6 @@ import SwiftJavaJNICore
 
 extension JavaType {
 
-  var fullyQualifiedName: String {
-    switch self {
-    case .class(let package, let name, _):
-      if let package, !package.isEmpty {
-        return "\(package).\(name)"
-      } else {
-        return name
-      }
-    default:
-      return description
-    }
-  }
-
   var jniTypeSignature: String {
     switch self {
     case .boolean: return "Z"

--- a/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
@@ -15,7 +15,8 @@
 import SwiftJavaJNICore
 
 extension JavaType {
-  var rawClassReference: String {
+
+  var fullyQualifiedName: String {
     switch self {
     case .class(let package, let name, _):
       if let package, !package.isEmpty {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1515,7 +1515,7 @@ extension JNISwift2JavaGenerator {
               ],
             ),
             function: "toArray",
-            arguments: [.constant("\(javaType.className!)[]::new")]
+            arguments: [.constant("\(javaType.rawClassReference)[]::new")]
           )
         )
 
@@ -1926,7 +1926,7 @@ extension JNISwift2JavaGenerator {
           } else {
             ""
           }
-        return "\(className).\(genericClause)wrapMemoryAddressUnsafe(\(inner), swiftArena)"
+        return "\(javaType.rawClassReference).\(genericClause)wrapMemoryAddressUnsafe(\(inner), swiftArena)"
 
       case .constructJavaClass(let inner, let javaType):
         let inner = inner.render(&printer, placeholder)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -23,7 +23,7 @@ extension JNISwift2JavaGenerator {
       swiftModuleName: swiftModuleName,
       javaPackage: self.javaPackage,
       javaClassLookupTable: self.javaClassLookupTable,
-      dependentJavaPackages: self.dependentJavaPackages,
+      moduleJavaPackages: self.moduleJavaPackages,
       knownTypes: SwiftKnownTypes(symbolTable: lookupContext.symbolTable),
       protocolWrappers: self.interfaceProtocolWrappers,
       logger: self.logger,
@@ -65,7 +65,7 @@ extension JNISwift2JavaGenerator {
         swiftModuleName: swiftModuleName,
         javaPackage: self.javaPackage,
         javaClassLookupTable: self.javaClassLookupTable,
-        dependentJavaPackages: self.dependentJavaPackages,
+        moduleJavaPackages: self.moduleJavaPackages,
         knownTypes: SwiftKnownTypes(symbolTable: lookupContext.symbolTable),
         protocolWrappers: self.interfaceProtocolWrappers,
         logger: self.logger,
@@ -87,7 +87,7 @@ extension JNISwift2JavaGenerator {
     let swiftModuleName: String
     let javaPackage: String
     let javaClassLookupTable: JavaClassLookupTable
-    let dependentJavaPackages: [String: String]
+    let moduleJavaPackages: ModuleJavaPackages
     var knownTypes: SwiftKnownTypes
     let protocolWrappers: [ImportedNominalType: JavaInterfaceSwiftWrapper]
     let logger: Logger
@@ -549,7 +549,7 @@ extension JNISwift2JavaGenerator {
         }
 
         let javaType = JavaType.class(
-          package: dependentJavaPackages[nominalType.nominalTypeDecl.moduleName],
+          package: moduleJavaPackages[nominalType.nominalTypeDecl.moduleName],
           name: nominalTypeName,
           typeParameters: try nominalType.genericArguments?.map { swiftType in
             try translateGenericTypeParameter(
@@ -985,7 +985,7 @@ extension JNISwift2JavaGenerator {
         }
 
         let javaType = JavaType.class(
-          package: dependentJavaPackages[nominalType.nominalTypeDecl.moduleName],
+          package: moduleJavaPackages[nominalType.nominalTypeDecl.moduleName],
           name: nominalType.nominalTypeDecl.qualifiedName,
           typeParameters: try nominalType.genericArguments?.map { swiftType in
             try translateGenericTypeParameter(
@@ -1134,7 +1134,7 @@ extension JNISwift2JavaGenerator {
           } ?? []
 
         return .class(
-          package: dependentJavaPackages[nominalType.nominalTypeDecl.moduleName],
+          package: moduleJavaPackages[nominalType.nominalTypeDecl.moduleName],
           name: nominalTypeName,
           typeParameters: typeParameters,
         )

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1515,7 +1515,7 @@ extension JNISwift2JavaGenerator {
               ],
             ),
             function: "toArray",
-            arguments: [.constant("\(javaType.rawClassReference)[]::new")]
+            arguments: [.constant("\(javaType.fullyQualifiedName)[]::new")]
           )
         )
 
@@ -1926,7 +1926,7 @@ extension JNISwift2JavaGenerator {
           } else {
             ""
           }
-        return "\(javaType.rawClassReference).\(genericClause)wrapMemoryAddressUnsafe(\(inner), swiftArena)"
+        return "\(javaType.fullyQualifiedName).\(genericClause)wrapMemoryAddressUnsafe(\(inner), swiftArena)"
 
       case .constructJavaClass(let inner, let javaType):
         let inner = inner.render(&printer, placeholder)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1515,7 +1515,7 @@ extension JNISwift2JavaGenerator {
               ],
             ),
             function: "toArray",
-            arguments: [.constant("\(javaType.fullyQualifiedName)[]::new")]
+            arguments: [.constant("\(javaType.fullyQualifiedClassName!)[]::new")]
           )
         )
 
@@ -1926,7 +1926,7 @@ extension JNISwift2JavaGenerator {
           } else {
             ""
           }
-        return "\(javaType.fullyQualifiedName).\(genericClause)wrapMemoryAddressUnsafe(\(inner), swiftArena)"
+        return "\(javaType.fullyQualifiedClassName!).\(genericClause)wrapMemoryAddressUnsafe(\(inner), swiftArena)"
 
       case .constructJavaClass(let inner, let javaType):
         let inner = inner.render(&printer, placeholder)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -23,6 +23,7 @@ extension JNISwift2JavaGenerator {
       swiftModuleName: swiftModuleName,
       javaPackage: self.javaPackage,
       javaClassLookupTable: self.javaClassLookupTable,
+      dependentJavaPackages: self.dependentJavaPackages,
       knownTypes: SwiftKnownTypes(symbolTable: lookupContext.symbolTable),
       protocolWrappers: self.interfaceProtocolWrappers,
       logger: self.logger,
@@ -64,6 +65,7 @@ extension JNISwift2JavaGenerator {
         swiftModuleName: swiftModuleName,
         javaPackage: self.javaPackage,
         javaClassLookupTable: self.javaClassLookupTable,
+        dependentJavaPackages: self.dependentJavaPackages,
         knownTypes: SwiftKnownTypes(symbolTable: lookupContext.symbolTable),
         protocolWrappers: self.interfaceProtocolWrappers,
         logger: self.logger,
@@ -85,6 +87,7 @@ extension JNISwift2JavaGenerator {
     let swiftModuleName: String
     let javaPackage: String
     let javaClassLookupTable: JavaClassLookupTable
+    let dependentJavaPackages: [String: String]
     var knownTypes: SwiftKnownTypes
     let protocolWrappers: [ImportedNominalType: JavaInterfaceSwiftWrapper]
     let logger: Logger
@@ -546,7 +549,7 @@ extension JNISwift2JavaGenerator {
         }
 
         let javaType = JavaType.class(
-          package: nil,
+          package: dependentJavaPackages[nominalType.nominalTypeDecl.moduleName],
           name: nominalTypeName,
           typeParameters: try nominalType.genericArguments?.map { swiftType in
             try translateGenericTypeParameter(
@@ -982,7 +985,7 @@ extension JNISwift2JavaGenerator {
         }
 
         let javaType = JavaType.class(
-          package: nil,
+          package: dependentJavaPackages[nominalType.nominalTypeDecl.moduleName],
           name: nominalType.nominalTypeDecl.qualifiedName,
           typeParameters: try nominalType.genericArguments?.map { swiftType in
             try translateGenericTypeParameter(
@@ -1131,7 +1134,7 @@ extension JNISwift2JavaGenerator {
           } ?? []
 
         return .class(
-          package: nil,
+          package: dependentJavaPackages[nominalType.nominalTypeDecl.moduleName],
           name: nominalTypeName,
           typeParameters: typeParameters,
         )

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1917,7 +1917,7 @@ extension JNISwift2JavaGenerator {
 
       case .wrapMemoryAddressUnsafe(let inner, let javaType):
         let inner = inner.render(&printer, placeholder)
-        guard case .class(_, let className, let typeParameters) = javaType else {
+        guard case .class(_, _, let typeParameters) = javaType else {
           fatalError("\(javaType) is not class.")
         }
         let genericClause =

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
@@ -32,6 +32,7 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
   let lookupContext: SwiftTypeLookupContext
 
   let javaClassLookupTable: JavaClassLookupTable
+  let dependentJavaPackages: [String: String]
 
   var javaPackagePath: String {
     javaPackage.replacingOccurrences(of: ".", with: "/")
@@ -75,6 +76,7 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
     swiftOutputDirectory: String,
     javaOutputDirectory: String,
     javaClassLookupTable: JavaClassLookupTable,
+    dependentJavaPackages: [String: String],
   ) {
     self.config = config
     self.logger = Logger(label: "jni-generator", logLevel: translator.log.logLevel)
@@ -84,6 +86,7 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
     self.swiftOutputDirectory = swiftOutputDirectory
     self.javaOutputDirectory = javaOutputDirectory
     self.javaClassLookupTable = javaClassLookupTable
+    self.dependentJavaPackages = dependentJavaPackages
     self.lookupContext = translator.lookupContext
 
     // If we are forced to write empty files, construct the expected outputs.

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
@@ -20,6 +20,9 @@ import SwiftJavaJNICore
 /// the fully qualified canoical names.
 package typealias JavaClassLookupTable = [String: String]
 
+/// A table where keys are Swift module names and the values are Java package names.
+package typealias ModuleJavaPackages = [String: String]
+
 package class JNISwift2JavaGenerator: Swift2JavaGenerator {
 
   let logger: Logger
@@ -32,7 +35,7 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
   let lookupContext: SwiftTypeLookupContext
 
   let javaClassLookupTable: JavaClassLookupTable
-  let dependentJavaPackages: [String: String]
+  let moduleJavaPackages: ModuleJavaPackages
 
   var javaPackagePath: String {
     javaPackage.replacingOccurrences(of: ".", with: "/")
@@ -76,7 +79,7 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
     swiftOutputDirectory: String,
     javaOutputDirectory: String,
     javaClassLookupTable: JavaClassLookupTable,
-    dependentJavaPackages: [String: String],
+    moduleJavaPackages: ModuleJavaPackages,
   ) {
     self.config = config
     self.logger = Logger(label: "jni-generator", logLevel: translator.log.logLevel)
@@ -86,7 +89,7 @@ package class JNISwift2JavaGenerator: Swift2JavaGenerator {
     self.swiftOutputDirectory = swiftOutputDirectory
     self.javaOutputDirectory = javaOutputDirectory
     self.javaClassLookupTable = javaClassLookupTable
-    self.dependentJavaPackages = dependentJavaPackages
+    self.moduleJavaPackages = moduleJavaPackages
     self.lookupContext = translator.lookupContext
 
     // If we are forced to write empty files, construct the expected outputs.

--- a/Sources/JExtractSwiftLib/Swift2Java.swift
+++ b/Sources/JExtractSwiftLib/Swift2Java.swift
@@ -21,9 +21,9 @@ import SwiftSyntaxBuilder
 
 public struct SwiftToJava {
   let config: Configuration
-  let dependentConfigs: [(String?, Configuration)]
+  let dependentConfigs: [DependentConfig]
 
-  public init(config: Configuration, dependentConfigs: [(String?, Configuration)]) {
+  public init(config: Configuration, dependentConfigs: [DependentConfig]) {
     self.config = config
     self.dependentConfigs = dependentConfigs
   }
@@ -95,14 +95,18 @@ public struct SwiftToJava {
       fatalError("Missing --output-java directory!")
     }
 
-    let wrappedJavaClassesLookupTable: JavaClassLookupTable = dependentConfigs.compactMap(\.1.classes).reduce(into: [:]) {
+    let wrappedJavaClassesLookupTable: JavaClassLookupTable = dependentConfigs.compactMap(\.configuration.classes).reduce(into: [:]) {
       for (canonicalName, javaClass) in $1 {
         $0[javaClass] = canonicalName
       }
     }
 
     let dependentJavaPackages = dependentConfigs.reduce(into: [String: String]()) { partialResult, dependency in
-      guard let moduleName = dependency.0, let javaPackage = dependency.1.javaPackage, !javaPackage.isEmpty else {
+      guard
+        let moduleName = dependency.swiftModuleName,
+        let javaPackage = dependency.configuration.javaPackage,
+        !javaPackage.isEmpty
+      else {
         return
       }
       partialResult[moduleName] = javaPackage

--- a/Sources/JExtractSwiftLib/Swift2Java.swift
+++ b/Sources/JExtractSwiftLib/Swift2Java.swift
@@ -101,7 +101,7 @@ public struct SwiftToJava {
       }
     }
 
-    let dependentJavaPackages = dependentConfigs.reduce(into: [String: String]()) { partialResult, dependency in
+    let moduleJavaPackages = dependentConfigs.reduce(into: [String: String]()) { partialResult, dependency in
       guard
         let moduleName = dependency.swiftModuleName,
         let javaPackage = dependency.configuration.javaPackage,
@@ -136,7 +136,7 @@ public struct SwiftToJava {
         swiftOutputDirectory: outputSwiftDirectory,
         javaOutputDirectory: outputJavaDirectory,
         javaClassLookupTable: wrappedJavaClassesLookupTable,
-        dependentJavaPackages: dependentJavaPackages
+        moduleJavaPackages: moduleJavaPackages
       )
 
       try generator.generate()

--- a/Sources/JExtractSwiftLib/Swift2Java.swift
+++ b/Sources/JExtractSwiftLib/Swift2Java.swift
@@ -21,9 +21,9 @@ import SwiftSyntaxBuilder
 
 public struct SwiftToJava {
   let config: Configuration
-  let dependentConfigs: [Configuration]
+  let dependentConfigs: [(String?, Configuration)]
 
-  public init(config: Configuration, dependentConfigs: [Configuration]) {
+  public init(config: Configuration, dependentConfigs: [(String?, Configuration)]) {
     self.config = config
     self.dependentConfigs = dependentConfigs
   }
@@ -95,10 +95,17 @@ public struct SwiftToJava {
       fatalError("Missing --output-java directory!")
     }
 
-    let wrappedJavaClassesLookupTable: JavaClassLookupTable = dependentConfigs.compactMap(\.classes).reduce(into: [:]) {
+    let wrappedJavaClassesLookupTable: JavaClassLookupTable = dependentConfigs.compactMap(\.1.classes).reduce(into: [:]) {
       for (canonicalName, javaClass) in $1 {
         $0[javaClass] = canonicalName
       }
+    }
+
+    let dependentJavaPackages = dependentConfigs.reduce(into: [String: String]()) { partialResult, dependency in
+      guard let moduleName = dependency.0, let javaPackage = dependency.1.javaPackage, !javaPackage.isEmpty else {
+        return
+      }
+      partialResult[moduleName] = javaPackage
     }
 
     translator.dependenciesClasses = Array(wrappedJavaClassesLookupTable.keys)
@@ -124,7 +131,8 @@ public struct SwiftToJava {
         javaPackage: config.javaPackage ?? "",
         swiftOutputDirectory: outputSwiftDirectory,
         javaOutputDirectory: outputJavaDirectory,
-        javaClassLookupTable: wrappedJavaClassesLookupTable
+        javaClassLookupTable: wrappedJavaClassesLookupTable,
+        dependentJavaPackages: dependentJavaPackages
       )
 
       try generator.generate()

--- a/Sources/SwiftJavaConfigurationShared/Configuration.swift
+++ b/Sources/SwiftJavaConfigurationShared/Configuration.swift
@@ -390,9 +390,19 @@ public func readConfiguration(
   }
 }
 
-/// Load all dependent configs configured with `--depends-on` and return a list of
-/// `(SwiftModuleName, Configuration)` tuples.
-public func loadDependentConfigs(dependsOn: [String]) throws -> [(String?, Configuration)] {
+/// Parsed dependent configuration provided via `--depends-on`.
+public struct DependentConfig {
+  public let swiftModuleName: String?
+  public let configuration: Configuration
+
+  public init(swiftModuleName: String?, configuration: Configuration) {
+    self.swiftModuleName = swiftModuleName
+    self.configuration = configuration
+  }
+}
+
+/// Load all dependent configs configured with `--depends-on`.
+public func loadDependentConfigs(dependsOn: [String]) throws -> [DependentConfig] {
   try dependsOn.map { dependentConfig in
     let equalLoc = dependentConfig.firstIndex(of: "=")
 
@@ -406,7 +416,7 @@ public func loadDependentConfigs(dependsOn: [String]) throws -> [(String?, Confi
 
     let config = try readConfiguration(configPath: URL(fileURLWithPath: configFileName)) ?? Configuration()
 
-    return (swiftModuleName, config)
+    return DependentConfig(swiftModuleName: swiftModuleName, configuration: config)
   }
 }
 

--- a/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
@@ -207,7 +207,7 @@ struct IncompatibleModeError: Error {
 extension SwiftJava.JExtractCommand {
   func jextractSwift(
     config: Configuration,
-    dependentConfigs: [(String?, Configuration)],
+    dependentConfigs: [DependentConfig],
   ) throws {
     try SwiftToJava(config: config, dependentConfigs: dependentConfigs).run()
   }

--- a/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JExtractCommand.swift
@@ -178,7 +178,7 @@ extension SwiftJava.JExtractCommand {
     let dependentConfigs = try loadDependentConfigs(dependsOn: self.dependsOn)
     print("[debug][swift-java] Dependent configs: \(dependentConfigs.count)")
 
-    try jextractSwift(config: config, dependentConfigs: dependentConfigs.map(\.1))
+    try jextractSwift(config: config, dependentConfigs: dependentConfigs)
   }
 
   /// Check if the configured modes are compatible, and fail if not
@@ -207,7 +207,7 @@ struct IncompatibleModeError: Error {
 extension SwiftJava.JExtractCommand {
   func jextractSwift(
     config: Configuration,
-    dependentConfigs: [Configuration],
+    dependentConfigs: [(String?, Configuration)],
   ) throws {
     try SwiftToJava(config: config, dependentConfigs: dependentConfigs).run()
   }

--- a/Sources/SwiftJavaTool/Commands/WrapJavaCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/WrapJavaCommand.swift
@@ -78,6 +78,10 @@ extension SwiftJava {
 }
 
 extension SwiftJava.WrapJavaCommand {
+  struct NamedDependentConfig {
+    let swiftModuleName: String
+    let configuration: Configuration
+  }
 
   mutating func runSwiftJavaCommand(config: inout Configuration) async throws {
     print("self.filterInclude = \(self.filterInclude)")
@@ -101,23 +105,23 @@ extension SwiftJava.WrapJavaCommand {
     )
 
     // Load all of the dependent configurations and associate them with Swift modules.
-    let dependentConfigs = try loadDependentConfigs(dependsOn: self.dependsOn).map { moduleName, config in
-      guard let moduleName else {
+    let dependentConfigs = try loadDependentConfigs(dependsOn: self.dependsOn).map { dependentConfig in
+      guard let moduleName = dependentConfig.swiftModuleName else {
         throw JavaToSwiftError.badConfigOption(self.dependsOn.joined(separator: " "))
       }
-      return (moduleName, config)
+      return NamedDependentConfig(swiftModuleName: moduleName, configuration: dependentConfig.configuration)
     }
     print("[debug][swift-java] Dependent configs: \(dependentConfigs.count)")
 
     // Include classpath entries which libs we depend on require...
-    for (fromModule, config) in dependentConfigs {
+    for dependentConfig in dependentConfigs {
       print(
-        "[trace][swift-java] Add dependent config (\(fromModule)) classpath elements: \(config.classpathEntries.count)"
+        "[trace][swift-java] Add dependent config (\(dependentConfig.swiftModuleName)) classpath elements: \(dependentConfig.configuration.classpathEntries.count)"
       )
       // TODO: may need to resolve the dependent configs rather than just get their configs
       // TODO: We should cache the resolved classpaths as well so we don't do it many times
-      for entry in config.classpathEntries {
-        print("[trace][swift-java] Add dependent config (\(fromModule)) classpath element: \(entry)")
+      for entry in dependentConfig.configuration.classpathEntries {
+        print("[trace][swift-java] Add dependent config (\(dependentConfig.swiftModuleName)) classpath element: \(entry)")
         classpathEntries.append(entry)
       }
     }
@@ -137,7 +141,7 @@ extension SwiftJava.WrapJavaCommand {
 
   mutating func generateWrappers(
     config: Configuration,
-    dependentConfigs: [(String, Configuration)],
+    dependentConfigs: [NamedDependentConfig],
     environment: JNIEnvironment
   ) throws {
     let translator = JavaTranslator(
@@ -163,10 +167,10 @@ extension SwiftJava.WrapJavaCommand {
     }
 
     // Note all of the dependent configurations.
-    for (swiftModuleName, dependentConfig) in dependentConfigs {
+    for dependentConfig in dependentConfigs {
       translator.addConfiguration(
-        dependentConfig,
-        forSwiftModule: swiftModuleName
+        dependentConfig.configuration,
+        forSwiftModule: dependentConfig.swiftModuleName
       )
     }
 

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -73,7 +73,8 @@ func assertOutput(
       javaPackage: "com.example.swift",
       swiftOutputDirectory: "/fake",
       javaOutputDirectory: "/fake",
-      javaClassLookupTable: javaClassLookupTable
+      javaClassLookupTable: javaClassLookupTable,
+      dependentJavaPackages: [:]
     )
 
     switch renderKind {

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -74,7 +74,7 @@ func assertOutput(
       swiftOutputDirectory: "/fake",
       javaOutputDirectory: "/fake",
       javaClassLookupTable: javaClassLookupTable,
-      dependentJavaPackages: [:]
+      moduleJavaPackages: [:]
     )
 
     switch renderKind {

--- a/Tests/JExtractSwiftTests/JNI/JNIDictionaryTest.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIDictionaryTest.swift
@@ -28,7 +28,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> f(SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """,
         """
@@ -104,7 +104,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> f(org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> dict, SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(dict, "dict must not be null").$memoryAddress()), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(dict, "dict must not be null").$memoryAddress()), swiftArena);
         }
         """,
         """
@@ -142,7 +142,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> f(org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> dict, SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(dict, "dict must not be null").$memoryAddress()), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(dict, "dict must not be null").$memoryAddress()), swiftArena);
         }
         """,
         """
@@ -183,7 +183,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Boolean> f(SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.String, java.lang.Boolean>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.String, java.lang.Boolean>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -200,7 +200,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Double> f(SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.String, java.lang.Double>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.String, java.lang.Double>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -217,7 +217,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.Long, java.lang.String> f(SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.Long, java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.Long, java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -234,7 +234,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.Integer, java.lang.Float> f(SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.Integer, java.lang.Float>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.Integer, java.lang.Float>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -295,7 +295,7 @@ struct JNIDictionaryTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> f(org.swift.swiftkit.core.collections.SwiftDictionaryMap<java.lang.String, java.lang.Long> dict, java.lang.String key, long value, SwiftArena swiftArena) {
-          return SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(dict, "dict must not be null").$memoryAddress(), key, value), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftDictionaryMap.<java.lang.String, java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(dict, "dict must not be null").$memoryAddress(), key, value), swiftArena);
         }
         """,
         """

--- a/Tests/JExtractSwiftTests/JNI/JNISetTest.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNISetTest.swift
@@ -28,7 +28,7 @@ struct JNISetTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftSet<java.lang.String> f(SwiftArena swiftArena) {
-          return SwiftSet.<java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftSet.<java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """,
         """
@@ -104,7 +104,7 @@ struct JNISetTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftSet<java.lang.String> f(org.swift.swiftkit.core.collections.SwiftSet<java.lang.String> set, SwiftArena swiftArena) {
-          return SwiftSet.<java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(set, "set must not be null").$memoryAddress()), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftSet.<java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(set, "set must not be null").$memoryAddress()), swiftArena);
         }
         """,
         """
@@ -145,7 +145,7 @@ struct JNISetTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftSet<java.lang.Long> f(SwiftArena swiftArena) {
-          return SwiftSet.<java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftSet.<java.lang.Long>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -162,7 +162,7 @@ struct JNISetTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftSet<java.lang.Boolean> f(SwiftArena swiftArena) {
-          return SwiftSet.<java.lang.Boolean>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftSet.<java.lang.Boolean>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -179,7 +179,7 @@ struct JNISetTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftSet<java.lang.Double> f(SwiftArena swiftArena) {
-          return SwiftSet.<java.lang.Double>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftSet.<java.lang.Double>wrapMemoryAddressUnsafe(SwiftModule.$f(), swiftArena);
         }
         """
       ]
@@ -240,7 +240,7 @@ struct JNISetTest {
       expectedChunks: [
         """
         public static org.swift.swiftkit.core.collections.SwiftSet<java.lang.String> f(org.swift.swiftkit.core.collections.SwiftSet<java.lang.String> set, java.lang.String element, SwiftArena swiftArena) {
-          return SwiftSet.<java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(set, "set must not be null").$memoryAddress(), element), swiftArena);
+          return org.swift.swiftkit.core.collections.SwiftSet.<java.lang.String>wrapMemoryAddressUnsafe(SwiftModule.$f(Objects.requireNonNull(set, "set must not be null").$memoryAddress(), element), swiftArena);
         }
         """,
         """


### PR DESCRIPTION
The main goal of this PR is to preserve the mapping between dependent Swift modules and their Java packages so JNI generation can resolve cross-module Java references correctly.

While doing that, I also replaced tuple-based dependent-config plumbing with named structures to make the data flow clearer and less error-prone.

 A concrete example of this setup can be found in TriForce: https://github.com/iDevid/TriForce
  
In that sample project, the Android app depends on **SharedNetworkLayer**, which in turn depends on **SharedModels**.