### PR TITLE
jextract/jni: Add `nativeJavaType` to `TranslatedResult` for explicit type handling

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -660,7 +660,7 @@ extension JNISwift2JavaGenerator {
     }
 
     let translatedSignature = translatedDecl.translatedFunctionSignature
-    let resultType = translatedSignature.resultType.javaType
+    let resultType = translatedSignature.result.javaType
     var parameters = translatedDecl.translatedFunctionSignature.parameters.map { $0.parameter.renderParameter() }
     let throwsClause = translatedDecl.throwsClause()
 
@@ -714,7 +714,7 @@ extension JNISwift2JavaGenerator {
         let globalArenaName = "SwiftMemoryManagement.DEFAULT_SWIFT_JAVA_AUTO_ARENA"
         let arguments = translatedDecl.translatedFunctionSignature.parameters.map(\.parameter.name) + [globalArenaName]
         let call = "\(translatedDecl.name)(\(arguments.joined(separator: ", ")))"
-        if translatedDecl.translatedFunctionSignature.resultType.javaType.isVoid {
+        if translatedDecl.translatedFunctionSignature.result.javaType.isVoid {
           printer.print("\(call);")
         } else {
           printer.print("return \(call);")
@@ -792,7 +792,7 @@ extension JNISwift2JavaGenerator {
     }
 
     // Indirect return receivers
-    for outParameter in translatedFunctionSignature.resultType.outParameters {
+    for outParameter in translatedFunctionSignature.result.outParameters {
       printer.print(
         "\(outParameter.type) \(outParameter.name) = \(outParameter.allocation.render(type: outParameter.type));"
       )
@@ -807,15 +807,15 @@ extension JNISwift2JavaGenerator {
       "\(effectiveParentName.fullName).\(translatedDecl.nativeFunctionName)(\(arguments.joined(separator: ", ")))"
 
     //=== Part 4: Convert the return value.
-    if translatedFunctionSignature.resultType.javaType.isVoid {
+    if translatedFunctionSignature.result.javaType.isVoid {
       printer.print("\(downcall);")
     } else {
       let result: String
       if translatedDecl.nativeFunctionSignature.result.javaType.isVoid {
         printer.print("\(downcall);")
-        result = translatedFunctionSignature.resultType.conversion.render(&printer, "")
+        result = translatedFunctionSignature.result.conversion.render(&printer, "")
       } else {
-        result = translatedFunctionSignature.resultType.conversion.render(&printer, downcall)
+        result = translatedFunctionSignature.result.conversion.render(&printer, downcall)
       }
       printer.print("return \(result);")
     }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -117,13 +117,20 @@ extension JNISwift2JavaGenerator {
 
       let conversions = try enumCase.parameters.enumerated().map { idx, parameter in
         let resultName = parameter.name ?? "arg\(idx)"
-        let result = SwiftResult(convention: .direct, type: parameter.type)
-        var translatedResult = try self.translate(swiftResult: result, methodName: methodName, resultName: resultName)
+        var translatedResult = try self.translateResult(
+          swiftType: parameter.type,
+          methodName: methodName,
+          resultName: resultName
+        )
         translatedResult.conversion = .replacingPlaceholder(
           translatedResult.conversion,
           placeholder: "$nativeParameters.\(resultName)",
         )
-        let nativeResult = try nativeTranslation.translate(swiftResult: result, methodName: methodName, resultName: resultName)
+        let nativeResult = try nativeTranslation.translateResult(
+          swiftType: parameter.type,
+          methodName: methodName,
+          resultName: resultName
+        )
         return (translated: translatedResult, native: nativeResult)
       }
 
@@ -324,7 +331,7 @@ extension JNISwift2JavaGenerator {
         )
       }
 
-      let translatedResult = try translate(swiftResult: SwiftResult(convention: .direct, type: swiftType.resultType), methodName: name)
+      let translatedResult = try translateResult(swiftType: swiftType.resultType, methodName: name)
 
       return TranslatedFunctionType(
         name: name,
@@ -370,8 +377,8 @@ extension JNISwift2JavaGenerator {
         exceptions.append(.integerOverflow)
       }
 
-      let resultType = try translate(
-        swiftResult: functionSignature.result,
+      let resultType = try translateResult(
+        swiftType: functionSignature.result.type,
         methodName: methodName,
         genericParameters: functionSignature.genericParameters,
         genericRequirements: functionSignature.genericRequirements,
@@ -892,15 +899,13 @@ extension JNISwift2JavaGenerator {
       }
     }
 
-    func translate(
-      swiftResult: SwiftResult,
+    func translateResult(
+      swiftType: SwiftType,
       methodName: String,
       resultName: String = "result",
       genericParameters: [SwiftGenericParameterDeclaration] = [],
       genericRequirements: [SwiftGenericRequirement] = [],
     ) throws -> TranslatedResult {
-      let swiftType = swiftResult.type
-
       // If the result type should cause any annotations on the method, include them here.
       let resultAnnotations: [JavaAnnotation] = getJavaTypeAnnotations(swiftType: swiftType, config: config)
 
@@ -1158,8 +1163,8 @@ extension JNISwift2JavaGenerator {
         let outParamName = "\(resultName)_\(idx)$"
 
         // Determine the Java type for this element
-        let elementResult = try translate(
-          swiftResult: .init(convention: .indirect, type: element.type),
+        let elementResult = try translateResult(
+          swiftType: element.type,
           methodName: methodName,
           resultName: outParamName,
           genericParameters: genericParameters,
@@ -1323,8 +1328,8 @@ extension JNISwift2JavaGenerator {
           genericRequirements: genericRequirements,
         )
 
-        let wrappedValueResult = try translate(
-          swiftResult: SwiftResult(convention: .direct, type: swiftType),
+        let wrappedValueResult = try translateResult(
+          swiftType: swiftType,
           methodName: methodName,
           resultName: resultName + "Wrapped$",
           genericParameters: genericParameters,

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1173,9 +1173,9 @@ extension JNISwift2JavaGenerator {
 
         // out names are always ...$N, no need to use real named tuple names here, this is just for the thunk
         elementOutParamNames.append(outParamName)
+        outParameters.append(contentsOf: elementResult.outParameters)
 
-        // FIXME: More accurate determination of whether the result is direct or indirect
-        if elementResult.outParameters.isEmpty {
+        if !elementResult.nativeJavaType.isVoid {
           // Convert direct result to indirect result.
           // For most class types (Swift wrapper classes), the JNI native representation
           // is 'long' (a memory address). However, String is a native JNI reference
@@ -1195,7 +1195,6 @@ extension JNISwift2JavaGenerator {
           )
           elementConversions.append(elementResult.conversion)
         } else {
-          outParameters.append(contentsOf: elementResult.outParameters)
           elementConversions.append(.placeToVar(elementResult.conversion, name: "\(resultName)_\(idx)"))
         }
         elementJavaTypes.append(elementResult.javaType)
@@ -1336,18 +1335,10 @@ extension JNISwift2JavaGenerator {
           genericRequirements: genericRequirements,
         )
 
-        // FIXME: More accurate JavaType using NativeJavaTranslation results directly
-        let nativeResultJavaType: JavaType =
-          if wrappedValueResult.outParameters.isEmpty {
-            .long
-          } else {
-            .void
-          }
-
         let returnType = JavaType.optional(javaType)
         return TranslatedResult(
           javaType: returnType,
-          nativeJavaType: nativeResultJavaType,
+          nativeJavaType: wrappedValueResult.nativeJavaType,
           annotations: parameterAnnotations,
           outParameters: [
             OutParameter(name: discriminatorName, type: .array(.byte), allocation: .newArray(.byte, size: 1))
@@ -1355,7 +1346,7 @@ extension JNISwift2JavaGenerator {
           conversion: .toOptionalFromIndirectReturn(
             discriminatorName: .constant(discriminatorName),
             optionalClass: "Optional",
-            nativeResultJavaType: nativeResultJavaType,
+            nativeResultJavaType: wrappedValueResult.nativeJavaType,
             toValue: wrappedValueResult.conversion,
             resultName: resultName
           )

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -179,8 +179,9 @@ extension JNISwift2JavaGenerator {
               conversion: .typeMetadataAddress(.placeholder),
             ),
           parameters: [],
-          resultType: TranslatedResult(
+          result: TranslatedResult(
             javaType: .optional(caseType),
+            nativeJavaType: nativeParametersType,
             outParameters: conversions.flatMap(\.translated.outParameters),
             conversion: enumCase.parameters.isEmpty
               ? constructRecordConversion
@@ -380,7 +381,7 @@ extension JNISwift2JavaGenerator {
         selfParameter: selfParameter,
         selfTypeParameter: selfTypeParameter,
         parameters: parameters,
-        resultType: resultType,
+        result: resultType,
         exceptions: exceptions,
       )
     }
@@ -699,13 +700,13 @@ extension JNISwift2JavaGenerator {
       switch mode {
       case .completableFuture:
         nativeFutureType = .completableFuture(nativeFunctionSignature.result.javaType)
-        translatedFutureType = .completableFuture(translatedFunctionSignature.resultType.javaType)
+        translatedFutureType = .completableFuture(translatedFunctionSignature.result.javaType)
         completeMethodID = "_JNIMethodIDCache.CompletableFuture.complete"
         completeExceptionallyMethodID = "_JNIMethodIDCache.CompletableFuture.completeExceptionally"
 
       case .legacyFuture:
         nativeFutureType = .simpleCompletableFuture(nativeFunctionSignature.result.javaType)
-        translatedFutureType = .future(translatedFunctionSignature.resultType.javaType)
+        translatedFutureType = .future(translatedFunctionSignature.result.javaType)
         completeMethodID = "_JNIMethodIDCache.SimpleCompletableFuture.complete"
         completeExceptionallyMethodID = "_JNIMethodIDCache.SimpleCompletableFuture.completeExceptionally"
       }
@@ -716,9 +717,10 @@ extension JNISwift2JavaGenerator {
         allocation: .new,
       )
 
-      let result = translatedFunctionSignature.resultType
-      translatedFunctionSignature.resultType = TranslatedResult(
+      let result = translatedFunctionSignature.result
+      translatedFunctionSignature.result = TranslatedResult(
         javaType: translatedFutureType,
+        nativeJavaType: .void,
         annotations: result.annotations,
         outParameters: result.outParameters + [futureOutParameter],
         conversion: .method(
@@ -948,6 +950,7 @@ extension JNISwift2JavaGenerator {
           case .foundationUUID, .essentialsUUID:
             return TranslatedResult(
               javaType: .javaUtilUUID,
+              nativeJavaType: .javaLangString,
               outParameters: [],
               conversion: .method(
                 .constant("java.util.UUID"),
@@ -963,6 +966,7 @@ extension JNISwift2JavaGenerator {
 
             return TranslatedResult(
               javaType: javaType,
+              nativeJavaType: javaType,
               annotations: resultAnnotations,
               outParameters: [],
               conversion: .placeholder,
@@ -990,6 +994,7 @@ extension JNISwift2JavaGenerator {
         if nominalType.nominalTypeDecl.isGeneric {
           return TranslatedResult(
             javaType: javaType,
+            nativeJavaType: .void,
             annotations: resultAnnotations,
             outParameters: [.init(name: resultName, type: ._OutSwiftGenericInstance, allocation: .new)],
             conversion: .wrapMemoryAddressUnsafe(
@@ -1003,6 +1008,7 @@ extension JNISwift2JavaGenerator {
         } else {
           return TranslatedResult(
             javaType: javaType,
+            nativeJavaType: .long,
             annotations: resultAnnotations,
             outParameters: [],
             conversion: .wrapMemoryAddressUnsafe(.placeholder, javaType),
@@ -1010,7 +1016,7 @@ extension JNISwift2JavaGenerator {
         }
 
       case .tuple([]):
-        return TranslatedResult(javaType: .void, outParameters: [], conversion: .placeholder)
+        return TranslatedResult(javaType: .void, nativeJavaType: .void, outParameters: [], conversion: .placeholder)
 
       case .tuple(let elements) where !elements.isEmpty:
         return try translateTupleResult(
@@ -1228,6 +1234,7 @@ extension JNISwift2JavaGenerator {
 
       return TranslatedResult(
         javaType: javaResultType,
+        nativeJavaType: .void,
         annotations: tupleAnnotations,
         outParameters: outParameters,
         conversion: javaNativeConversionStep
@@ -1271,6 +1278,7 @@ extension JNISwift2JavaGenerator {
             if let nextIntergralTypeWithSpaceForByte = javaType.nextIntergralTypeWithSpaceForByte {
               return TranslatedResult(
                 javaType: .class(package: nil, name: returnType),
+                nativeJavaType: nextIntergralTypeWithSpaceForByte.javaType,
                 annotations: parameterAnnotations,
                 outParameters: [],
                 conversion: .combinedValueToOptional(
@@ -1287,6 +1295,7 @@ extension JNISwift2JavaGenerator {
               // use an indirect return for the discriminator.
               return TranslatedResult(
                 javaType: .class(package: nil, name: returnType),
+                nativeJavaType: javaType,
                 annotations: parameterAnnotations,
                 outParameters: [
                   OutParameter(name: discriminatorName, type: .array(.byte), allocation: .newArray(.byte, size: 1))
@@ -1333,6 +1342,7 @@ extension JNISwift2JavaGenerator {
         let returnType = JavaType.optional(javaType)
         return TranslatedResult(
           javaType: returnType,
+          nativeJavaType: nativeResultJavaType,
           annotations: parameterAnnotations,
           outParameters: [
             OutParameter(name: discriminatorName, type: .array(.byte), allocation: .newArray(.byte, size: 1))
@@ -1449,6 +1459,7 @@ extension JNISwift2JavaGenerator {
         )
         return TranslatedResult(
           javaType: .array(innerResult.javaType),
+          nativeJavaType: .array(innerResult.javaType),
           annotations: annotations,
           outParameters: [],
           conversion: .placeholder
@@ -1462,6 +1473,7 @@ extension JNISwift2JavaGenerator {
 
           return TranslatedResult(
             javaType: .array(javaType),
+            nativeJavaType: .array(javaType),
             annotations: annotations,
             outParameters: [],
             conversion: .placeholder,
@@ -1480,6 +1492,7 @@ extension JNISwift2JavaGenerator {
         // We assume this is a JExtract class.
         return TranslatedResult(
           javaType: .array(javaType),
+          nativeJavaType: .array(.long),
           annotations: annotations,
           outParameters: [],
           conversion: .method(
@@ -1564,6 +1577,7 @@ extension JNISwift2JavaGenerator {
 
       return TranslatedResult(
         javaType: dictType,
+        nativeJavaType: .long,
         outParameters: [],
         conversion: .wrapMemoryAddressUnsafe(.placeholder, dictType),
       )
@@ -1606,6 +1620,7 @@ extension JNISwift2JavaGenerator {
 
       return TranslatedResult(
         javaType: setType,
+        nativeJavaType: .long,
         outParameters: [],
         conversion: .wrapMemoryAddressUnsafe(.placeholder, setType),
       )
@@ -1682,17 +1697,17 @@ extension JNISwift2JavaGenerator {
     var selfParameter: TranslatedParameter?
     var selfTypeParameter: TranslatedParameter?
     var parameters: [TranslatedParameter]
-    var resultType: TranslatedResult
+    var result: TranslatedResult
     var exceptions: [JavaExceptionType]
 
     // if the result type implied any annotations,
     // propagate them onto the function the result is returned from
     var annotations: [JavaAnnotation] {
-      self.resultType.annotations
+      self.result.annotations
     }
 
     var requiresSwiftArena: Bool {
-      self.resultType.conversion.requiresSwiftArena
+      self.result.conversion.requiresSwiftArena
     }
   }
 
@@ -1704,12 +1719,15 @@ extension JNISwift2JavaGenerator {
 
   /// Represent a Swift API result translated to Java.
   struct TranslatedResult {
-    let javaType: JavaType
+    var javaType: JavaType
+
+    /// result type of native function
+    var nativeJavaType: JavaType
 
     /// Java annotations that should be propagated from the result type onto the method
     var annotations: [JavaAnnotation] = []
 
-    let outParameters: [OutParameter]
+    var outParameters: [OutParameter]
 
     /// Represents how to convert the Java native result into a user-facing result.
     var conversion: JavaNativeConversionStep

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1765,10 +1765,6 @@ extension JNISwift2JavaGenerator {
     let name: String
     let type: JavaType
     let allocation: Allocation
-
-    var javaParameter: JavaParameter {
-      JavaParameter(name: self.name, type: self.type)
-    }
   }
 
   /// Represent a Swift closure type in the user facing Java API.

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -80,6 +80,8 @@ extension JNISwift2JavaGenerator {
         }
 
       let result = try translate(swiftResult: functionSignature.result, methodName: methodName)
+      assert(translatedFunctionSignature.result.nativeJavaType == result.javaType)
+      assert(translatedFunctionSignature.result.outParameters.map(\.javaParameter.type) == result.outParameters.map(\.type))
 
       return NativeFunctionSignature(
         selfParameter: nativeSelf,

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -79,9 +79,9 @@ extension JNISwift2JavaGenerator {
           nil
         }
 
-      let result = try translate(swiftResult: functionSignature.result, methodName: methodName)
-      assert(translatedFunctionSignature.result.nativeJavaType == result.javaType)
-      assert(translatedFunctionSignature.result.outParameters.map(\.javaParameter.type) == result.outParameters.map(\.type))
+      let result = try translateResult(swiftType: functionSignature.result.type, methodName: methodName)
+      assert(translatedFunctionSignature.result.nativeJavaType == result.javaType, "Not synchronized with JavaTranslation")
+      assert(translatedFunctionSignature.result.outParameters.map(\.javaParameter.type) == result.outParameters.map(\.type), "Not synchronized with JavaTranslation")
 
       return NativeFunctionSignature(
         selfParameter: nativeSelf,
@@ -591,11 +591,8 @@ extension JNISwift2JavaGenerator {
           throw JavaTranslationError.unsupportedSwiftType(swiftType)
         }
 
-        let wrappedValueResult = try translate(
-          swiftResult: .init(
-            convention: .direct,
-            type: swiftType
-          ),
+        let wrappedValueResult = try translateResult(
+          swiftType: swiftType,
           methodName: methodName,
           resultName: resultName + "Wrapped"
         )
@@ -695,12 +692,12 @@ extension JNISwift2JavaGenerator {
       }
     }
 
-    func translate(
-      swiftResult: SwiftResult,
+    func translateResult(
+      swiftType: SwiftType,
       methodName: String,
       resultName: String = "result"
     ) throws -> NativeResult {
-      switch swiftResult.type {
+      switch swiftType {
       case .nominal(let nominalType):
         if let knownType = nominalType.asKnownType {
           switch knownType {
@@ -738,7 +735,7 @@ extension JNISwift2JavaGenerator {
             guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType.kind, config: self.config),
               javaType.implementsJavaValue
             else {
-              throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
+              throw JavaTranslationError.unsupportedSwiftType(swiftType)
             }
 
             if let indirectReturnType = JNIJavaTypeTranslator.indirectConversionStepSwiftType(
@@ -761,15 +758,15 @@ extension JNISwift2JavaGenerator {
         }
 
         if nominalType.isSwiftJavaWrapper {
-          throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
+          throw JavaTranslationError.unsupportedSwiftType(swiftType)
         }
 
         if nominalType.nominalTypeDecl.isGeneric {
           return NativeResult(
             javaType: .void,
             conversion: .genericValueIndirectReturn(
-              .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: swiftResult.type)),
-              swiftFunctionResultType: swiftResult.type,
+              .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: swiftType)),
+              swiftFunctionResultType: swiftType,
               outArgumentName: resultName + "Out"
             ),
             outParameters: [.init(name: resultName + "Out", type: ._OutSwiftGenericInstance)]
@@ -777,7 +774,7 @@ extension JNISwift2JavaGenerator {
         } else {
           return NativeResult(
             javaType: .long,
-            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: swiftResult.type)),
+            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: swiftType)),
             outParameters: []
           )
         }
@@ -793,7 +790,7 @@ extension JNISwift2JavaGenerator {
         return try translateTupleResult(methodName: methodName, elements: elements, resultName: resultName)
 
       case .metatype, .tuple, .function, .existential, .opaque, .genericParameter, .composite:
-        throw JavaTranslationError.unsupportedSwiftType(swiftResult.type)
+        throw JavaTranslationError.unsupportedSwiftType(swiftType)
       }
     }
 
@@ -809,8 +806,8 @@ extension JNISwift2JavaGenerator {
         let outParamName = "\(resultName)_\(idx)$"
 
         // Get the JNI type for this element
-        let elementResult = try translate(
-          swiftResult: .init(convention: .indirect, type: element.type),
+        let elementResult = try translateResult(
+          swiftType: element.type,
           methodName: methodName,
           resultName: outParamName
         )

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -812,14 +812,12 @@ extension JNISwift2JavaGenerator {
           resultName: outParamName
         )
 
-        // FIXME: More accurate determination of whether the result is direct or indirect
-        if elementResult.outParameters.isEmpty {
+        outParameters.append(contentsOf: elementResult.outParameters)
+        if !elementResult.javaType.isVoid {
           // Convert direct result to indirect result
           outParameters.append(
             JavaParameter(name: outParamName, type: .array(elementResult.javaType))
           )
-        } else {
-          outParameters.append(contentsOf: elementResult.outParameters)
         }
 
         destructureElements.append(

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -81,7 +81,7 @@ extension JNISwift2JavaGenerator {
 
       let result = try translateResult(swiftType: functionSignature.result.type, methodName: methodName)
       assert(translatedFunctionSignature.result.nativeJavaType == result.javaType, "Not synchronized with JavaTranslation")
-      assert(translatedFunctionSignature.result.outParameters.map(\.javaParameter.type) == result.outParameters.map(\.type), "Not synchronized with JavaTranslation")
+      assert(translatedFunctionSignature.result.outParameters.map(\.type) == result.outParameters.map(\.type.javaType), "Not synchronized with JavaTranslation")
 
       return NativeFunctionSignature(
         selfParameter: nativeSelf,

--- a/Sources/JExtractSwiftLib/JNI/TranslatedFunctionDecl+NamedTuples.swift
+++ b/Sources/JExtractSwiftLib/JNI/TranslatedFunctionDecl+NamedTuples.swift
@@ -19,7 +19,7 @@ extension JNISwift2JavaGenerator.TranslatedFunctionDecl {
   /// Returns any used labeled tuple types that this function uses
   var usedLabeledTuples: [JavaType] {
     var result: [JavaType] = []
-    collectLabeledTuples(from: translatedFunctionSignature.resultType.javaType, into: &result)
+    collectLabeledTuples(from: translatedFunctionSignature.result.javaType, into: &result)
     for param in translatedFunctionSignature.parameters {
       collectLabeledTuples(from: param.parameter.type.javaType, into: &result)
     }

--- a/Sources/JExtractSwiftLib/JavaParameter.swift
+++ b/Sources/JExtractSwiftLib/JavaParameter.swift
@@ -16,7 +16,7 @@ import SwiftJavaJNICore
 
 /// Represent a parameter in Java code.
 struct JavaParameter {
-  enum ParameterType: CustomStringConvertible {
+  enum ParameterType: Equatable, CustomStringConvertible {
     case concrete(JavaType)
     case generic(name: String, extends: [JavaType])
 


### PR DESCRIPTION
This PR is a refactoring effort to address the architectural concerns proposed in #720.

Previously, the return types of native functions were handled implicitly within `JavaTranslation`.
This PR changes that to an explicit exchange using the newly added `nativeJavaType` in `TranslatedResult`.

This change resolves existing `// FIXME:` comments in the tuple generation logic.

To ensure that `JavaTranslation` and `NativeJavaTranslation` generate identical signatures for native functions, I have added an assertion to validate the correctness of `nativeJavaType`.