### PR TITLE
jextract/jni: Support static function calls for specialized types

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/BoxSpecialization.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/BoxSpecialization.swift
@@ -18,6 +18,10 @@ public struct Box<Element>: Hashable {
   public init(count: Int64) {
     self.count = count
   }
+
+  public static func describeElement() -> String {
+    String(describing: Element.self)
+  }
 }
 
 public struct Fish: Hashable {

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/BoxSpecializationTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/BoxSpecializationTest.java
@@ -36,6 +36,11 @@ public class BoxSpecializationTest {
         Method setCount = fishBoxClass.getMethod("setCount", long.class);
         assertNotNull(setCount);
 
+        // Static method
+        Method describeElement = fishBoxClass.getMethod("describeElement");
+        assertNotNull(describeElement);
+        assertEquals(String.class, describeElement.getReturnType());
+
         // Constrained extension method (only on FishBox, not on Box)
         Method describeFish = fishBoxClass.getMethod("describeFish");
         assertNotNull(describeFish);

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/BoxSpecializationTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/BoxSpecializationTest.java
@@ -61,4 +61,9 @@ public class BoxSpecializationTest {
             "Box should have one generic type parameter");
         assertEquals("Element", Box.class.getTypeParameters()[0].getName());
     }
+
+    @Test
+    void callFishBoxStaticMethod() {
+        assertEquals("Fish", FishBox.describeElement());
+    }
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -349,11 +349,19 @@ extension JNISwift2JavaGenerator {
       }
 
       for method in decl.methods {
+        if isEffectivelyGeneric && method.isStatic {
+          self.logger.debug("Skipping static method '\(method.name)' on unspecialized generic type '\(decl.effectiveJavaName)'")
+          continue
+        }
         printFunctionDowncallMethods(&printer, method)
         printer.println()
       }
 
       for variable in decl.variables {
+        if isEffectivelyGeneric && variable.isStatic {
+          self.logger.debug("Skipping static property '\(variable.name)' on unspecialized generic type '\(decl.effectiveJavaName)'")
+          continue
+        }
         printFunctionDowncallMethods(&printer, variable)
         printer.println()
       }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -366,20 +366,23 @@ extension JNISwift2JavaGenerator {
       guard let selfParameter else {
         return nil
       }
-
-      let isGeneric = selfParameter.selfType.asNominalTypeDeclaration?.isGeneric == true
-      if isGeneric {
-        return try self.translateParameter(
-          swiftType: .metatype(selfParameter.selfType),
-          parameterName: "selfTypePointer",
-          methodName: methodName,
-          parentName: parentName,
-          genericParameters: genericParameters,
-          genericRequirements: genericRequirements,
-          parameterPosition: nil,
-        )
-      } else {
+      let selfType = selfParameter.selfType
+      let isGeneric = selfType.asNominalTypeDeclaration?.isGeneric == true
+      guard isGeneric else {
         return nil
+      }
+
+      switch selfParameter {
+      case .instance:
+        return TranslatedParameter(
+          parameter: JavaParameter(name: "selfTypePointer", type: .long),
+          conversion: .typeMetadataAddress(.placeholder),
+        )
+      case .staticMethod, .initializer:
+        return TranslatedParameter(
+          parameter: JavaParameter(name: "selfTypePointer", type: .long),
+          conversion: .call(.constant(""), function: "$typeMetadataAddressDowncall"),
+        )
       }
     }
 

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -366,8 +366,7 @@ extension JNISwift2JavaGenerator {
       guard let selfParameter else {
         return nil
       }
-      let selfType = selfParameter.selfType
-      let isGeneric = selfType.asNominalTypeDeclaration?.isGeneric == true
+      let isGeneric = selfParameter.selfType.asNominalTypeDeclaration?.isGeneric == true
       guard isGeneric else {
         return nil
       }
@@ -381,7 +380,7 @@ extension JNISwift2JavaGenerator {
       case .staticMethod, .initializer:
         return TranslatedParameter(
           parameter: JavaParameter(name: "selfTypePointer", type: .long),
-          conversion: .call(.constant(""), function: "$typeMetadataAddressDowncall"),
+          conversion: .constant("$typeMetadataAddressDowncall()"),
         )
       }
     }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -1039,12 +1039,10 @@ extension JNISwift2JavaGenerator {
     printer.println()
     printer.printBraceBlock("extension \(type.swiftNominal.qualifiedName): \(protocolName)") { printer in
       for variable in type.variables {
-        if variable.isStatic { continue }
         printFunctionDecl(&printer, decl: variable, skipMethodBody: false)
       }
 
       for method in type.methods {
-        if method.isStatic { continue }
         printFunctionDecl(&printer, decl: method, skipMethodBody: false)
       }
     }

--- a/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
+++ b/Sources/JExtractSwiftLib/Swift2JavaVisitor.swift
@@ -213,11 +213,6 @@ final class Swift2JavaVisitor {
       functionSignature: signature,
     )
 
-    if typeContext?.swiftNominal.isGeneric == true && typeContext?.isSpecialization != true && imported.isStatic {
-      log.debug("Skip importing static function in generic type: '\(node.qualifiedNameForDebug)'")
-      return
-    }
-
     log.debug("Record imported method \(node.qualifiedNameForDebug)")
     if let typeContext {
       typeContext.methods.append(imported)
@@ -450,11 +445,6 @@ final class Swift2JavaVisitor {
       apiKind: kind,
       functionSignature: signature,
     )
-
-    if typeContext?.swiftNominal.isGeneric == true && typeContext?.isSpecialization != true && imported.isStatic {
-      log.debug("Skip importing static accessor in generic type: '\(node.qualifiedNameForDebug)'")
-      return
-    }
 
     log.debug(
       "Record imported variable accessor \(kind == .getter || kind == .subscriptGetter ? "getter" : "setter"):\(node.qualifiedNameForDebug)"

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
@@ -215,6 +215,39 @@ struct JNIGenericTypeTests {
   }
 
   @Test
+  func generateOpenerForGenericStaticMethod() throws {
+    let input =
+      #"""
+      public struct Box<Element> {
+        public static func describeElement() -> String {
+          "\(Element.self)"
+        }
+      }
+      """#
+
+    try assertOutput(
+      input: input,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 2,
+      expectedChunks: [
+        """
+        protocol _SwiftModule_Box_opener {
+          static func _describeElement(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jstring?
+        }
+        """,
+        #"""
+        extension Box: _SwiftModule_Box_opener {
+          static func _describeElement(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jstring? {
+            return Box<Element>.describeElement().getJNILocalRefValue(in: environment)
+          }
+        }
+        """#,
+      ]
+    )
+  }
+
+  @Test
   func genericValueInEnumCase() throws {
     let input =
       #"""

--- a/Tests/JExtractSwiftTests/SpecializationTests.swift
+++ b/Tests/JExtractSwiftTests/SpecializationTests.swift
@@ -213,6 +213,10 @@ struct SpecializationTests {
         public func count() -> Int {
           return items.count
         }
+      
+        public static func elementDescription() -> String {
+          return "\(Element.self)"
+        }
       }
 
       public struct Fish {
@@ -226,10 +230,21 @@ struct SpecializationTests {
       input: input,
       .jni,
       .java,
-      detectChunkByInitialLines: 1,
+      detectChunkByInitialLines: 2,
       expectedChunks: [
         "public final class FishBox implements JNISwiftInstance {",
-        "public long count()",
+        """
+        public long count() {
+          return FishBox.$count(this.$memoryAddress(), this.$typeMetadataAddress());
+        }
+        private static native long $count(long selfPointer, long selfTypePointer);
+        """,
+        """
+        public static java.lang.String elementDescription() {
+          return FishBox.$elementDescription($typeMetadataAddressDowncall());
+        }
+        private static native java.lang.String $elementDescription(long selfTypePointer);
+        """
       ],
     )
   }

--- a/Tests/JExtractSwiftTests/SpecializationTests.swift
+++ b/Tests/JExtractSwiftTests/SpecializationTests.swift
@@ -213,7 +213,7 @@ struct SpecializationTests {
         public func count() -> Int {
           return items.count
         }
-      
+
         public static func elementDescription() -> String {
           return "\(Element.self)"
         }
@@ -244,7 +244,7 @@ struct SpecializationTests {
           return FishBox.$elementDescription($typeMetadataAddressDowncall());
         }
         private static native java.lang.String $elementDescription(long selfTypePointer);
-        """
+        """,
       ],
     )
   }


### PR DESCRIPTION
For types that were specialized via `typealias`, these static members were not being exported.

```swift
public struct Box<Element>: Hashable {
  ...
  // not exported for FishBox 
  public static func describeElement() -> String {
    String(describing: Element.self)
  }
}

public typealias FishBox = Box<Fish>
```

When all generic parameters are fully specialized, it should be possible to invoke these static members because `Self` can be successfully resolved from the Java side. 
This PR updates the generator to correctly support and export these static function calls.