### PR TITLE
jextract/ffm: Treat underscore labels as empty suffixes in function overloads

### DIFF
--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -165,6 +165,10 @@ public func globalOverloaded(b: Int) {
   p("globalOverloaded(b: \(b))")
 }
 
+public func globalOverloaded(_ c: Int) {
+  p("globalOverloaded(c: \(c))")
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/main/java/com/example/swift/HelloJava2Swift.java
@@ -85,7 +85,7 @@ public class HelloJava2Swift {
             var origBytes = arena.allocateFrom("foobar");
             var origDat = Data.init(origBytes, origBytes.byteSize(), arena);
             CallTraces.trace("origDat.count = " + origDat.getCount());
-            
+
             var retDat = MySwiftLibrary.globalReceiveReturnData(origDat, arena);
             retDat.withUnsafeBytes((retBytes) -> {
                 var str = retBytes.getString(0);
@@ -104,6 +104,7 @@ public class HelloJava2Swift {
         // Overloaded functions with label-based disambiguation
         MySwiftLibrary.globalOverloadedA(100);
         MySwiftLibrary.globalOverloadedB(200);
+        MySwiftLibrary.globalOverloaded(300);
 
         System.out.println("DONE.");
     }

--- a/Sources/JExtractSwiftLib/JavaIdentifierFactory.swift
+++ b/Sources/JExtractSwiftLib/JavaIdentifierFactory.swift
@@ -81,11 +81,12 @@ package struct JavaIdentifierFactory {
       return ""
     default:
       guard needsSuffix(for: baseName) else { return "" }
-      let labels = decl.functionSignature.parameters
-        .compactMap { $0.argumentLabel }
-      // A parameterless function that still conflicts (e.g. with a property
-      // getter) gets a bare "_" so it compiles as a distinct Java method.
-      guard !labels.isEmpty else { return "_" }
+      if decl.functionSignature.parameters.isEmpty {
+        // A parameterless function that still conflicts (e.g. with a property
+        // getter) gets a bare "_" so it compiles as a distinct Java method.
+        return "_"
+      }
+      let labels = decl.functionSignature.parameters.compactMap(\.argumentLabel)
       // Join labels in camelCase: takeValue(a:) → takeValueA
       return labels.map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined()
     }

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -530,6 +530,7 @@ final class MethodImportTests {
 
     public func takeValue(a: Swift.String) -> Swift.Int
     public func takeValue(b: Swift.String) -> Swift.Int
+    public func takeValue(_ c: Swift.String) -> Swift.Int
     public func uniqueFunc(x: Swift.Int) -> Swift.Int
     public func overloaded(a: Swift.Int) -> Swift.Int
     public func overloaded(a: Swift.String) -> Swift.Int
@@ -551,6 +552,7 @@ final class MethodImportTests {
       expectedChunks: [
         "public static long takeValueA(java.lang.String a)",
         "public static long takeValueB(java.lang.String b)",
+        "public static long takeValue(java.lang.String c)",
       ]
     )
   }
@@ -679,6 +681,7 @@ final class MethodImportTests {
       expectedChunks: [
         "public static long takeValueA(java.lang.String a)",
         "public static long takeValueB(java.lang.String b)",
+        "public static long takeValue(java.lang.String c)",
       ]
     )
   }


### PR DESCRIPTION
Currently, when a function overload uses an underscore (`_`) as an argument label, the generator uses the underscore literally as a suffix for the Java method name.

```swift
func foo(a: Int)    // in Java, void fooA(long a)
func foo(_ b: Int)  // in Java, void foo_(long b)
```

In Swift, `_` is not an identifier; it simply denotes the omission of a label. Therefore, IMO, using it as a literal suffix in Java feels unnatural.

This PR updates the naming logic for function overloads to treat the `_` label as an empty suffix.

## Notes



This change can lead to name collisions in specific cases. For example:

```swift
public func takeValue(_ a: Int, b: Int) -> Int { 0 }
public func takeValue(b: Int, _ c: Int) -> Int { 0 }
```

With this PR, both methods would map to `takeValueB`.
However, even if we kept the underscore (the previous behavior), collisions would still be unavoidable if a function like `func takeValue_(b: Int)` existed.
To approach such corner-case collisions, we should eventually provide a way for users to explicitly specify the export name. (like `@JavaExport("export_name")`).