### PR TITLE
wrap-java: Fix escaped method calls and handle $ prefix

### DIFF
--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/JavaKitExample.swift
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/JavaKitExample.swift
@@ -62,6 +62,10 @@ extension HelloSwift: HelloSwiftNativeMethods {
       fatalError("Expected subclass here")
     }
 
+    // Check escaped name
+    assert(self.`init`(42) == 42)
+    assert(self._echo("Hello") == "Hello")
+
     // Check "is" behavior
     assert(newHello.is(HelloSwift.self))
     assert(!newHello.is(HelloSubclass.self))

--- a/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/HelloSwift.java
+++ b/Samples/JavaKitSampleApp/Sources/JavaKitExample/com/example/swift/HelloSwift.java
@@ -47,6 +47,10 @@ public class HelloSwift {
         return value;
     }
 
+    public String $echo(String value) {
+        return value;
+    }
+
     public Predicate<Integer> lessThanTen() {
         Predicate<Integer> predicate = i -> (i < 10);
         return predicate;

--- a/Sources/JavaStdlib/JavaIO/generated/FileDescriptor.swift
+++ b/Sources/JavaStdlib/JavaIO/generated/FileDescriptor.swift
@@ -26,7 +26,7 @@ open class FileDescriptor: JavaObject {
   open func valid() -> Bool
 }
 extension JavaClass<FileDescriptor> {
-  @JavaStaticField(isFinal: true)
+  @JavaStaticField("in", isFinal: true)
   public var `in`: FileDescriptor!
 
   @JavaStaticField(isFinal: true)

--- a/Sources/SwiftJava/generated/JavaString.swift
+++ b/Sources/SwiftJava/generated/JavaString.swift
@@ -483,7 +483,7 @@ open class JavaString: JavaObject {
   /// ```java
   /// public java.lang.String java.lang.String.repeat(int)
   /// ```
-  @JavaMethod
+  @JavaMethod("repeat")
   open func `repeat`(_ arg0: Int32) -> String
 
   /// Java method `isBlank`.

--- a/Sources/SwiftJavaRuntimeSupport/generated/JavaSwiftArena.swift
+++ b/Sources/SwiftJavaRuntimeSupport/generated/JavaSwiftArena.swift
@@ -4,7 +4,14 @@ import SwiftJavaJNICore
 
 @JavaInterface("org.swift.swiftkit.core.SwiftArena")
 public struct JavaSwiftArena {
-
+  /// Java method `register`.
+  ///
+  /// ### Java method signature
+  /// ```java
+  /// public abstract void org.swift.swiftkit.core.SwiftArena.register(org.swift.swiftkit.core.SwiftInstance)
+  /// ```
+  @JavaMethod
+  public func register(_ arg0: JavaSwiftInstance?)
 }
 extension JavaClass<JavaSwiftArena> {
   /// Java method `ofAuto`.

--- a/Sources/SwiftJavaRuntimeSupport/generated/JavaSwiftInstance.swift
+++ b/Sources/SwiftJavaRuntimeSupport/generated/JavaSwiftInstance.swift
@@ -2,24 +2,15 @@
 import SwiftJava
 import SwiftJavaJNICore
 
-@JavaInterface("org.swift.swiftkit.core.JNISwiftInstance", extends: JavaSwiftInstance.self)
-public struct JavaJNISwiftInstance {
-  /// Java method `$typeMetadataAddress`.
-  ///
-  /// ### Java method signature
-  /// ```java
-  /// public abstract long org.swift.swiftkit.core.JNISwiftInstance.$typeMetadataAddress()
-  /// ```
-  @JavaMethod("$typeMetadataAddress")
-  public func _typeMetadataAddress() -> Int64
-
+@JavaInterface("org.swift.swiftkit.core.SwiftInstance")
+public struct JavaSwiftInstance {
   /// Java method `$memoryAddress`.
   ///
   /// ### Java method signature
   /// ```java
   /// public abstract long org.swift.swiftkit.core.SwiftInstance.$memoryAddress()
   /// ```
-  @JavaMethod("$memoryAddress")
+@JavaMethod("$memoryAddress")
   public func _memoryAddress() -> Int64
 
   /// Java method `$ensureAlive`.
@@ -28,6 +19,6 @@ public struct JavaJNISwiftInstance {
   /// ```java
   /// public default void org.swift.swiftkit.core.SwiftInstance.$ensureAlive()
   /// ```
-  @JavaMethod("$ensureAlive")
+@JavaMethod("$ensureAlive")
   public func _ensureAlive()
 }

--- a/Sources/SwiftJavaRuntimeSupport/generated/JavaSwiftInstance.swift
+++ b/Sources/SwiftJavaRuntimeSupport/generated/JavaSwiftInstance.swift
@@ -10,7 +10,7 @@ public struct JavaSwiftInstance {
   /// ```java
   /// public abstract long org.swift.swiftkit.core.SwiftInstance.$memoryAddress()
   /// ```
-@JavaMethod("$memoryAddress")
+  @JavaMethod("$memoryAddress")
   public func _memoryAddress() -> Int64
 
   /// Java method `$ensureAlive`.
@@ -19,6 +19,6 @@ public struct JavaSwiftInstance {
   /// ```java
   /// public default void org.swift.swiftkit.core.SwiftInstance.$ensureAlive()
   /// ```
-@JavaMethod("$ensureAlive")
+  @JavaMethod("$ensureAlive")
   public func _ensureAlive()
 }

--- a/Sources/SwiftJavaRuntimeSupport/swift-java.config
+++ b/Sources/SwiftJavaRuntimeSupport/swift-java.config
@@ -1,6 +1,7 @@
 {
   "classpath" : "SwiftKitCore/build/classes/java/main",
   "classes" : {
+    "org.swift.swiftkit.core.SwiftInstance" : "JavaSwiftInstance",
     "org.swift.swiftkit.core.JNISwiftInstance" : "JavaJNISwiftInstance",
     "org.swift.swiftkit.core.SwiftArena" : "JavaSwiftArena"
   }

--- a/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
@@ -1079,11 +1079,12 @@ extension JavaClassTranslator {
       outerOptional: .implicitlyUnwrappedOptional
     )
     let (swiftFieldName, swiftFieldNameIsEscaped) = javaField.getName().escapedSwiftName
-    var fieldAttributeStr = if javaField.isStatic {
-      "@JavaStaticField"
-    } else {
-      "@JavaField"
-    }
+    var fieldAttributeStr =
+      if javaField.isStatic {
+        "@JavaStaticField"
+      } else {
+        "@JavaField"
+      }
     var parameters: [String] = []
     if swiftFieldNameIsEscaped {
       parameters.append("\"\(javaField.getName())\"")

--- a/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaClassTranslator.swift
@@ -259,11 +259,6 @@ struct JavaClassTranslator {
         continue
       }
 
-      guard method.getName().isValidSwiftFunctionName else {
-        log.warning("Skipping method \(method.getName()) because it is not a valid Swift function name")
-        continue
-      }
-
       addMethod(method, isNative: false)
     }
 
@@ -949,8 +944,8 @@ extension JavaClassTranslator {
 
     // --- Handle other effects
     let throwsStr = javaMethod.throwsCheckedException ? "throws" : ""
-    let swiftMethodName = javaMethod.getName().escapedSwiftName
-    let swiftOptionalMethodName = "\(javaMethod.getName())Optional".escapedSwiftName
+    let (swiftMethodName, swiftMethodNameEscaped) = javaMethod.getName().escapedSwiftName
+    let (swiftOptionalMethodName, _) = "\(javaMethod.getName())Optional".escapedSwiftName
 
     // --- Handle docs for the generated method.
     // Include the original Java signature
@@ -987,10 +982,8 @@ extension JavaClassTranslator {
         }
       // Do we need to record any generic information, in order to enable type-erasure for the upcalls?
       var parameters: [String] = []
-      // If the method name is "init", we need to explicitly specify it in the annotation
-      // because "init" is a Swift keyword and will be escaped in the function name via `init`
-      if javaMethod.getName() == "init" {
-        parameters.append("\"init\"")
+      if swiftMethodNameEscaped {
+        parameters.append("\"\(javaMethod.getName())\"")
       }
       if hasTypeEraseGenericResultType {
         let returnType = javaMethod.getReturnType()!
@@ -1085,8 +1078,23 @@ extension JavaClassTranslator {
       preferValueTypes: true,
       outerOptional: .implicitlyUnwrappedOptional
     )
-    let fieldAttribute: AttributeSyntax = javaField.isStatic ? "@JavaStaticField" : "@JavaField"
-    let swiftFieldName = javaField.getName().escapedSwiftName
+    let (swiftFieldName, swiftFieldNameIsEscaped) = javaField.getName().escapedSwiftName
+    var fieldAttributeStr = if javaField.isStatic {
+      "@JavaStaticField"
+    } else {
+      "@JavaField"
+    }
+    var parameters: [String] = []
+    if swiftFieldNameIsEscaped {
+      parameters.append("\"\(javaField.getName())\"")
+    }
+    parameters.append("isFinal: \(javaField.isFinal)")
+    if !parameters.isEmpty {
+      fieldAttributeStr += "("
+      fieldAttributeStr.append(parameters.joined(separator: ", "))
+      fieldAttributeStr += ")"
+    }
+    let fieldAttribute: AttributeSyntax = "\(raw: fieldAttributeStr)"
     let fieldAnnotations = javaField.getDeclaredAnnotations().compactMap(\.self)
     let invisibleFieldAnnotations = runtimeInvisibleAnnotations.annotationsFor(field: javaField.getName())
     let availableAttributes = swiftAvailableAttributes(
@@ -1109,7 +1117,7 @@ extension JavaClassTranslator {
           ""
         }
       return """
-        \(raw: availableAttributes.render())\(fieldAttribute)(isFinal: \(raw: javaField.isFinal))
+        \(raw: availableAttributes.render())\(fieldAttribute)
         public var \(raw: swiftFieldName): \(raw: typeName)
 
 
@@ -1121,7 +1129,7 @@ extension JavaClassTranslator {
         """
     } else {
       return """
-        \(raw: availableAttributes.render())\(fieldAttribute)(isFinal: \(raw: javaField.isFinal))
+        \(raw: availableAttributes.render())\(fieldAttribute)
         public var \(raw: swiftFieldName): \(raw: typeName)
         """
     }

--- a/Sources/SwiftJavaToolLib/StringExtras.swift
+++ b/Sources/SwiftJavaToolLib/StringExtras.swift
@@ -27,17 +27,19 @@ extension String {
   }
 
   /// Escape a name with backticks if it's a Swift keyword.
-  var escapedSwiftName: String {
-    if isValidSwiftIdentifier(for: .variableName) {
-      return self
+  var escapedSwiftName: (swiftName: String, escaped: Bool) {
+    var escaped = false
+    var copy = self
+    if starts(with: "$") {
+      copy = "_\(self.dropFirst())"
+      escaped = true
     }
 
-    return "`\(self)`"
-  }
+    if copy.isValidSwiftIdentifier(for: .variableName) {
+      return (copy, escaped)
+    }
 
-  /// Returns whether this is a valid Swift function name
-  var isValidSwiftFunctionName: Bool {
-    !self.starts(with: "$")
+    return ("`\(copy)`", true)
   }
 
   /// Replace all occurrences of one character in the string with another.

--- a/Tests/SwiftJavaToolLibTests/WrapJavaTests/BasicWrapJavaTests.swift
+++ b/Tests/SwiftJavaToolLibTests/WrapJavaTests/BasicWrapJavaTests.swift
@@ -286,7 +286,7 @@ final class BasicWrapJavaTests: XCTestCase {
     let classpathURL = try await compileJava(
       """
       package com.example;
-      
+
       class MyClass {
         public long init;
         public static boolean $foo; 
@@ -298,7 +298,7 @@ final class BasicWrapJavaTests: XCTestCase {
 
     try assertWrapJavaOutput(
       javaClassNames: [
-        "com.example.MyClass",
+        "com.example.MyClass"
       ],
       classpath: [classpathURL],
       expectedChunks: [
@@ -317,7 +317,7 @@ final class BasicWrapJavaTests: XCTestCase {
         """
         @JavaStaticMethod("$bar")
         public func _bar()
-        """
+        """,
       ]
     )
   }

--- a/Tests/SwiftJavaToolLibTests/WrapJavaTests/BasicWrapJavaTests.swift
+++ b/Tests/SwiftJavaToolLibTests/WrapJavaTests/BasicWrapJavaTests.swift
@@ -281,4 +281,44 @@ final class BasicWrapJavaTests: XCTestCase {
       ]
     )
   }
+
+  func test_wrapJava_escapedSwiftName() async throws {
+    let classpathURL = try await compileJava(
+      """
+      package com.example;
+      
+      class MyClass {
+        public long init;
+        public static boolean $foo; 
+        public void func() {}
+        public static void $bar() {}
+      }
+      """
+    )
+
+    try assertWrapJavaOutput(
+      javaClassNames: [
+        "com.example.MyClass",
+      ],
+      classpath: [classpathURL],
+      expectedChunks: [
+        """
+        @JavaField("init", isFinal: false)
+        public var `init`: Int64
+        """,
+        """
+        @JavaStaticField("$foo", isFinal: false)
+        public var _foo: Bool
+        """,
+        """
+        @JavaMethod("func")
+        open func `func`()
+        """,
+        """
+        @JavaStaticMethod("$bar")
+        public func _bar()
+        """
+      ]
+    )
+  }
 }


### PR DESCRIPTION
This PR fixes two issues related to Java-to-Swift method name mapping in wrap-java.

1. Fix for Escaped Method Calls

Currently, Java methods that are Swift keywords (e.g., `init`) are correctly escaped in the Swift interface. 
However, the macro was using these escaped names to call the Java methods, leading to failures.

<img width="622" height="167" alt="expanded macro" src="https://github.com/user-attachments/assets/bf770740-fa57-46a1-8216-ebfefe8757fc" />

This PR ensures the original name is passed to the macro arguments when a name is escaped.

2. Handling of `$` Prefix

Methods with a `$` prefix were previously ignored.
To support future use cases like `SwiftInstance.$memoryAddress()`, I have enabled importing these methods by mapping the `$` prefix to an underscore.