### PR TITLE
Use loadLibraryWithFallbacks when loading in static{} in jni mode

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -132,8 +132,8 @@ extension JNISwift2JavaGenerator {
           """
 
           static {
-            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            System.loadLibrary(LIB_NAME);
+            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+            SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
           }
           """
         )
@@ -245,8 +245,8 @@ extension JNISwift2JavaGenerator {
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();
           static boolean initializeLibs() {
-              System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-              System.loadLibrary(LIB_NAME);
+              SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+              SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
               return true;
           }
           """

--- a/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
@@ -68,8 +68,8 @@ struct JNIClassTests {
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();
           static boolean initializeLibs() {
-            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            System.loadLibrary(LIB_NAME);
+            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+            SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
             return true;
           }
         """,

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -52,8 +52,8 @@ struct JNIEnumTests {
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();
           static boolean initializeLibs() {
-            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            System.loadLibrary(LIB_NAME);
+            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+            SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
             return true;
           }
         """,

--- a/Tests/JExtractSwiftTests/JNI/JNIModuleTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIModuleTests.swift
@@ -60,8 +60,8 @@ struct JNIModuleTests {
           static final java.lang.String LIB_NAME = "SwiftModule";
 
           static {
-            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            System.loadLibrary(LIB_NAME);
+            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+            SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
           }
         """
       ]
@@ -296,7 +296,7 @@ struct JNIModuleTests {
         """
       ],
       notExpectedChunks: [
-        "System.loadLibrary",
+        "loadLibraryWithFallbacks",
         "initializeLibs",
       ]
     )

--- a/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
@@ -62,8 +62,8 @@ struct JNIStructTests {
           @SuppressWarnings("unused")
           private static final boolean INITIALIZED_LIBS = initializeLibs();
           static boolean initializeLibs() {
-            System.loadLibrary(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
-            System.loadLibrary(LIB_NAME);
+            SwiftLibraries.loadLibraryWithFallbacks(SwiftLibraries.LIB_NAME_SWIFT_JAVA);
+            SwiftLibraries.loadLibraryWithFallbacks(LIB_NAME);
             return true;
           }
         """,
@@ -225,7 +225,7 @@ struct JNIStructTests {
         """
       ],
       notExpectedChunks: [
-        "System.loadLibrary",
+        "loadLibraryWithFallbacks",
         "initializeLibs",
       ]
     )


### PR DESCRIPTION
We should be using SwiftLibraries.loadLibraryWithFallbacks in order to find libaries inside a jar that includes the .so files as resouces. 

Instead, in JNI mode, we were using just System.loadLibrary which won't search resources.

FFM already did the right thing before