### PR TITLE
Refactor to use more strongly-typed interfaces

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -856,7 +856,7 @@ extension JNISwift2JavaGenerator {
           return TranslatedParameter(
             parameter: JavaParameter(
               name: parameterName,
-              type: .class(package: nil, name: "Optional<\(javaType)>"),
+              type: .optional(javaType),
               annotations: parameterAnnotations,
             ),
             conversion: .method(
@@ -876,7 +876,7 @@ extension JNISwift2JavaGenerator {
         return TranslatedParameter(
           parameter: JavaParameter(
             name: parameterName,
-            type: .class(package: nil, name: "Optional", typeParameters: [javaType]),
+            type: .optional(javaType),
             annotations: parameterAnnotations,
           ),
           conversion: .method(
@@ -904,46 +904,35 @@ extension JNISwift2JavaGenerator {
 
       switch swiftType {
       case .nominal(let nominalType):
-        if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
+        if let knownType = nominalType.asKnownType {
           switch knownType {
-          case .optional:
-            guard let genericArgs = nominalType.genericArguments, genericArgs.count == 1 else {
-              throw JavaTranslationError.unsupportedSwiftType(swiftType)
-            }
+          case .optional(let wrapped):
             return try translateOptionalResult(
-              wrappedType: genericArgs[0],
+              wrappedType: wrapped,
+              methodName: methodName,
               resultName: resultName,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
 
-          case .array:
-            guard let elementType = nominalType.genericArguments?.first else {
-              throw JavaTranslationError.unsupportedSwiftType(swiftType)
-            }
+          case .array(let element):
             return try translateArrayResult(
-              elementType: elementType,
+              elementType: element,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
 
-          case .dictionary:
-            guard let genericArgs = nominalType.genericArguments, genericArgs.count == 2 else {
-              throw JavaTranslationError.dictionaryRequiresKeyAndValueTypes(swiftType)
-            }
+          case .dictionary(let key, let value):
             return try translateDictionaryResult(
-              keyType: genericArgs[0],
-              valueType: genericArgs[1],
+              keyType: key,
+              valueType: value,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
 
-          case .set:
-            guard let genericArgs = nominalType.genericArguments, genericArgs.count == 1 else {
-              throw JavaTranslationError.setRequiresElementType(swiftType)
-            }
+          case .set(let element):
             return try translateSetResult(
-              elementType: genericArgs[0],
+              elementType: element,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
@@ -968,7 +957,7 @@ extension JNISwift2JavaGenerator {
             )
 
           default:
-            guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config) else {
+            guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType.kind, config: self.config) else {
               throw JavaTranslationError.unsupportedSwiftType(swiftType)
             }
 
@@ -1046,52 +1035,40 @@ extension JNISwift2JavaGenerator {
       case .nominal(let nominalType):
         let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
 
-        if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
+        if let knownType = nominalType.asKnownType {
           switch knownType {
-          case .optional:
-            guard let genericArgs = nominalType.genericArguments, genericArgs.count == 1 else {
-              throw JavaTranslationError.unsupportedSwiftType(swiftType)
-            }
+          case .optional(let wrapped):
             let wrappedType = try translateGenericTypeParameter(
-              genericArgs[0],
+              wrapped,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
-            return .class(package: "java.util", name: "Optional", typeParameters: [wrappedType])
+            return .optional(wrappedType)
 
-          case .array:
-            guard let elementType = nominalType.genericArguments?.first else {
-              throw JavaTranslationError.unsupportedSwiftType(swiftType)
-            }
+          case .array(let element):
             let elementJavaType = try translateGenericTypeParameter(
-              elementType,
+              element,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
             return .array(elementJavaType)
 
-          case .dictionary:
-            guard let genericArgs = nominalType.genericArguments, genericArgs.count == 2 else {
-              throw JavaTranslationError.dictionaryRequiresKeyAndValueTypes(swiftType)
-            }
+          case .dictionary(let key, let value):
             let keyJavaType = try translateGenericTypeParameter(
-              genericArgs[0],
+              key,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
             let valueJavaType = try translateGenericTypeParameter(
-              genericArgs[1],
+              value,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
             return .swiftDictionaryMap(keyJavaType, valueJavaType)
 
-          case .set:
-            guard let genericArgs = nominalType.genericArguments, genericArgs.count == 1 else {
-              throw JavaTranslationError.setRequiresElementType(swiftType)
-            }
+          case .set(let element):
             let elementJavaType = try translateGenericTypeParameter(
-              genericArgs[0],
+              element,
               genericParameters: genericParameters,
               genericRequirements: genericRequirements,
             )
@@ -1110,7 +1087,7 @@ extension JNISwift2JavaGenerator {
             return .javaUtilUUID
 
           default:
-            guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config) else {
+            guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType.kind, config: self.config) else {
               throw JavaTranslationError.unsupportedSwiftType(swiftType)
             }
             return javaType.boxedType
@@ -1259,6 +1236,7 @@ extension JNISwift2JavaGenerator {
 
     func translateOptionalResult(
       wrappedType swiftType: SwiftType,
+      methodName: String,
       resultName: String,
       genericParameters: [SwiftGenericParameterDeclaration],
       genericRequirements: [SwiftGenericRequirement],
@@ -1338,7 +1316,7 @@ extension JNISwift2JavaGenerator {
 
         let wrappedValueResult = try translate(
           swiftResult: SwiftResult(convention: .direct, type: swiftType),
-          methodName: "",
+          methodName: methodName,
           resultName: resultName + "Wrapped$",
           genericParameters: genericParameters,
           genericRequirements: genericRequirements,
@@ -1352,7 +1330,7 @@ extension JNISwift2JavaGenerator {
             .void
           }
 
-        let returnType = JavaType.class(package: nil, name: "Optional", typeParameters: [javaType])
+        let returnType = JavaType.optional(javaType)
         return TranslatedResult(
           javaType: returnType,
           annotations: parameterAnnotations,

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericCombinationTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericCombinationTests.swift
@@ -55,7 +55,7 @@ struct JNIGenericCombinationTests {
         detectChunkByInitialLines: 2,
         expectedChunks: [
           """
-          public static Optional<MyID<java.lang.String>> makeStringIDOptional(java.lang.String value, SwiftArena swiftArena) {
+          public static java.util.Optional<MyID<java.lang.String>> makeStringIDOptional(java.lang.String value, SwiftArena swiftArena) {
             byte[] result$_discriminator$ = new byte[1];
             org.swift.swiftkit.core._OutSwiftGenericInstance resultWrapped$ = new org.swift.swiftkit.core._OutSwiftGenericInstance();
             SwiftModule.$makeStringIDOptional(value, result$_discriminator$, resultWrapped$);
@@ -113,7 +113,7 @@ struct JNIGenericCombinationTests {
         detectChunkByInitialLines: 2,
         expectedChunks: [
           """
-          public static void takeStringIDOptional(Optional<MyID<java.lang.String>> value) {
+          public static void takeStringIDOptional(java.util.Optional<MyID<java.lang.String>> value) {
             SwiftModule.$takeStringIDOptional(value.map(MyID<java.lang.String>::$memoryAddress).orElse(0L));
           }
           """,

--- a/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
@@ -155,7 +155,7 @@ struct JNIOptionalTests {
          * public func optionalClass(_ arg: MyClass?) -> MyClass?
          * }
          */
-        public static Optional<MyClass> optionalClass(Optional<MyClass> arg, SwiftArena swiftArena) {
+        public static java.util.Optional<MyClass> optionalClass(java.util.Optional<MyClass> arg, SwiftArena swiftArena) {
           byte[] result$_discriminator$ = new byte[1];
           long result$ = SwiftModule.$optionalClass(arg.map(MyClass::$memoryAddress).orElse(0L), result$_discriminator$);
           return (result$_discriminator$[0] == 1) ? Optional.of(MyClass.wrapMemoryAddressUnsafe(result$, swiftArena)) : Optional.empty();
@@ -218,7 +218,7 @@ struct JNIOptionalTests {
          * public func optionalJavaKitClass(_ arg: JavaLong?)
          * }
          */
-        public static void optionalJavaKitClass(Optional<java.lang.Long> arg) {
+        public static void optionalJavaKitClass(java.util.Optional<java.lang.Long> arg) {
           SwiftModule.$optionalJavaKitClass(arg.orElse(null));
         }
         """,


### PR DESCRIPTION
This is a straightforward refactoring with no semantic changes.
Improving code clarity by leveraging strongly-typed interfaces.

I also updated `translateOptionalResult` to include the `methodName` parameter, as its previous omission seemed unnatural.
