### PR TITLE
reject unsupported tuple components

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -1458,7 +1458,14 @@ extension JNISwift2JavaGenerator {
       genericParameters: [SwiftGenericParameterDeclaration],
       genericRequirements: [SwiftGenericRequirement],
     ) throws -> JavaType {
-      try translateGenericTypeParameter(
+      switch swiftType {
+      case let .tuple(elements):
+        if elements.count != 1 { throw JavaTranslationError.unsupportedSwiftType(swiftType) }
+      default:
+        break
+      }
+
+      return try translateGenericTypeParameter(
         swiftType,
         genericParameters: genericParameters,
         genericRequirements: genericRequirements,

--- a/Tests/JExtractSwiftTests/JNI/JNIDictionaryTest.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIDictionaryTest.swift
@@ -322,4 +322,34 @@ struct JNIDictionaryTest {
       ]
     )
   }
+
+  @Test("Import: () -> [UInt32: tuple] is unsupported")
+  func tupleDictionaryValue_swift() throws {
+    try assertOutput(
+      input: """
+        public enum ResponseType {
+          case ok
+        }
+
+        public class BindingStore {
+          public typealias RawResponse = (requestId: UInt32, stringResponse: String, responseType: ResponseType, finished: Bool)
+          public static var completeResponses: [UInt32: RawResponse] = [:]
+        }
+        """,
+      .jni,
+      .swift,
+      expectedChunks: [],
+      notExpectedChunks: [
+        """
+        dictionaryGetJNIValue
+        """,
+        """
+        getCompleteResponses
+        """,
+        """
+        setCompleteResponses
+        """,
+      ]
+    )
+  }
 }


### PR DESCRIPTION
I noticed that jextract allowed multielement swift tuples in places where the JNI bridge later requires a concrete JavaBoxable type. Swift tuples cannot conform to protocols, so the generated code could fail to compile. I fixed it by rejecting unsupported tuple components during translation 🫣


```
ObertonWalletCore/destination/JExtractSwiftPlugin/Sources/BindingStore+SwiftJava.swift:24:41: error: type 'BindingStore.RawResponse' (aka '(requestId: UInt32, stringResponse: String, responseType: TSDKBindingResponseType, finished: Bool)') cannot conform to 'JavaBoxable' [#ProtocolTypeNonConformance]
22 | @_cdecl("Java_com_custwallet_core_BindingStore__00024getCompleteResponses__")
23 | public func Java_com_custwallet_core_BindingStore__00024getCompleteResponses__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jlong {
24 |   return BindingStore.completeResponses.dictionaryGetJNIValue(in: environment)
   |                                         |- error: type 'BindingStore.RawResponse' (aka '(requestId: UInt32, stringResponse: String, responseType: TSDKBindingResponseType, finished: Bool)') cannot conform to 'JavaBoxable' [#ProtocolTypeNonConformance]
   |                                         `- note: only concrete types such as structs, enums and classes can conform to protocols
25 | } // printCDecl(_:javaMethodName:parentName:parameters:resultType:_:) @ JExtractSwiftLib/JNISwift2JavaGenerator+SwiftThunkPrinting.swift:751
26 | 

/oberton-wallet-core/.build/checkouts/swift-java/Sources/SwiftJava/BridgedValues/JavaValue+Dictionary.swift:20:1: note: required by referencing instance method 'dictionaryGetJNIValue(in:)' on 'Dictionary' where 'Value' = 'BindingStore.RawResponse' (aka '(requestId: UInt32, stringResponse: String, responseType: TSDKBindingResponseType, finished: Bool)')
18 | // MARK: Dictionary extension for JNI bridging
19 | 
20 | extension Dictionary where Key: JavaBoxable & Hashable, Value: JavaBoxable {
   | `- note: required by referencing instance method 'dictionaryGetJNIValue(in:)' on 'Dictionary' where 'Value' = 'BindingStore.RawResponse' (aka '(requestId: UInt32, stringResponse: String, responseType: TSDKBindingResponseType, finished: Bool)')
21 |   /// Box this dictionary and return a jlong pointer for passing across JNI.
22 |   /// The dictionary is retained on the Swift heap; Java holds the pointer.
```