### PR TITLE
jextract/jni: Use switch expressions in `getCase()`

### DIFF
--- a/Sources/CodePrinting/CodePrinter.swift
+++ b/Sources/CodePrinting/CodePrinter.swift
@@ -91,6 +91,7 @@ public struct CodePrinter {
   public mutating func printBraceBlock(
     _ header: Any,
     parameters: [String]? = nil,
+    _ terminator: PrinterTerminator = .sloc,
     function: String = #function,
     file: String = #fileID,
     line: UInt = #line,
@@ -104,7 +105,7 @@ public struct CodePrinter {
     indent()
     try body(&self)
     outdent()
-    print("}", .sloc, function: function, file: file, line: line)
+    print("}", terminator, function: function, file: file, line: line)
   }
 
   public mutating func printIfBlock(
@@ -224,6 +225,7 @@ public enum PrinterTerminator: String {
   case commaNewLine = ",\n"
   case `continue` = ""
   case sloc = "// <source location>"
+  case semicolonNewLine = ";\n"
 
   public static func parameterSeparator(_ isLast: Bool) -> Self {
     if isLast {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -528,19 +528,17 @@ extension JNISwift2JavaGenerator {
     }.contains(where: \.requiresSwiftArena)
 
     printer.printBraceBlock("public Case getCase(\(requiresSwiftArena ? "SwiftArena swiftArena" : ""))") { printer in
-      printer.print("Discriminator discriminator = this.getDiscriminator();")
-      printer.printBraceBlock("switch (discriminator)") { printer in
+      printer.printBraceBlock("return switch (this.getDiscriminator())", .semicolonNewLine) { printer in
         for enumCase in decl.cases {
           guard let translatedCase = self.translatedEnumCase(for: enumCase) else {
             continue
           }
           let arenaArgument = translatedCase.requiresSwiftArena ? "swiftArena" : ""
           printer.print(
-            "case \(enumCase.name.uppercased()): return this.getAs\(enumCase.name.firstCharacterUppercased)(\(arenaArgument)).orElseThrow();"
+            "case \(enumCase.name.uppercased()) -> this.getAs\(enumCase.name.firstCharacterUppercased)(\(arenaArgument)).orElseThrow();"
           )
         }
       }
-      printer.print(#"throw new RuntimeException("Unknown discriminator value " + discriminator);"#)
     }
   }
 

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -177,13 +177,11 @@ struct JNIEnumTests {
         """,
         """
         public Case getCase() {
-          Discriminator discriminator = this.getDiscriminator();
-          switch (discriminator) {
-            case FIRST: return this.getAsFirst().orElseThrow();
-            case SECOND: return this.getAsSecond().orElseThrow();
-            case THIRD: return this.getAsThird().orElseThrow();
+          return switch (this.getDiscriminator()) {
+            case FIRST -> this.getAsFirst().orElseThrow();
+            case SECOND -> this.getAsSecond().orElseThrow();
+            case THIRD -> this.getAsThird().orElseThrow();
           }
-          throw new RuntimeException("Unknown discriminator value " + discriminator);
         }
         """,
       ]


### PR DESCRIPTION
Using a switch expression for the `Case getCase()` implementation makes the code cleaner.
Since switch expressions are exhaustive, it eliminates the need to throw a `RuntimeException`.