### PR TITLE
jextract: bytes passing benchmarks

### DIFF
--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// FFM mode supports [UInt8] and Data, but NOT [[UInt8]], UnsafeRawBufferPointer,
+// or UnsafeMutableRawBufferPointer. The benchmark class on the Java side omits
+// the unsupported cases.
+
+// ==== -----------------------------------------------------------------------
+// MARK: [UInt8] pass-through
+
+public func benchAcceptBytes(_ bytes: [UInt8]) -> Int {
+  bytes.count
+}
+
+public func benchReturnBytes(_ size: Int) -> [UInt8] {
+  [UInt8](repeating: 0, count: size)
+}
+
+public func benchEchoBytes(_ bytes: [UInt8]) -> [UInt8] {
+  bytes
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Data
+
+public func benchAcceptData(_ data: Data) -> Int {
+  data.count
+}
+
+public func benchReturnData(_ size: Int) -> Data {
+  Data(count: size)
+}
+
+public func benchEchoData(_ data: Data) -> Data {
+  data
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: real world examples
+
+public func benchSparseShard(
+  dimension: Int32,
+  numShards: Int32,
+  indices: [Int32],
+  values: [Int32],
+  helperKey: [UInt8]
+) -> [UInt8] {
+  let outSize = Int(indices.count) * 40 + helperKey.count
+  return [UInt8](repeating: 0, count: outSize)
+}

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
@@ -18,50 +18,41 @@ import FoundationEssentials
 import Foundation
 #endif
 
-// FFM mode supports [UInt8] and Data, but NOT [[UInt8]], UnsafeRawBufferPointer,
-// or UnsafeMutableRawBufferPointer. The benchmark class on the Java side omits
-// the unsupported cases.
-
 // ==== -----------------------------------------------------------------------
 // MARK: [UInt8] pass-through
 
-public func benchAcceptBytes(_ bytes: [UInt8]) -> Int {
+public func acceptBytes(_ bytes: [UInt8]) -> Int {
   bytes.count
 }
 
-public func benchReturnBytes(_ size: Int) -> [UInt8] {
-  [UInt8](repeating: 0, count: size)
+public func returnBytes(_ size: Int) -> [UInt8] {
+  [UInt8](repeating: 0xff, count: size)
 }
 
-public func benchEchoBytes(_ bytes: [UInt8]) -> [UInt8] {
+public func echoBytes(_ bytes: [UInt8]) -> [UInt8] {
   bytes
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: Data
 
-public func benchAcceptData(_ data: Data) -> Int {
+public func acceptData(_ data: Data) -> Int {
   data.count
 }
 
-public func benchReturnData(_ size: Int) -> Data {
-  Data(count: size)
-}
-
-public func benchEchoData(_ data: Data) -> Data {
-  data
+public func returnData(_ size: Int) -> Data {
+  Data(repeating: 0xff, count: size)
 }
 
 // ==== -----------------------------------------------------------------------
-// MARK: real world examples
+// MARK: large multi-parameter function
 
-public func benchSparseShard(
-  dimension: Int32,
-  numShards: Int32,
-  indices: [Int32],
-  values: [Int32],
-  helperKey: [UInt8]
+public func largeFunction(
+  a: Int32,
+  b: [UInt8],
+  c: [Int32],
+  d: [UInt8]
 ) -> [UInt8] {
-  let outSize = Int(indices.count) * 40 + helperKey.count
-  return [UInt8](repeating: 0, count: outSize)
+  let outSize = b.count + d.count + c.count * 4
+  return [UInt8](repeating: 0xff, count: outSize)
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
@@ -50,7 +50,7 @@ public func returnData(_ size: Int) -> Data {
 public func largeFunction(
   a: Int32,
   b: [UInt8],
-  c: [Int32],
+  c: [Int8],
   d: [UInt8]
 ) -> [UInt8] {
   let outSize = b.count + d.count + c.count * 4

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/jmh/java/org/swift/swiftkit/ffm/FFMByteArrayBenchmark.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/jmh/java/org/swift/swiftkit/ffm/FFMByteArrayBenchmark.java
@@ -21,16 +21,6 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * Byte-array marshalling benchmarks (FFM mode).
- *
- * FFM mode supports the [UInt8] and Data shapes but not [[UInt8]],
- * UnsafeRawBufferPointer, or UnsafeMutableRawBufferPointer — the
- * corresponding benchmarks live only in JNIByteArrayBenchmark.
- *
- * Method suffix _ffm aligns these rows with their _jni counterparts for
- * side-by-side reading when reports are sorted alphabetically.
- */
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 2, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@@ -39,6 +29,9 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 1, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Xmx1g" })
 public class FFMByteArrayBenchmark {
 
+    @Param({"ffm"})
+    public String mode;
+
     @Param({"4096", "65536", "262144", "1048576", "8388608", "16777216"})
     public int totalBytes;
 
@@ -46,9 +39,11 @@ public class FFMByteArrayBenchmark {
     Data data;
     ClosableAllocatingSwiftArena arena;
 
-    int[] sparseIndices;
-    int[] sparseValues;
-    byte[] helperKey;
+    // Fixtures for largeFunction(a:b:c:d:)
+    int large_a;
+    byte[] large_b;
+    int[] large_c;
+    byte[] large_d;
 
     @Setup(Level.Trial)
     public void beforeAll() {
@@ -61,13 +56,14 @@ public class FFMByteArrayBenchmark {
 
         data = Data.init(flat, arena);
 
-        sparseIndices = new int[8192];
-        sparseValues = new int[8192];
+        large_a = 1000;
+        large_b = new byte[8192];
+        large_c = new int[8192];
         for (int i = 0; i < 8192; i++) {
-            sparseIndices[i] = i * 17;
-            sparseValues[i] = i;
+            large_b[i] = (byte) (i & 0xff);
+            large_c[i] = i;
         }
-        helperKey = new byte[32];
+        large_d = new byte[32];
     }
 
     @TearDown(Level.Trial)
@@ -80,17 +76,17 @@ public class FFMByteArrayBenchmark {
 
     @Benchmark
     public long acceptBytes_ffm() {
-        return MySwiftLibrary.benchAcceptBytes(flat);
+        return MySwiftLibrary.acceptBytes(flat);
     }
 
     @Benchmark
     public byte[] returnBytes_ffm() {
-        return MySwiftLibrary.benchReturnBytes(totalBytes);
+        return MySwiftLibrary.returnBytes(totalBytes);
     }
 
     @Benchmark
     public byte[] echoBytes_ffm() {
-        return MySwiftLibrary.benchEchoBytes(flat);
+        return MySwiftLibrary.echoBytes(flat);
     }
 
     // ==== -----------------------------------------------------------------
@@ -98,28 +94,28 @@ public class FFMByteArrayBenchmark {
 
     @Benchmark
     public long acceptData_ffm() {
-        return MySwiftLibrary.benchAcceptData(data);
+        return MySwiftLibrary.acceptData(data);
     }
 
     @Benchmark
     public Data returnData_ffm(Blackhole bh) {
-        Data result = MySwiftLibrary.benchReturnData(totalBytes, arena);
+        Data result = MySwiftLibrary.returnData(totalBytes, arena);
         bh.consume(result.getCount());
         return result;
     }
 
     @Benchmark
     public Data echoData_ffm(Blackhole bh) {
-        Data echoed = MySwiftLibrary.benchEchoData(data, arena);
+        Data echoed = MySwiftLibrary.echoData(data, arena);
         bh.consume(echoed.getCount());
         return echoed;
     }
 
     // ==== -----------------------------------------------------------------
-    // MARK: sparse shard
+    // MARK: large multi-parameter function
 
     @Benchmark
-    public byte[] sparseShard_ffm() {
-        return MySwiftLibrary.benchSparseShard(1000, 2, sparseIndices, sparseValues, helperKey);
+    public byte[] wide_ffm() {
+        return MySwiftLibrary.largeFunction(large_a, large_b, large_c, large_d);
     }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/jmh/java/org/swift/swiftkit/ffm/FFMByteArrayBenchmark.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/jmh/java/org/swift/swiftkit/ffm/FFMByteArrayBenchmark.java
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package org.swift.swiftkit.ffm;
+
+import com.example.swift.Data;
+import com.example.swift.MySwiftLibrary;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Byte-array marshalling benchmarks (FFM mode).
+ *
+ * FFM mode supports the [UInt8] and Data shapes but not [[UInt8]],
+ * UnsafeRawBufferPointer, or UnsafeMutableRawBufferPointer — the
+ * corresponding benchmarks live only in JNIByteArrayBenchmark.
+ *
+ * Method suffix _ffm aligns these rows with their _jni counterparts for
+ * side-by-side reading when reports are sorted alphabetically.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 2, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Xmx1g" })
+public class FFMByteArrayBenchmark {
+
+    @Param({"4096", "65536", "262144", "1048576", "8388608", "16777216"})
+    public int totalBytes;
+
+    byte[] flat;
+    Data data;
+    ClosableAllocatingSwiftArena arena;
+
+    int[] sparseIndices;
+    int[] sparseValues;
+    byte[] helperKey;
+
+    @Setup(Level.Trial)
+    public void beforeAll() {
+        arena = AllocatingSwiftArena.ofConfined();
+
+        flat = new byte[totalBytes];
+        for (int i = 0; i < totalBytes; i++) {
+            flat[i] = (byte) (i & 0xff);
+        }
+
+        data = Data.init(flat, arena);
+
+        sparseIndices = new int[8192];
+        sparseValues = new int[8192];
+        for (int i = 0; i < 8192; i++) {
+            sparseIndices[i] = i * 17;
+            sparseValues[i] = i;
+        }
+        helperKey = new byte[32];
+    }
+
+    @TearDown(Level.Trial)
+    public void afterAll() {
+        arena.close();
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: [UInt8]
+
+    @Benchmark
+    public long acceptBytes_ffm() {
+        return MySwiftLibrary.benchAcceptBytes(flat);
+    }
+
+    @Benchmark
+    public byte[] returnBytes_ffm() {
+        return MySwiftLibrary.benchReturnBytes(totalBytes);
+    }
+
+    @Benchmark
+    public byte[] echoBytes_ffm() {
+        return MySwiftLibrary.benchEchoBytes(flat);
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: Data
+
+    @Benchmark
+    public long acceptData_ffm() {
+        return MySwiftLibrary.benchAcceptData(data);
+    }
+
+    @Benchmark
+    public Data returnData_ffm(Blackhole bh) {
+        Data result = MySwiftLibrary.benchReturnData(totalBytes, arena);
+        bh.consume(result.getCount());
+        return result;
+    }
+
+    @Benchmark
+    public Data echoData_ffm(Blackhole bh) {
+        Data echoed = MySwiftLibrary.benchEchoData(data, arena);
+        bh.consume(echoed.getCount());
+        return echoed;
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: sparse shard
+
+    @Benchmark
+    public byte[] sparseShard_ffm() {
+        return MySwiftLibrary.benchSparseShard(1000, 2, sparseIndices, sparseValues, helperKey);
+    }
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
@@ -23,79 +23,64 @@ import Foundation
 // ==== -----------------------------------------------------------------------
 // MARK: [UInt8] pass-through
 
-public func benchAcceptBytes(_ bytes: [UInt8]) -> Int {
+public func acceptBytes(_ bytes: [UInt8]) -> Int {
   bytes.count
 }
 
-public func benchReturnBytes(_ size: Int) -> [UInt8] {
+public func returnBytes(_ size: Int) -> [UInt8] {
   [UInt8](repeating: 0xff, count: size)
 }
 
-public func benchEchoBytes(_ bytes: [UInt8]) -> [UInt8] {
+public func echoBytes(_ bytes: [UInt8]) -> [UInt8] {
   bytes
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: [[UInt8]] pass-through
 
-public func benchAcceptNestedBytes(_ arrays: [[UInt8]]) -> Int {
+public func acceptNestedBytes(_ arrays: [[UInt8]]) -> Int {
   arrays.reduce(0) { $0 + $1.count }
 }
 
-public func benchReturnNestedBytes(_ outer: Int, _ inner: Int) -> [[UInt8]] {
+public func returnNestedBytes(_ outer: Int, _ inner: Int) -> [[UInt8]] {
   (0..<outer).map { _ in [UInt8](repeating: 0xff, count: inner) }
 }
 
-public func benchEchoNestedBytes(_ arrays: [[UInt8]]) -> [[UInt8]] {
+public func echoNestedBytes(_ arrays: [[UInt8]]) -> [[UInt8]] {
   arrays
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: UnsafeRawBufferPointer (JNI only)
 
-public func benchAcceptBuffer(_ buf: UnsafeRawBufferPointer) -> Int {
+public func acceptBuffer(_ buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }
 
-public func benchAcceptMutableBuffer(_ buf: UnsafeMutableRawBufferPointer) -> Int {
+public func acceptMutableBuffer(_ buf: UnsafeMutableRawBufferPointer) -> Int {
   buf.count
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: Data
 
-public func benchAcceptData(_ data: Data) -> Int {
+public func acceptData(_ data: Data) -> Int {
   data.count
 }
 
-public func benchReturnData(_ size: Int) -> Data {
+public func returnData(_ size: Int) -> Data {
   Data(repeating: 0xff, count: size)
 }
 
-public func benchEchoData(_ data: Data) -> Data {
-  data
-}
-
 // ==== -----------------------------------------------------------------------
-// MARK: real world examples
+// MARK: large multi-parameter function
 
-public func benchSparseShard(
-  dimension: Int32,
-  numShards: Int32,
-  indices: [Int32],
-  values: [Int32],
-  helperKey: [UInt8]
+public func largeFunction(
+  a: Int32,
+  b: [UInt8],
+  c: [Int32],
+  d: [UInt8]
 ) -> [UInt8] {
-  let outSize = Int(indices.count) * 40 + helperKey.count
+  let outSize = b.count + d.count + c.count * 4
   return [UInt8](repeating: 0xff, count: outSize)
-}
-
-public func benchDenseShard(
-  dimension: Int32,
-  numShards: Int32,
-  measurement: [UInt8],
-  helperKey: [UInt8]
-) -> [[UInt8]] {
-  let shardSize = measurement.count / Int(numShards)
-  return (0..<Int(numShards)).map { _ in [UInt8](repeating: 0xff, count: shardSize) }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/BenchByteArrays.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftJava
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// ==== -----------------------------------------------------------------------
+// MARK: [UInt8] pass-through
+
+public func benchAcceptBytes(_ bytes: [UInt8]) -> Int {
+  bytes.count
+}
+
+public func benchReturnBytes(_ size: Int) -> [UInt8] {
+  [UInt8](repeating: 0xff, count: size)
+}
+
+public func benchEchoBytes(_ bytes: [UInt8]) -> [UInt8] {
+  bytes
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: [[UInt8]] pass-through
+
+public func benchAcceptNestedBytes(_ arrays: [[UInt8]]) -> Int {
+  arrays.reduce(0) { $0 + $1.count }
+}
+
+public func benchReturnNestedBytes(_ outer: Int, _ inner: Int) -> [[UInt8]] {
+  (0..<outer).map { _ in [UInt8](repeating: 0xff, count: inner) }
+}
+
+public func benchEchoNestedBytes(_ arrays: [[UInt8]]) -> [[UInt8]] {
+  arrays
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: UnsafeRawBufferPointer (JNI only)
+
+public func benchAcceptBuffer(_ buf: UnsafeRawBufferPointer) -> Int {
+  buf.count
+}
+
+public func benchAcceptMutableBuffer(_ buf: UnsafeMutableRawBufferPointer) -> Int {
+  buf.count
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Data
+
+public func benchAcceptData(_ data: Data) -> Int {
+  data.count
+}
+
+public func benchReturnData(_ size: Int) -> Data {
+  Data(repeating: 0xff, count: size)
+}
+
+public func benchEchoData(_ data: Data) -> Data {
+  data
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: real world examples
+
+public func benchSparseShard(
+  dimension: Int32,
+  numShards: Int32,
+  indices: [Int32],
+  values: [Int32],
+  helperKey: [UInt8]
+) -> [UInt8] {
+  let outSize = Int(indices.count) * 40 + helperKey.count
+  return [UInt8](repeating: 0xff, count: outSize)
+}
+
+public func benchDenseShard(
+  dimension: Int32,
+  numShards: Int32,
+  measurement: [UInt8],
+  helperKey: [UInt8]
+) -> [[UInt8]] {
+  let shardSize = measurement.count / Int(numShards)
+  return (0..<Int(numShards)).map { _ in [UInt8](repeating: 0xff, count: shardSize) }
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/src/jmh/java/com/example/swift/JNIByteArrayBenchmark.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/jmh/java/com/example/swift/JNIByteArrayBenchmark.java
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package com.example.swift;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.swift.swiftkit.core.ClosableSwiftArena;
+import org.swift.swiftkit.core.SwiftArena;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Byte-array marshalling benchmarks (JNI mode).
+ *
+ * All benchmark methods are suffixed with _jni to sort adjacently to their
+ * _ffm counterparts in combined reports. Covers [UInt8], [[UInt8]],
+ * UnsafeRawBufferPointer, UnsafeMutableRawBufferPointer, and Data.
+ *
+ * Sizes span 4 KB .. 16 MB to expose:
+ *   - [[UInt8]] overhead (per-call FindClass, intermediate [jobject?] buffer,
+ *     per-element SetObjectArrayElement).
+ *   - Sparse vs dense patterns: flat-byte input scaling with sparsity vs
+ *     dense-array input scaling with the full payload size.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 2, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Xmx1g" })
+public class JNIByteArrayBenchmark {
+
+    @Param({"4096", "65536", "262144", "1048576", "8388608", "16777216"})
+    public int totalBytes;
+
+    // [[UInt8]] shape: outer * inner = totalBytes.
+    @Param({"2"})
+    public int outerCount;
+
+    byte[] flat;
+    byte[][] nested;
+    Data data;
+    ClosableSwiftArena arena;
+
+    // Sparse state: fixed shape, isolates the sparse-input benefit.
+    int[] sparseIndices;
+    int[] sparseValues;
+    byte[] helperKey;
+
+    @Setup(Level.Trial)
+    public void beforeAll() {
+        arena = SwiftArena.ofConfined();
+
+        flat = new byte[totalBytes];
+        for (int i = 0; i < totalBytes; i++) {
+            flat[i] = (byte) (i & 0xff);
+        }
+
+        int innerSize = totalBytes / outerCount;
+        nested = new byte[outerCount][];
+        for (int i = 0; i < outerCount; i++) {
+            nested[i] = new byte[innerSize];
+            for (int j = 0; j < innerSize; j++) {
+                nested[i][j] = (byte) ((i + j) & 0xff);
+            }
+        }
+
+        data = Data.fromByteArray(flat, arena);
+
+        sparseIndices = new int[8192];
+        sparseValues = new int[8192];
+        for (int i = 0; i < 8192; i++) {
+            sparseIndices[i] = i * 17;
+            sparseValues[i] = i;
+        }
+        helperKey = new byte[32];
+    }
+
+    @TearDown(Level.Trial)
+    public void afterAll() {
+        arena.close();
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: [UInt8]
+
+    @Benchmark
+    public long acceptBytes_jni() {
+        return MySwiftLibrary.benchAcceptBytes(flat);
+    }
+
+    @Benchmark
+    public byte[] returnBytes_jni() {
+        return MySwiftLibrary.benchReturnBytes(totalBytes);
+    }
+
+    @Benchmark
+    public byte[] echoBytes_jni() {
+        return MySwiftLibrary.benchEchoBytes(flat);
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: [[UInt8]]
+
+    @Benchmark
+    public long acceptNested_jni() {
+        return MySwiftLibrary.benchAcceptNestedBytes(nested);
+    }
+
+    @Benchmark
+    public byte[][] returnNested_jni() {
+        return MySwiftLibrary.benchReturnNestedBytes(outerCount, totalBytes / outerCount);
+    }
+
+    @Benchmark
+    public byte[][] echoNested_jni() {
+        return MySwiftLibrary.benchEchoNestedBytes(nested);
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: UnsafeRawBufferPointer (JNI only — FFM cannot express this today)
+
+    @Benchmark
+    public long acceptBuffer_jni() {
+        return MySwiftLibrary.benchAcceptBuffer(flat);
+    }
+
+    @Benchmark
+    public long acceptMutableBuffer_jni() {
+        return MySwiftLibrary.benchAcceptMutableBuffer(flat);
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: Data
+
+    @Benchmark
+    public long acceptData_jni() {
+        return MySwiftLibrary.benchAcceptData(data);
+    }
+
+    @Benchmark
+    public Data returnData_jni(Blackhole bh) {
+        Data result = MySwiftLibrary.benchReturnData(totalBytes, arena);
+        bh.consume(result.getCount());
+        return result;
+    }
+
+    @Benchmark
+    public Data echoData_jni(Blackhole bh) {
+        Data echoed = MySwiftLibrary.benchEchoData(data, arena);
+        bh.consume(echoed.getCount());
+        return echoed;
+    }
+
+    // ==== -----------------------------------------------------------------
+    // MARK: sparse vs dense shard
+
+    @Benchmark
+    public byte[] sparseShard_jni() {
+        return MySwiftLibrary.benchSparseShard(1000, 2, sparseIndices, sparseValues, helperKey);
+    }
+
+    @Benchmark
+    public byte[][] denseShard_jni() {
+        return MySwiftLibrary.benchDenseShard(1000, 2, flat, helperKey);
+    }
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/src/jmh/java/com/example/swift/JNIByteArrayBenchmark.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/jmh/java/com/example/swift/JNIByteArrayBenchmark.java
@@ -21,19 +21,6 @@ import org.swift.swiftkit.core.SwiftArena;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * Byte-array marshalling benchmarks (JNI mode).
- *
- * All benchmark methods are suffixed with _jni to sort adjacently to their
- * _ffm counterparts in combined reports. Covers [UInt8], [[UInt8]],
- * UnsafeRawBufferPointer, UnsafeMutableRawBufferPointer, and Data.
- *
- * Sizes span 4 KB .. 16 MB to expose:
- *   - [[UInt8]] overhead (per-call FindClass, intermediate [jobject?] buffer,
- *     per-element SetObjectArrayElement).
- *   - Sparse vs dense patterns: flat-byte input scaling with sparsity vs
- *     dense-array input scaling with the full payload size.
- */
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 2, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@@ -42,22 +29,24 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 1, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Xmx1g" })
 public class JNIByteArrayBenchmark {
 
-    @Param({"4096", "65536", "262144", "1048576", "8388608", "16777216"})
+    @Param({"jni"})
+    public String mode;
+
+    @Param({"4096", "65536", "16777216"})
     public int totalBytes;
 
-    // [[UInt8]] shape: outer * inner = totalBytes.
-    @Param({"2"})
-    public int outerCount;
+    public final int outerCount = 2;
 
     byte[] flat;
     byte[][] nested;
     Data data;
     ClosableSwiftArena arena;
 
-    // Sparse state: fixed shape, isolates the sparse-input benefit.
-    int[] sparseIndices;
-    int[] sparseValues;
-    byte[] helperKey;
+    // Fixtures for largeFunction(a:b:c:d:)
+    int large_a;
+    byte[] large_b;
+    int[] large_c;
+    byte[] large_d;
 
     @Setup(Level.Trial)
     public void beforeAll() {
@@ -79,13 +68,14 @@ public class JNIByteArrayBenchmark {
 
         data = Data.fromByteArray(flat, arena);
 
-        sparseIndices = new int[8192];
-        sparseValues = new int[8192];
+        large_a = 1000;
+        large_b = new byte[8192];
+        large_c = new int[8192];
         for (int i = 0; i < 8192; i++) {
-            sparseIndices[i] = i * 17;
-            sparseValues[i] = i;
+            large_b[i] = (byte) (i & 0xff);
+            large_c[i] = i;
         }
-        helperKey = new byte[32];
+        large_d = new byte[32];
     }
 
     @TearDown(Level.Trial)
@@ -98,17 +88,17 @@ public class JNIByteArrayBenchmark {
 
     @Benchmark
     public long acceptBytes_jni() {
-        return MySwiftLibrary.benchAcceptBytes(flat);
+        return MySwiftLibrary.acceptBytes(flat);
     }
 
     @Benchmark
     public byte[] returnBytes_jni() {
-        return MySwiftLibrary.benchReturnBytes(totalBytes);
+        return MySwiftLibrary.returnBytes(totalBytes);
     }
 
     @Benchmark
     public byte[] echoBytes_jni() {
-        return MySwiftLibrary.benchEchoBytes(flat);
+        return MySwiftLibrary.echoBytes(flat);
     }
 
     // ==== -----------------------------------------------------------------
@@ -116,17 +106,17 @@ public class JNIByteArrayBenchmark {
 
     @Benchmark
     public long acceptNested_jni() {
-        return MySwiftLibrary.benchAcceptNestedBytes(nested);
+        return MySwiftLibrary.acceptNestedBytes(nested);
     }
 
     @Benchmark
     public byte[][] returnNested_jni() {
-        return MySwiftLibrary.benchReturnNestedBytes(outerCount, totalBytes / outerCount);
+        return MySwiftLibrary.returnNestedBytes(outerCount, totalBytes / outerCount);
     }
 
     @Benchmark
     public byte[][] echoNested_jni() {
-        return MySwiftLibrary.benchEchoNestedBytes(nested);
+        return MySwiftLibrary.echoNestedBytes(nested);
     }
 
     // ==== -----------------------------------------------------------------
@@ -134,12 +124,12 @@ public class JNIByteArrayBenchmark {
 
     @Benchmark
     public long acceptBuffer_jni() {
-        return MySwiftLibrary.benchAcceptBuffer(flat);
+        return MySwiftLibrary.acceptBuffer(flat);
     }
 
     @Benchmark
     public long acceptMutableBuffer_jni() {
-        return MySwiftLibrary.benchAcceptMutableBuffer(flat);
+        return MySwiftLibrary.acceptMutableBuffer(flat);
     }
 
     // ==== -----------------------------------------------------------------
@@ -147,33 +137,28 @@ public class JNIByteArrayBenchmark {
 
     @Benchmark
     public long acceptData_jni() {
-        return MySwiftLibrary.benchAcceptData(data);
+        return MySwiftLibrary.acceptData(data);
     }
 
     @Benchmark
     public Data returnData_jni(Blackhole bh) {
-        Data result = MySwiftLibrary.benchReturnData(totalBytes, arena);
+        Data result = MySwiftLibrary.returnData(totalBytes, arena);
         bh.consume(result.getCount());
         return result;
     }
 
     @Benchmark
     public Data echoData_jni(Blackhole bh) {
-        Data echoed = MySwiftLibrary.benchEchoData(data, arena);
+        Data echoed = MySwiftLibrary.echoData(data, arena);
         bh.consume(echoed.getCount());
         return echoed;
     }
 
     // ==== -----------------------------------------------------------------
-    // MARK: sparse vs dense shard
+    // MARK: large multi-parameter function
 
     @Benchmark
-    public byte[] sparseShard_jni() {
-        return MySwiftLibrary.benchSparseShard(1000, 2, sparseIndices, sparseValues, helperKey);
-    }
-
-    @Benchmark
-    public byte[][] denseShard_jni() {
-        return MySwiftLibrary.benchDenseShard(1000, 2, flat, helperKey);
+    public byte[] wide_jni() {
+        return MySwiftLibrary.largeFunction(large_a, large_b, large_c, large_d);
     }
 }


### PR DESCRIPTION
On an M2 macbook, I'll run later on linux as well but this is just about rough ideas:

```

Benchmark                                      (totalBytes)  Mode  Cnt       Score       Error  Units
JNIByteArrayBenchmark.acceptBuffer_jni                 4096  avgt    3       0.314 ±     0.214  us/op
JNIByteArrayBenchmark.acceptBuffer_jni                65536  avgt    3       1.085 ±     0.112  us/op
JNIByteArrayBenchmark.acceptBuffer_jni             16777216  avgt    3     287.848 ±    73.858  us/op
JNIByteArrayBenchmark.acceptBytes_jni                  4096  avgt    3      42.275 ±   115.404  us/op
JNIByteArrayBenchmark.acceptBytes_jni                 65536  avgt    3     628.038 ±   215.706  us/op
JNIByteArrayBenchmark.acceptBytes_jni              16777216  avgt    3  159460.417 ± 60075.214  us/op
JNIByteArrayBenchmark.acceptData_jni                   4096  avgt    3       0.015 ±     0.001  us/op
JNIByteArrayBenchmark.acceptData_jni                  65536  avgt    3       0.016 ±     0.005  us/op
JNIByteArrayBenchmark.acceptData_jni               16777216  avgt    3       0.015 ±     0.001  us/op
JNIByteArrayBenchmark.acceptMutableBuffer_jni          4096  avgt    3       0.340 ±     0.042  us/op
JNIByteArrayBenchmark.acceptMutableBuffer_jni         65536  avgt    3       3.109 ±     0.312  us/op
JNIByteArrayBenchmark.acceptMutableBuffer_jni      16777216  avgt    3     616.923 ±   467.034  us/op
JNIByteArrayBenchmark.acceptNested_jni                 4096  avgt    3      41.110 ±     7.999  us/op
JNIByteArrayBenchmark.acceptNested_jni                65536  avgt    3     629.788 ±   201.350  us/op
JNIByteArrayBenchmark.acceptNested_jni             16777216  avgt    3  156828.319 ± 16632.867  us/op
JNIByteArrayBenchmark.denseShard_jni                   4096  avgt    3      43.136 ±     3.939  us/op
JNIByteArrayBenchmark.denseShard_jni                  65536  avgt    3     630.803 ±   333.042  us/op
JNIByteArrayBenchmark.denseShard_jni               16777216  avgt    3  160196.253 ± 18796.422  us/op
JNIByteArrayBenchmark.echoBytes_jni                    4096  avgt    3      40.404 ±     5.682  us/op
JNIByteArrayBenchmark.echoBytes_jni                   65536  avgt    3     635.765 ±    37.211  us/op
JNIByteArrayBenchmark.echoBytes_jni                16777216  avgt    3  162764.906 ± 42880.991  us/op
JNIByteArrayBenchmark.echoData_jni                     4096  avgt    3       0.191 ±     0.102  us/op
JNIByteArrayBenchmark.echoData_jni                    65536  avgt    3       0.303 ±     4.236  us/op
JNIByteArrayBenchmark.echoData_jni                 16777216  avgt    3       0.189 ±     0.160  us/op
JNIByteArrayBenchmark.echoNested_jni                   4096  avgt    3      42.729 ±    10.072  us/op
JNIByteArrayBenchmark.echoNested_jni                  65536  avgt    3     633.071 ±   156.590  us/op
JNIByteArrayBenchmark.echoNested_jni               16777216  avgt    3  159919.885 ± 24323.902  us/op
JNIByteArrayBenchmark.returnBytes_jni                  4096  avgt    3       0.560 ±     0.307  us/op
JNIByteArrayBenchmark.returnBytes_jni                 65536  avgt    3       2.797 ±     7.527  us/op
JNIByteArrayBenchmark.returnBytes_jni              16777216  avgt    3     631.423 ±   354.456  us/op
JNIByteArrayBenchmark.returnData_jni                   4096  avgt    3       1.019 ±     0.231  us/op
JNIByteArrayBenchmark.returnData_jni                  65536  avgt    3      10.607 ±    11.934  us/op
JNIByteArrayBenchmark.returnData_jni               16777216  avgt    3    2516.995 ±  2224.608  us/op
JNIByteArrayBenchmark.returnNested_jni                 4096  avgt    3       2.423 ±     1.649  us/op
JNIByteArrayBenchmark.returnNested_jni                65536  avgt    3       5.400 ±     7.372  us/op
JNIByteArrayBenchmark.returnNested_jni             16777216  avgt    3     604.660 ±    65.900  us/op
JNIByteArrayBenchmark.sparseShard_jni                  4096  avgt    3     728.087 ±   188.162  us/op
JNIByteArrayBenchmark.sparseShard_jni                 65536  avgt    3     738.260 ±    99.180  us/op
JNIByteArrayBenchmark.sparseShard_jni              16777216  avgt    3     728.695 ±   209.163  us/op
```