### PR TITLE
Add @Suite to test classes missing it

### DIFF
--- a/Tests/JExtractSwiftTests/ByteArrayTests.swift
+++ b/Tests/JExtractSwiftTests/ByteArrayTests.swift
@@ -16,6 +16,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class ByteArrayTests {
 
   @Test(

--- a/Tests/JExtractSwiftTests/ClassPrintingTests.swift
+++ b/Tests/JExtractSwiftTests/ClassPrintingTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 struct ClassPrintingTests {
   let class_interfaceFile =
     """

--- a/Tests/JExtractSwiftTests/DataImportTests.swift
+++ b/Tests/JExtractSwiftTests/DataImportTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class DataImportTests {
   private static let ifConfigImport = """
     #if canImport(FoundationEssentials)

--- a/Tests/JExtractSwiftTests/ExtensionImportTests.swift
+++ b/Tests/JExtractSwiftTests/ExtensionImportTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class ExtensionImportTests {
   let interfaceFile =
     """

--- a/Tests/JExtractSwiftTests/FFMNestedTypesTests.swift
+++ b/Tests/JExtractSwiftTests/FFMNestedTypesTests.swift
@@ -16,6 +16,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class FFMNestedTypesTests {
   let class_interfaceFile =
     """

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -17,6 +17,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class FuncCallbackImportTests {
 
   static let class_interfaceFile =

--- a/Tests/JExtractSwiftTests/InternalExtractTests.swift
+++ b/Tests/JExtractSwiftTests/InternalExtractTests.swift
@@ -16,6 +16,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class InternalExtractTests {
   let text =
     """

--- a/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIIntConversionChecksTests.swift
@@ -16,6 +16,7 @@ import Testing
 
 @testable import JExtractSwiftLib
 
+@Suite
 struct JNIIntConversionChecksTests {
   private let signedSource = """
     public struct MyStruct {

--- a/Tests/JExtractSwiftTests/JNI/JNIUnsignedNumberTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIUnsignedNumberTests.swift
@@ -16,6 +16,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class JNIUnsignedNumberTests {
 
   @Test("Import: UInt16 (char)")

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -17,6 +17,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class MethodImportTests {
   let class_interfaceFile =
     """

--- a/Tests/JExtractSwiftTests/MethodThunkTests.swift
+++ b/Tests/JExtractSwiftTests/MethodThunkTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class MethodThunkTests {
   let input =
     """

--- a/Tests/JExtractSwiftTests/OptionalImportTests.swift
+++ b/Tests/JExtractSwiftTests/OptionalImportTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class OptionalImportTests {
   let interfaceFile =
     """

--- a/Tests/JExtractSwiftTests/SendableTests.swift
+++ b/Tests/JExtractSwiftTests/SendableTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class SendableTests {
   let source =
     """

--- a/Tests/JExtractSwiftTests/StringPassingTests.swift
+++ b/Tests/JExtractSwiftTests/StringPassingTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class StringPassingTests {
   let class_interfaceFile =
     """

--- a/Tests/JExtractSwiftTests/SwiftDocumentationParsingTests.swift
+++ b/Tests/JExtractSwiftTests/SwiftDocumentationParsingTests.swift
@@ -16,6 +16,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 struct SwiftDocumentationParsingTests {
   @Test(
     "Simple Swift func documentation",

--- a/Tests/JExtractSwiftTests/UnsignedNumberTests.swift
+++ b/Tests/JExtractSwiftTests/UnsignedNumberTests.swift
@@ -16,6 +16,7 @@ import JExtractSwiftLib
 import SwiftJavaConfigurationShared
 import Testing
 
+@Suite
 final class UnsignedNumberTests {
 
   @Test(

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -15,6 +15,7 @@
 import JExtractSwiftLib
 import Testing
 
+@Suite
 final class VariableImportTests {
   let class_interfaceFile =
     """


### PR DESCRIPTION
While looking through the tests, I noticed that several test classes were missing the `@Suite` annotation.

Since there was no clear reason for this inconsistency, I have updated the classes to ensure `@Suite` is applied consistently.

Note: As a first-time experiment, I leveraged GitHub Copilot to handle the entire implementation for this PR.