### PR TITLE
jextract/jni: Fix compilation of nested generic types

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
@@ -51,7 +51,7 @@ public enum NamespaceEnum {
     public static func something() {}
   }
 
-  public struct GenericType<T> {
+  public struct NestedGenericType<T> {
     public var value: Int
   }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/NestedTypes.swift
@@ -50,4 +50,8 @@ public enum NamespaceEnum {
   public enum Nested {
     public static func something() {}
   }
+
+  public struct GenericType<T> {
+    public var value: Int
+  }
 }

--- a/Sources/JExtractSwiftLib/ImportedDecls.swift
+++ b/Sources/JExtractSwiftLib/ImportedDecls.swift
@@ -167,7 +167,7 @@ package final class ImportedNominalType: ImportedDecl {
   }
 
   var swiftType: SwiftType {
-    .nominal(.init(nominalTypeDecl: swiftNominal))
+    swiftNominal.asSwiftType
   }
 
   /// Structured Java-facing type name — "FishBox" for specialized, "Box" for base

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -920,7 +920,7 @@ extension JNISwift2JavaGenerator {
   }
 
   private func openerProtocolName(for type: SwiftNominalTypeDeclaration) -> String {
-    "_\(swiftModuleName)_\(type.name)_opener"
+    "_\(swiftModuleName)_\(type.flatName)_opener"
   }
 
   private func printOpenerProtocol(_ printer: inout CodePrinter, _ type: ImportedNominalType) {
@@ -969,7 +969,7 @@ extension JNISwift2JavaGenerator {
       }
     }
     printer.println()
-    printer.printBraceBlock("extension \(type.swiftNominal.name): \(protocolName)") { printer in
+    printer.printBraceBlock("extension \(type.swiftNominal.qualifiedName): \(protocolName)") { printer in
       for variable in type.variables {
         if variable.isStatic { continue }
         printFunctionDecl(&printer, decl: variable, skipMethodBody: false)

--- a/Sources/JExtractSwiftLib/SwiftTypes/SwiftType.swift
+++ b/Sources/JExtractSwiftLib/SwiftTypes/SwiftType.swift
@@ -589,3 +589,18 @@ enum TypeTranslationError: Error {
   /// Unknown nominal type.
   case unknown(TypeSyntax, file: StaticString = #file, line: Int = #line)
 }
+
+extension SwiftNominalTypeDeclaration {
+  var asSwiftNominalType: SwiftNominalType {
+    let genericArguments = genericParameters.map { SwiftType.genericParameter($0) }
+    return SwiftNominalType(
+      parent: parent?.asSwiftNominalType,
+      nominalTypeDecl: self,
+      genericArguments: genericArguments.isEmpty ? nil : genericArguments
+    )
+  }
+
+  var asSwiftType: SwiftType {
+    .nominal(asSwiftNominalType)
+  }
+}

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
@@ -121,7 +121,7 @@ struct JNIGenericTypeTests {
           static func _get_description(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong) -> jstring? {
             assert(selfPointer != 0, "selfPointer memory address was null")
             let selfPointerBits$ = Int(Int64(fromJNI: selfPointer, in: environment))
-            let selfPointer$ = UnsafeMutablePointer<MyID>(bitPattern: selfPointerBits$)
+            let selfPointer$ = UnsafeMutablePointer<MyID<T>>(bitPattern: selfPointerBits$)
             guard let selfPointer$ else {
               fatalError("selfPointer memory address was null in call to \(#function)!")
             }
@@ -239,7 +239,6 @@ struct JNIGenericTypeTests {
       ]
     )
 
-
     try assertOutput(
       input: input,
       .jni,
@@ -250,6 +249,39 @@ struct JNIGenericTypeTests {
         public func Java_com_example_swift_MyEnum__00024getAsFoo__J_3BLorg_swift_swiftkit_core__1OutSwiftGenericInstance_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong, result_discriminator$: jbyteArray?, resultWrappedOut: jobject?) {
         """#
       ]
+    )
+  }
+
+  @Test
+  func nestedGenericType() throws {
+    let input =
+      #"""
+      public enum Foo {
+        public struct Bar<T> {
+          public func work() {}
+        }
+      }
+      """#
+
+    try assertOutput(
+      input: input,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        #"""
+        extension Foo.Bar: _SwiftModule_Foo_Bar_opener {
+          static func _work(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, selfPointer: jlong) {
+            ...
+            let selfPointer$ = UnsafeMutablePointer<Foo.Bar<T>>(bitPattern: selfPointerBits$)
+            guard let selfPointer$ else {
+             fatalError("selfPointer memory address was null in call to \(#function)!")
+            }
+            selfPointer$.pointee.work()
+          }
+        }
+        """#
+      ],
     )
   }
 


### PR DESCRIPTION
Currently, nested generic types cause compilation errors because the generator fails to include necessary namespaces and generic parameters.

```swift
// MARK: original declaration
public enum NamespaceEnum {
  public struct GenericType<T> {
    public var value: Int
  }
}

// MARK: generated code

//        ↓ missing namespace
extension GenericType: _MySwiftLibrary_GenericType_opener {
  static func _get_value(...) -> jlong {
    ...
    let selfPointer$ = UnsafeMutablePointer<NamespaceEnum.GenericType>(bitPattern: selfPointerBits$)
    //                                    missing type parameter <T> ↑
    ...
  }
```

Based on my experiments, Swift handles type inference differently for nested generics compared to top-level generics.
While top-level generic parameters can often be inferred within an extension, nested generic types require explicit type parameters when referenced inside the extension body.


```swift
struct TopLevelGeneric<T> {}

extension TopLevelGeneric {
    static func foo() -> String {
        "\(TopLevelGeneric.self)" // OK
    }
}

enum Nested {
    struct Generic<T> {}
}

extension Nested.Generic {
    static func foo() -> String {
        "\(Nested.Generic.self)" // error: generic parameter 'T' could not be inferred
    }
}
```

To resolve this, I have updated the generator to:

1.	Use the qualified name for extension declarations.
2.	Use the full type name including generic parameters within function bodies.
    The root cause was that `SwiftType` in `SwiftFunctionSignature` was missing its generic parameters.
    It appears that `ImportedNominalType.swiftType` was incorrectly stripping these parameters during the type conversion process.
    This PR fixes that logic to ensure generic information is preserved.
