### PR TITLE
jextract/jni: Fix label-based overloading for JNI

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -64,6 +64,18 @@ public func returnLargestUnsignedByte() -> UInt8 {
   UInt8.max
 }
 
+public func globalOverloaded(a: Int) -> Int {
+  a + 1
+}
+
+public func globalOverloaded(b: Int) -> Int {
+  b + 2
+}
+
+public func globalOverloaded(_ c: Int) -> Int {
+  c + 3
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -78,4 +78,11 @@ public class MySwiftLibraryTest {
     void returnLargestUnsignedByte() {
         assertEquals(-1, MySwiftLibrary.returnLargestUnsignedByte());
     }
+
+    @Test
+    void labeledOverloads() {
+        assertEquals(101, MySwiftLibrary.globalOverloadedA(100));
+        assertEquals(202, MySwiftLibrary.globalOverloadedB(200));
+        assertEquals(303, MySwiftLibrary.globalOverloaded(300));
+    }
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -277,6 +277,10 @@ extension JNISwift2JavaGenerator {
   private func printGlobalSwiftThunkSources(_ printer: inout CodePrinter) throws {
     printHeader(&printer)
 
+    self.currentJavaIdentifiers = JavaIdentifierFactory(
+      self.analysis.importedGlobalFuncs + self.analysis.importedGlobalVariables
+    )
+
     for decl in analysis.importedGlobalFuncs {
       printSwiftFunctionThunk(&printer, decl)
       printer.println()
@@ -290,8 +294,11 @@ extension JNISwift2JavaGenerator {
 
   private func printNominalTypeThunks(_ printer: inout CodePrinter, _ type: ImportedNominalType) throws {
     printHeader(&printer)
-
     printer.println()
+
+    self.currentJavaIdentifiers = JavaIdentifierFactory(
+      type.initializers + type.variables + type.methods
+    )
 
     switch type.swiftNominal.kind {
     case .actor, .class, .enum, .struct:


### PR DESCRIPTION
This PR fixes an issue where label-based function overloading was not working correctly for JNI.
While this feature is already supported on the FFM side, the JNI implementation was incomplete.

Interestingly, standalone Java code generation (as seen in `MethodImportTests`) seemed to work fine. However, when both Swift and Java code were generated simultaneously, the resulting source code became corrupted.

The root cause was that the Swift-side code generator was caching state-dependent values in `JNISwift2JavaGenerator` incorrectly.
This created a strange behavior where the logic appeared to work in isolated unit tests but failed during actual full-scale code generation.

- Example compile error

```java
.../MySwiftLibrary.java:260: error: method globalOverloaded(long) is already defined in class MySwiftLibrary
  public static long globalOverloaded(long b) throws SwiftIntegerOverflowException {
                     ^
.../MySwiftLibrary.java:263: error: method $globalOverloaded(long) is already defined in class MySwiftLibrary
  private static native long $globalOverloaded(long b);
                             ^
.../MySwiftLibrary.java:275: error: method globalOverloaded(long) is already defined in class MySwiftLibrary
  public static long globalOverloaded(long c) throws SwiftIntegerOverflowException {
                     ^
.../MySwiftLibrary.java:278: error: method $globalOverloaded(long) is already defined in class MySwiftLibrary
  private static native long $globalOverloaded(long c);
```

This PR updates the Swift code generator to address this issue.

## Note

~~This PR is currently a Draft as it depends on #741. I will mark it as ready for review once the dependency is merged.~~