### PR TITLE
Allow swift-collections up to next major

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -122,7 +122,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     .package(url: "https://github.com/apple/swift-system", from: "1.4.0"),
     .package(url: "https://github.com/apple/swift-log", from: "1.2.0"),
-    .package(url: "https://github.com/apple/swift-collections", .upToNextMinor(from: "1.3.0")), // primarily for ordered collections
+    .package(url: "https://github.com/apple/swift-collections", from: "1.3.0"), // primarily for ordered collections
     .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0", traits: ["SubprocessFoundation"]),
 
     // Benchmarking


### PR DESCRIPTION
Not sure why this was so restrictive