### PR TITLE
jextract: Fix access level check for `MinimumInputAccessLevelMode.package`

### DIFF
--- a/Sources/JExtractSwiftLib/Convenience/SwiftSyntax+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/SwiftSyntax+Extensions.swift
@@ -106,12 +106,8 @@ extension WithModifiersSyntax {
   }
 
   var isAtLeastPackage: Bool {
-    if self.modifiers.isEmpty {
-      return false
-    }
-
-    return self.modifiers.contains { modifier in
-      modifier.isAtLeastInternal
+    self.modifiers.contains { modifier in
+      modifier.isAtLeastPackage
     }
   }
 

--- a/Sources/JExtractSwiftLib/Convenience/SwiftSyntax+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/SwiftSyntax+Extensions.swift
@@ -96,7 +96,7 @@ extension DeclModifierSyntax {
 
 extension WithModifiersSyntax {
   func isPublic(in type: NominalTypeDeclSyntaxNode?) -> Bool {
-    if let type, case .protocolDecl(let protocolDecl) = Syntax(type).as(SyntaxEnum.self) {
+    if let protocolDecl = type?.as(ProtocolDeclSyntax.self) {
       return protocolDecl.isPublic(in: nil)
     }
 

--- a/Tests/JExtractSwiftTests/InternalExtractTests.swift
+++ b/Tests/JExtractSwiftTests/InternalExtractTests.swift
@@ -18,21 +18,23 @@ import Testing
 
 @Suite
 final class InternalExtractTests {
-  let text =
-    """
-    internal func catchMeIfYouCan()
-    """
-
   @Test("Import: internal decl if configured")
-  func data_swiftThunk() throws {
+  func internalScope() throws {
     var config = Configuration()
     config.minimumInputAccessLevelMode = .internal
+
+    let text =
+      """
+      internal func catchMeIfYouCan()
+      func catchMeIfYouCan2()
+      """
 
     try assertOutput(
       input: text,
       config: config,
       .ffm,
       .java,
+      detectChunkByInitialLines: 2,
       expectedChunks: [
         """
         /**
@@ -44,7 +46,54 @@ final class InternalExtractTests {
         public static void catchMeIfYouCan() {
           swiftjava_SwiftModule_catchMeIfYouCan.call();
         }
+        """,
         """
+        public static void catchMeIfYouCan2() {
+          swiftjava_SwiftModule_catchMeIfYouCan2.call();
+        }
+        """,
+      ]
+    )
+  }
+
+  @Test("Import: package decl if configured")
+  func packageScope() throws {
+    var config = Configuration()
+    config.minimumInputAccessLevelMode = .package
+
+    let text =
+      """
+      package func catchMeIfYouCan()
+      func skipMe()
+      internal func skipMe2()
+      """
+
+    try assertOutput(
+      input: text,
+      config: config,
+      .ffm,
+      .java,
+      detectChunkByInitialLines: 2,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * package func catchMeIfYouCan()
+         * }
+         */
+        public static void catchMeIfYouCan() {
+          swiftjava_SwiftModule_catchMeIfYouCan.call();
+        }
+        """
+      ],
+      notExpectedChunks: [
+        """
+        public static void skipMe() {
+        """,
+        """
+        public static void skipMe2() {
+        """,
       ]
     )
   }


### PR DESCRIPTION
This PR fixes a bug where `internal` functions were incorrectly included when `MinimumInputAccessLevelMode` was set to `package`.

The issue was a simple oversight in the logic, which has been corrected in this lightweight update.