### PR TITLE
jextract/jni: Fix code generation for optional `String` in tuples

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Tuples.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Tuples.swift
@@ -28,6 +28,10 @@ public func echoTriple(triple: (Bool, Double, Int64)) -> (Bool, Double, Int64) {
   triple
 }
 
+public func echoOptionalTriple(triple: (Int64?, String?, Alignment?)) -> (Int64?, String?, Alignment?) {
+  triple
+}
+
 public func makeBigTuple() -> (
   Bool, Int8, Int16, UInt16,
   Int32, Int64, Float, Double,

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/TupleTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/TupleTest.java
@@ -22,6 +22,9 @@ import org.swift.swiftkit.core.tuple.Tuple16;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Optional;
+import java.util.OptionalLong;
+
 public class TupleTest {
     @Test
     void returnPair() {
@@ -63,6 +66,32 @@ public class TupleTest {
     }
 
     @Test
+    void echoOptionalTriple() {
+        try (var arena = SwiftArena.ofConfined()) {
+            Tuple3<OptionalLong, Optional<String>, Optional<Alignment>> input = new Tuple3<>(
+                    OptionalLong.of(100L),
+                    Optional.of("hello"),
+                    Optional.of(Alignment.horizontal(arena))
+            );
+            Tuple3<OptionalLong, Optional<String>, Optional<Alignment>> result = MySwiftLibrary.echoOptionalTriple(input, arena);
+            assertEquals(input.$0, result.$0);
+            assertEquals(input.$1, result.$1);
+            assertEquals(input.$2.map(Alignment::getDiscriminator), result.$2.map(Alignment::getDiscriminator));
+        }
+        try (var arena = SwiftArena.ofConfined()) {
+            Tuple3<OptionalLong, Optional<String>, Optional<Alignment>> input = new Tuple3<>(
+                    OptionalLong.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+            );
+            Tuple3<OptionalLong, Optional<String>, Optional<Alignment>> result = MySwiftLibrary.echoOptionalTriple(input, arena);
+            assertEquals(input.$0, result.$0);
+            assertEquals(input.$1, result.$1);
+            assertEquals(input.$2.map(Alignment::getDiscriminator), result.$2.map(Alignment::getDiscriminator));
+        }
+    }
+
+    @Test
     void makeBigTuple() {
         Tuple16<Boolean, Byte, Short, Character,
                 Integer, Long, Float, Double,
@@ -90,11 +119,11 @@ public class TupleTest {
     void namedByteArrayTuple() {
         var result = MySwiftLibrary.namedByteArrayTuple();
 
-        assertArrayEquals(new byte[] { 1, 2, 3 }, result.name());
-        assertArrayEquals(new byte[] { 4, 5 }, result.another());
+        assertArrayEquals(new byte[]{1, 2, 3}, result.name());
+        assertArrayEquals(new byte[]{4, 5}, result.another());
 
-        assertArrayEquals(new byte[] { 1, 2, 3 }, (byte[]) result.$0);
-        assertArrayEquals(new byte[] { 4, 5 }, (byte[]) result.$1);
+        assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) result.$0);
+        assertArrayEquals(new byte[]{4, 5}, (byte[]) result.$1);
     }
 
     @Test

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1193,22 +1193,9 @@ extension JNISwift2JavaGenerator {
         outParameters.append(contentsOf: elementResult.outParameters)
 
         if !elementResult.nativeJavaType.isVoid {
-          // Convert direct result to indirect result.
-          // For most class types (Swift wrapper classes), the JNI native representation
-          // is 'long' (a memory address). However, String is a native JNI reference
-          // type and must keep its original type so the out-parameter array matches
-          // the native method signature (String[] not long[])
-          let nativeElementType: JavaType
-          if elementResult.javaType.isString {
-            nativeElementType = elementResult.javaType
-          } else if case .class = elementResult.javaType {
-            nativeElementType = .long
-          } else {
-            nativeElementType = elementResult.javaType
-          }
-          let arrayType: JavaType = .array(nativeElementType)
+          let arrayType: JavaType = .array(elementResult.nativeJavaType)
           outParameters.append(
-            OutParameter(name: outParamName, type: arrayType, allocation: .newArray(nativeElementType, size: 1))
+            OutParameter(name: outParamName, type: arrayType, allocation: .newArray(elementResult.nativeJavaType, size: 1))
           )
           elementConversions.append(elementResult.conversion)
         } else {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -80,8 +80,14 @@ extension JNISwift2JavaGenerator {
         }
 
       let result = try translateResult(swiftType: functionSignature.result.type, methodName: methodName)
-      assert(translatedFunctionSignature.result.nativeJavaType == result.javaType, "Not synchronized with JavaTranslation")
-      assert(translatedFunctionSignature.result.outParameters.map(\.type) == result.outParameters.map(\.type.javaType), "Not synchronized with JavaTranslation")
+      assert(
+        translatedFunctionSignature.result.nativeJavaType == result.javaType,
+        "Not synchronized with JavaTranslation, \(translatedFunctionSignature.result.nativeJavaType) != \(result.javaType), name=\(methodName)"
+      )
+      assert(
+        translatedFunctionSignature.result.outParameters.map(\.type) == result.outParameters.map(\.type.javaType),
+        "Not synchronized with JavaTranslation, \(translatedFunctionSignature.result.outParameters.map(\.type)) != \(result.outParameters.map(\.type.javaType)), name=\(methodName)"
+      )
 
       return NativeFunctionSignature(
         selfParameter: nativeSelf,


### PR DESCRIPTION
Previously, there was a special handling logic for `String` within tuples, but this logic was not applied to `String?`, leading to incorrect output.

By leveraging the `nativeJavaType` introduced in #722, I was able to remove this special-case logic entirely. 