### PR TITLE
jextract/jni: Use boolean instead of byte for Optional discriminator

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -850,7 +850,7 @@ extension JNISwift2JavaGenerator {
                 annotations: parameterAnnotations,
               ),
               conversion: .commaSeparated([
-                .isOptionalPresent,
+                .method(.placeholder, function: "isPresent", arguments: []),
                 .method(.placeholder, function: "orElse", arguments: [.constant(placeholderValue)]),
               ]),
             )
@@ -1295,7 +1295,7 @@ extension JNISwift2JavaGenerator {
                 nativeJavaType: javaType,
                 annotations: parameterAnnotations,
                 outParameters: [
-                  OutParameter(name: discriminatorName, type: .array(.byte), allocation: .newArray(.byte, size: 1))
+                  OutParameter(name: discriminatorName, type: .array(.boolean), allocation: .newArray(.boolean, size: 1))
                 ],
                 conversion: .toOptionalFromIndirectReturn(
                   discriminatorName: .constant(discriminatorName),
@@ -1341,7 +1341,7 @@ extension JNISwift2JavaGenerator {
         nativeJavaType: wrappedValueResult.nativeJavaType,
         annotations: parameterAnnotations,
         outParameters: [
-          OutParameter(name: discriminatorName, type: .array(.byte), allocation: .newArray(.byte, size: 1))
+          OutParameter(name: discriminatorName, type: .array(.boolean), allocation: .newArray(.boolean, size: 1))
         ] + wrappedValueResult.outParameters,
         conversion: .toOptionalFromIndirectReturn(
           discriminatorName: .constant(discriminatorName),
@@ -1798,8 +1798,6 @@ extension JNISwift2JavaGenerator {
 
     indirect case member(JavaNativeConversionStep, field: String)
 
-    case isOptionalPresent
-
     indirect case combinedValueToOptional(
       JavaNativeConversionStep,
       JavaType,
@@ -1830,10 +1828,7 @@ extension JNISwift2JavaGenerator {
         variable: nativeResultJavaType.isVoid ? nil : (name: "\(resultName)$", type: nativeResultJavaType),
         [
           .ternary(
-            .equals(
-              .subscriptOf(discriminatorName, arguments: [.constant("0")]),
-              .constant("1"),
-            ),
+            .subscriptOf(discriminatorName, arguments: [.constant("0")]),
             thenExp: .method(.constant(optionalClass), function: "of", arguments: [valueConversion]),
             elseExp: .method(.constant(optionalClass), function: "empty"),
           )
@@ -1920,9 +1915,6 @@ extension JNISwift2JavaGenerator {
       case .call(let inner, let function):
         let inner = inner.render(&printer, placeholder)
         return "\(function)(\(inner))"
-
-      case .isOptionalPresent:
-        return "(byte) (\(placeholder).isPresent() ? 1 : 0)"
 
       case .method(let inner, let methodName, let arguments):
         let inner = inner.render(&printer, placeholder)
@@ -2045,7 +2037,7 @@ extension JNISwift2JavaGenerator {
     /// Whether the conversion uses SwiftArena.
     var requiresSwiftArena: Bool {
       switch self {
-      case .placeholder, .constant, .isOptionalPresent, .combinedName:
+      case .placeholder, .constant, .combinedName:
         return false
 
       case .constructSwiftValue, .wrapMemoryAddressUnsafe:

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -477,7 +477,7 @@ extension JNISwift2JavaGenerator {
 
             return NativeParameter(
               parameters: [
-                JavaParameter(name: discriminatorName, type: .byte),
+                JavaParameter(name: discriminatorName, type: .boolean),
                 JavaParameter(name: valueName, type: javaType),
               ],
               conversion: .optionalLowering(
@@ -568,7 +568,7 @@ extension JNISwift2JavaGenerator {
                   discriminatorParameterName: discriminatorName
                 ),
                 outParameters: [
-                  JavaParameter(name: discriminatorName, type: .array(.byte))
+                  JavaParameter(name: discriminatorName, type: .array(.boolean))
                 ]
               )
             }
@@ -602,7 +602,7 @@ extension JNISwift2JavaGenerator {
           discriminatorParameterName: discriminatorName
         ),
         outParameters: [
-          JavaParameter(name: discriminatorName, type: .array(.byte))
+          JavaParameter(name: discriminatorName, type: .array(.boolean))
         ] + wrappedValueResult.outParameters
       )
     }
@@ -1494,7 +1494,7 @@ extension JNISwift2JavaGenerator {
 
       case .optionalLowering(let valueConversion, let discriminatorName, let valueName):
         let value = valueConversion.render(&printer, valueName)
-        return "\(discriminatorName) == 1 ? \(value) : nil"
+        return "\(discriminatorName) == jboolean(JNI_TRUE) ? \(value) : nil"
 
       case .optionalChain(let inner):
         let inner = inner.render(&printer, placeholder)
@@ -1535,8 +1535,8 @@ extension JNISwift2JavaGenerator {
           }
           printer.print(
             """
-            var flag$ = Int8(1)
-            environment.interface.SetByteArrayRegion(environment, \(discriminatorParameterName), 0, 1, &flag$)
+            var flag$ = jboolean(JNI_TRUE)
+            environment.interface.SetBooleanArrayRegion(environment, \(discriminatorParameterName), 0, 1, &flag$)
             """
           )
         }
@@ -1546,8 +1546,8 @@ extension JNISwift2JavaGenerator {
           }
           printer.print(
             """
-            var flag$ = Int8(0)
-            environment.interface.SetByteArrayRegion(environment, \(discriminatorParameterName), 0, 1, &flag$)
+            var flag$ = jboolean(JNI_FALSE)
+            environment.interface.SetBooleanArrayRegion(environment, \(discriminatorParameterName), 0, 1, &flag$)
             """
           )
         }

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericCombinationTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericCombinationTests.swift
@@ -56,14 +56,14 @@ struct JNIGenericCombinationTests {
         expectedChunks: [
           """
           public static java.util.Optional<MyID<java.lang.String>> makeStringIDOptional(java.lang.String value, SwiftArena swiftArena) {
-            byte[] result$_discriminator$ = new byte[1];
+            boolean[] result$_discriminator$ = new boolean[1];
             org.swift.swiftkit.core._OutSwiftGenericInstance resultWrapped$ = new org.swift.swiftkit.core._OutSwiftGenericInstance();
             SwiftModule.$makeStringIDOptional(value, result$_discriminator$, resultWrapped$);
-            return (result$_discriminator$[0] == 1) ? Optional.of(MyID.<java.lang.String>wrapMemoryAddressUnsafe(resultWrapped$.selfPointer, resultWrapped$.selfTypePointer, swiftArena)) : Optional.empty();
+            return (result$_discriminator$[0]) ? Optional.of(MyID.<java.lang.String>wrapMemoryAddressUnsafe(resultWrapped$.selfPointer, resultWrapped$.selfTypePointer, swiftArena)) : Optional.empty();
           }
           """,
           """
-          private static native void $makeStringIDOptional(java.lang.String value, byte[] result_discriminator$, org.swift.swiftkit.core._OutSwiftGenericInstance resultWrappedOut);
+          private static native void $makeStringIDOptional(java.lang.String value, boolean[] result_discriminator$, org.swift.swiftkit.core._OutSwiftGenericInstance resultWrappedOut);
           """,
         ]
       )
@@ -78,8 +78,8 @@ struct JNIGenericCombinationTests {
         detectChunkByInitialLines: 2,
         expectedChunks: [
           """
-          @_cdecl("Java_com_example_swift_SwiftModule__00024makeStringIDOptional__Ljava_lang_String_2_3BLorg_swift_swiftkit_core__1OutSwiftGenericInstance_2")
-          public func Java_com_example_swift_SwiftModule__00024makeStringIDOptional__Ljava_lang_String_2_3BLorg_swift_swiftkit_core__1OutSwiftGenericInstance_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, value: jstring?, result_discriminator$: jbyteArray?, resultWrappedOut: jobject?) {
+          @_cdecl("Java_com_example_swift_SwiftModule__00024makeStringIDOptional__Ljava_lang_String_2_3ZLorg_swift_swiftkit_core__1OutSwiftGenericInstance_2")
+          public func Java_com_example_swift_SwiftModule__00024makeStringIDOptional__Ljava_lang_String_2_3ZLorg_swift_swiftkit_core__1OutSwiftGenericInstance_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, value: jstring?, result_discriminator$: jbooleanArray?, resultWrappedOut: jobject?) {
             if let innerResult$ = SwiftModule.makeStringIDOptional(String(fromJNI: value, in: environment)) {
               let resultWrapped$ = UnsafeMutablePointer<MyID<String>>.allocate(capacity: 1)
               resultWrapped$.initialize(to: innerResult$)
@@ -90,12 +90,12 @@ struct JNIGenericCombinationTests {
                let metadataPointerBits$ = Int64(Int(bitPattern: metadataPointer))
                environment.interface.SetLongField(environment, resultWrappedOut, _JNIMethodIDCache._OutSwiftGenericInstance.selfTypePointer, metadataPointerBits$.getJNIValue(in: environment))
               }
-              var flag$ = Int8(1)
-              environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
+              var flag$ = jboolean(JNI_TRUE)
+              environment.interface.SetBooleanArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
             } 
             else {
-              var flag$ = Int8(0)
-              environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
+              var flag$ = jboolean(JNI_FALSE)
+              environment.interface.SetBooleanArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
             }
             return 
           }

--- a/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIOptionalTests.swift
@@ -47,14 +47,14 @@ struct JNIOptionalTests {
          * }
          */
         public static OptionalInt optionalSugar(OptionalLong arg) {
-          long result_combined$ = SwiftModule.$optionalSugar((byte) (arg.isPresent() ? 1 : 0), arg.orElse(0L));
+          long result_combined$ = SwiftModule.$optionalSugar(arg.isPresent(), arg.orElse(0L));
           byte result_discriminator$ = (byte) (result_combined$ & 0xFF);
           int result_value$ = (int) (result_combined$ >> 32);
           return result_discriminator$ == 1 ? OptionalInt.of(result_value$) : OptionalInt.empty();
         }
         """,
         """
-        private static native long $optionalSugar(byte arg_discriminator, long arg_value);
+        private static native long $optionalSugar(boolean arg_discriminator, long arg_value);
         """,
       ]
     )
@@ -66,13 +66,13 @@ struct JNIOptionalTests {
       input: source,
       .jni,
       .swift,
-      detectChunkByInitialLines: 1,
+      detectChunkByInitialLines: 2,
       javaClassLookupTable: classLookupTable,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024optionalSugar__BJ")
-        public func Java_com_example_swift_SwiftModule__00024optionalSugar__BJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg_discriminator: jbyte, arg_value: jlong) -> jlong {
-          let result_value$ = SwiftModule.optionalSugar(arg_discriminator == 1 ? Int64(fromJNI: arg_value, in: environment) : nil).map {
+        @_cdecl("Java_com_example_swift_SwiftModule__00024optionalSugar__ZJ")
+        public func Java_com_example_swift_SwiftModule__00024optionalSugar__ZJ(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg_discriminator: jboolean, arg_value: jlong) -> jlong {
+          let result_value$ = SwiftModule.optionalSugar(arg_discriminator == jboolean(JNI_TRUE) ? Int64(fromJNI: arg_value, in: environment) : nil).map {
             Int64($0) << 32 | Int64(1)
           } ?? 0
           return result_value$.getJNILocalRefValue(in: environment)
@@ -98,13 +98,13 @@ struct JNIOptionalTests {
          * }
          */
         public static Optional<String> optionalExplicit(Optional<String> arg) {
-          byte[] result$_discriminator$ = new byte[1];
-          java.lang.String result$ = SwiftModule.$optionalExplicit((byte) (arg.isPresent() ? 1 : 0), arg.orElse(null), result$_discriminator$);
-          return (result$_discriminator$[0] == 1) ? Optional.of(result$) : Optional.empty();
+          boolean[] result$_discriminator$ = new boolean[1];
+          java.lang.String result$ = SwiftModule.$optionalExplicit(arg.isPresent(), arg.orElse(null), result$_discriminator$);
+          return (result$_discriminator$[0]) ? Optional.of(result$) : Optional.empty();
         }
         """,
         """
-        private static native java.lang.String $optionalExplicit(byte arg_discriminator, java.lang.String arg_value, byte[] result_discriminator$);
+        private static native java.lang.String $optionalExplicit(boolean arg_discriminator, java.lang.String arg_value, boolean[] result_discriminator$);
         """,
       ]
     )
@@ -120,18 +120,18 @@ struct JNIOptionalTests {
       javaClassLookupTable: classLookupTable,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024optionalExplicit__BLjava_lang_String_2_3B")
-        public func Java_com_example_swift_SwiftModule__00024optionalExplicit__BLjava_lang_String_2_3B(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg_discriminator: jbyte, arg_value: jstring?, result_discriminator$: jbyteArray?) -> jstring? {
+        @_cdecl("Java_com_example_swift_SwiftModule__00024optionalExplicit__ZLjava_lang_String_2_3Z")
+        public func Java_com_example_swift_SwiftModule__00024optionalExplicit__ZLjava_lang_String_2_3Z(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg_discriminator: jboolean, arg_value: jstring?, result_discriminator$: jbooleanArray?) -> jstring? {
           let result$: jstring?
-          if let innerResult$ = SwiftModule.optionalExplicit(arg_discriminator == 1 ? String(fromJNI: arg_value, in: environment) : nil) {
+          if let innerResult$ = SwiftModule.optionalExplicit(arg_discriminator == jboolean(JNI_TRUE) ? String(fromJNI: arg_value, in: environment) : nil) {
             result$ = innerResult$.getJNIValue(in: environment)
-            var flag$ = Int8(1)
-            environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
+            var flag$ = jboolean(JNI_TRUE)
+            environment.interface.SetBooleanArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
           }
           else {
             result$ = nil
-            var flag$ = Int8(0)
-            environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
+            var flag$ = jboolean(JNI_FALSE)
+            environment.interface.SetBooleanArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
           }
           return result$
         }
@@ -156,13 +156,13 @@ struct JNIOptionalTests {
          * }
          */
         public static java.util.Optional<MyClass> optionalClass(java.util.Optional<MyClass> arg, SwiftArena swiftArena) {
-          byte[] result$_discriminator$ = new byte[1];
+          boolean[] result$_discriminator$ = new boolean[1];
           long result$ = SwiftModule.$optionalClass(arg.map(MyClass::$memoryAddress).orElse(0L), result$_discriminator$);
-          return (result$_discriminator$[0] == 1) ? Optional.of(MyClass.wrapMemoryAddressUnsafe(result$, swiftArena)) : Optional.empty();
+          return (result$_discriminator$[0]) ? Optional.of(MyClass.wrapMemoryAddressUnsafe(result$, swiftArena)) : Optional.empty();
         }
         """,
         """
-        private static native long $optionalClass(long arg, byte[] result_discriminator$);
+        private static native long $optionalClass(long arg, boolean[] result_discriminator$);
         """,
       ]
     )
@@ -178,8 +178,8 @@ struct JNIOptionalTests {
       javaClassLookupTable: classLookupTable,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024optionalClass__J_3B")
-        public func Java_com_example_swift_SwiftModule__00024optionalClass__J_3B(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg: jlong, result_discriminator$: jbyteArray?) -> jlong {
+        @_cdecl("Java_com_example_swift_SwiftModule__00024optionalClass__J_3Z")
+        public func Java_com_example_swift_SwiftModule__00024optionalClass__J_3Z(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, arg: jlong, result_discriminator$: jbooleanArray?) -> jlong {
           let argBits$ = Int(Int64(fromJNI: arg, in: environment))
           let arg$ = UnsafeMutablePointer<MyClass>(bitPattern: argBits$)
           let result$: jlong
@@ -188,13 +188,13 @@ struct JNIOptionalTests {
             resultWrapped$.initialize(to: innerResult$)
             let resultWrappedBits$ = Int64(Int(bitPattern: resultWrapped$))
             result$ = resultWrappedBits$.getJNILocalRefValue(in: environment)
-            var flag$ = Int8(1)
-            environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
+            var flag$ = jboolean(JNI_TRUE)
+            environment.interface.SetBooleanArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
           }
           else {
             result$ = 0
-            var flag$ = Int8(0)
-            environment.interface.SetByteArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
+            var flag$ = jboolean(JNI_FALSE)
+            environment.interface.SetBooleanArrayRegion(environment, result_discriminator$, 0, 1, &flag$)
           }
           return result$
         }
@@ -267,14 +267,14 @@ struct JNIOptionalTests {
       detectChunkByInitialLines: 2,
       expectedChunks: [
         """
-        byte[] result$_discriminator$ = new byte[1];
-        byte[] resultWrapped$_0$$_discriminator$ = new byte[1];
+        boolean[] result$_discriminator$ = new boolean[1];
+        boolean[] resultWrapped$_0$$_discriminator$ = new boolean[1];
         long[] resultWrapped$_0$ = new long[1];
         long[] resultWrapped$_1$ = new long[1];
         SwiftModule.$optionalTuple(result$_discriminator$, resultWrapped$_0$$_discriminator$, resultWrapped$_0$, resultWrapped$_1$);
         """,
         """
-        private static native void $optionalTuple(byte[] result_discriminator$, byte[] resultWrapped_0$_discriminator$, long[] resultWrapped_0$, long[] resultWrapped_1$);
+        private static native void $optionalTuple(boolean[] result_discriminator$, boolean[] resultWrapped_0$_discriminator$, long[] resultWrapped_0$, long[] resultWrapped_1$);
         """,
       ]
     )


### PR DESCRIPTION
This PR changes the discriminator type used to distinguish between `some` and `none` in Optional values from `byte` to `boolean`.

Using a `boolean` is more intuitive for representing a binary state. 
This change also simplifies the generated code by reducing the reliance on ternary operators.