### PR TITLE
jextract/ffm: Fix TranslatedParameter to hold a single JavaParameter

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -310,8 +310,8 @@ extension FFMSwift2JavaGenerator {
       )
     } else {
       // Otherwise, the lambda must be wrapped with the lowered function instance.
-      let apiParams = functionType.parameters.flatMap {
-        $0.javaParameters.map { param in "\(param.type) \(param.name)" }
+      let apiParams = functionType.parameters.map {
+        "\($0.parameter.type) \($0.parameter.name)"
       }
 
       printer.print(
@@ -338,7 +338,7 @@ extension FFMSwift2JavaGenerator {
         printer.indent()
         var convertedArgs: [String] = []
         for param in functionType.parameters {
-          let arg = param.conversion.render(&printer, param.javaParameters[0].name)
+          let arg = param.conversion.render(&printer, param.parameter.name)
           convertedArgs.append(arg)
         }
 
@@ -379,8 +379,7 @@ extension FFMSwift2JavaGenerator {
     if !annotationsStr.isEmpty { annotationsStr += "\n" }
 
     var paramDecls = translatedSignature.parameters
-      .flatMap(\.javaParameters)
-      .map { $0.renderParameter() }
+      .map { $0.parameter.renderParameter() }
     if translatedSignature.requiresSwiftArena {
       paramDecls.append("AllocatingSwiftArena swiftArena")
     }
@@ -435,10 +434,8 @@ extension FFMSwift2JavaGenerator {
     var downCallArguments: [String] = []
 
     // Regular parameters.
-    for (i, parameter) in translatedSignature.parameters.enumerated() {
-      let original = decl.functionSignature.parameters[i]
-      let parameterName = original.parameterName ?? "_\(i)"
-      let lowered = parameter.conversion.render(&printer, parameterName)
+    for parameter in translatedSignature.parameters {
+      let lowered = parameter.conversion.render(&printer, parameter.parameter.name)
       downCallArguments.append(lowered)
     }
 

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
@@ -42,7 +42,7 @@ extension FFMSwift2JavaGenerator {
 
   /// Represent a Swift API parameter translated to Java.
   struct TranslatedParameter {
-    /// Java parameter(s) mapped to the Swift parameter.
+    /// Java parameter mapped to the Swift parameter.
     var parameter: JavaParameter
 
     /// Describes how to convert the Java parameter to the lowered arguments for
@@ -426,9 +426,9 @@ extension FFMSwift2JavaGenerator {
           case .string:
             return TranslatedParameter(
               parameter: JavaParameter(
-                  name: parameterName,
-                  type: .javaLangString
-                ),
+                name: parameterName,
+                type: .javaLangString
+              ),
               conversion: .call(.placeholder, function: "SwiftStrings.toCString", withArena: true)
             )
 
@@ -466,19 +466,19 @@ extension FFMSwift2JavaGenerator {
 
         return TranslatedParameter(
           parameter: JavaParameter(
-              name: parameterName,
-              type: try translate(swiftType: swiftType)
-            ),
+            name: parameterName,
+            type: try translate(swiftType: swiftType)
+          ),
           conversion: .swiftValueSelfSegment(.placeholder)
         )
 
       case .tuple([]):
         return TranslatedParameter(
           parameter: JavaParameter(
-              name: parameterName,
-              type: .void,
-              annotations: parameterAnnotations
-            ),
+            name: parameterName,
+            type: .void,
+            annotations: parameterAnnotations
+          ),
           conversion: .placeholder
         )
 
@@ -495,9 +495,9 @@ extension FFMSwift2JavaGenerator {
       case .function:
         return TranslatedParameter(
           parameter: JavaParameter(
-              name: parameterName,
-              type: JavaType.class(package: nil, name: "\(methodName).\(parameterName)")
-            ),
+            name: parameterName,
+            type: JavaType.class(package: nil, name: "\(methodName).\(parameterName)")
+          ),
           conversion: .call(.placeholder, function: "\(methodName).$toUpcallStub", withArena: true)
         )
 

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaTranslation.swift
@@ -43,9 +43,7 @@ extension FFMSwift2JavaGenerator {
   /// Represent a Swift API parameter translated to Java.
   struct TranslatedParameter {
     /// Java parameter(s) mapped to the Swift parameter.
-    ///
-    /// Array because one Swift parameter can be mapped to multiple parameters.
-    var javaParameters: [JavaParameter]
+    var parameter: JavaParameter
 
     /// Describes how to convert the Java parameter to the lowered arguments for
     /// the foreign function.
@@ -255,9 +253,7 @@ extension FFMSwift2JavaGenerator {
     ) throws -> TranslatedParameter {
       if let cType = try? CType(cdeclType: type) {
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(name: parameterName, type: cType.javaType)
-          ],
+          parameter: JavaParameter(name: parameterName, type: cType.javaType),
           conversion: .placeholder
         )
       }
@@ -268,9 +264,7 @@ extension FFMSwift2JavaGenerator {
           switch knownType {
           case .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer:
             return TranslatedParameter(
-              javaParameters: [
-                JavaParameter(name: parameterName, type: .javaForeignMemorySegment)
-              ],
+              parameter: JavaParameter(name: parameterName, type: .javaForeignMemorySegment),
               conversion: .method(
                 .explodedName(component: "pointer"),
                 methodName: "reinterpret",
@@ -373,13 +367,11 @@ extension FFMSwift2JavaGenerator {
           overflowCheck = .none
         }
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(
-              name: parameterName,
-              type: javaType,
-              annotations: parameterAnnotations
-            )
-          ],
+          parameter: JavaParameter(
+            name: parameterName,
+            type: javaType,
+            annotations: parameterAnnotations
+          ),
           conversion: .placeholder,
           needs32BitIntOverflowCheck: overflowCheck
         )
@@ -389,13 +381,11 @@ extension FFMSwift2JavaGenerator {
       case .metatype:
         // Metatype are expressed as 'org.swift.swiftkit.SwiftAnyType'
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(
-              name: parameterName,
-              type: JavaType.class(package: "org.swift.swiftkit.ffm", name: "SwiftAnyType"),
-              annotations: parameterAnnotations
-            )
-          ],
+          parameter: JavaParameter(
+            name: parameterName,
+            type: JavaType.class(package: "org.swift.swiftkit.ffm", name: "SwiftAnyType"),
+            annotations: parameterAnnotations
+          ),
           conversion: .swiftValueSelfSegment(.placeholder)
         )
 
@@ -415,9 +405,7 @@ extension FFMSwift2JavaGenerator {
 
           case .unsafeRawBufferPointer, .unsafeMutableRawBufferPointer:
             return TranslatedParameter(
-              javaParameters: [
-                JavaParameter(name: parameterName, type: .javaForeignMemorySegment)
-              ],
+              parameter: JavaParameter(name: parameterName, type: .javaForeignMemorySegment),
               conversion: .commaSeparated([
                 .placeholder,
                 .method(.placeholder, methodName: "byteSize", arguments: [], withArena: false),
@@ -437,20 +425,16 @@ extension FFMSwift2JavaGenerator {
 
           case .string:
             return TranslatedParameter(
-              javaParameters: [
-                JavaParameter(
+              parameter: JavaParameter(
                   name: parameterName,
                   type: .javaLangString
-                )
-              ],
+                ),
               conversion: .call(.placeholder, function: "SwiftStrings.toCString", withArena: true)
             )
 
           case .array(let element) where element == knownTypes.uint8:
             return TranslatedParameter(
-              javaParameters: [
-                JavaParameter(name: parameterName, type: .array(.byte), annotations: parameterAnnotations)
-              ],
+              parameter: JavaParameter(name: parameterName, type: .array(.byte), annotations: parameterAnnotations),
               conversion:
                 .commaSeparated([
                   .call(
@@ -481,24 +465,20 @@ extension FFMSwift2JavaGenerator {
         }
 
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(
+          parameter: JavaParameter(
               name: parameterName,
               type: try translate(swiftType: swiftType)
-            )
-          ],
+            ),
           conversion: .swiftValueSelfSegment(.placeholder)
         )
 
       case .tuple([]):
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(
+          parameter: JavaParameter(
               name: parameterName,
               type: .void,
               annotations: parameterAnnotations
-            )
-          ],
+            ),
           conversion: .placeholder
         )
 
@@ -514,12 +494,10 @@ extension FFMSwift2JavaGenerator {
 
       case .function:
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(
+          parameter: JavaParameter(
               name: parameterName,
               type: JavaType.class(package: nil, name: "\(methodName).\(parameterName)")
-            )
-          ],
+            ),
           conversion: .call(.placeholder, function: "\(methodName).$toUpcallStub", withArena: true)
         )
 
@@ -578,22 +556,17 @@ extension FFMSwift2JavaGenerator {
           genericParameters: genericParameters,
           genericRequirements: genericRequirements
         )
-        guard elementTranslated.javaParameters.count == 1 else {
-          throw JavaTranslationError.unhandledType(element.type)
-        }
         let extraction = JavaConversionStep.replacingPlaceholder(
           elementTranslated.conversion,
           placeholder: "\(parameterName).$\(idx)"
         )
         elementConversions.append(extraction)
-        elementJavaTypes.append(elementTranslated.javaParameters[0].type.javaType)
+        elementJavaTypes.append(elementTranslated.parameter.type.javaType)
       }
 
       let javaType: JavaType = .tuple(elementTypes: elementJavaTypes)
       return TranslatedParameter(
-        javaParameters: [
-          JavaParameter(name: parameterName, type: javaType)
-        ],
+        parameter: JavaParameter(name: parameterName, type: javaType),
         conversion: .commaSeparated(elementConversions)
       )
     }
@@ -624,9 +597,7 @@ extension FFMSwift2JavaGenerator {
           default: throw JavaTranslationError.unhandledType(known: .optional(swiftType))
           }
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(name: parameterName, type: JavaType(className: translatedClass))
-          ],
+          parameter: JavaParameter(name: parameterName, type: JavaType(className: translatedClass)),
           conversion: .call(.placeholder, function: "SwiftRuntime.\(lowerFunc)", withArena: true)
         )
       }
@@ -646,9 +617,7 @@ extension FFMSwift2JavaGenerator {
 
         let translatedTy = try self.translate(swiftType: swiftType)
         return TranslatedParameter(
-          javaParameters: [
-            JavaParameter(name: parameterName, type: JavaType(className: "Optional<\(translatedTy.description)>"))
-          ],
+          parameter: JavaParameter(name: parameterName, type: .optional(translatedTy)),
           conversion: .call(.placeholder, function: "SwiftRuntime.toOptionalSegmentInstance", withArena: false)
         )
       case .existential, .opaque, .genericParameter:

--- a/Tests/JExtractSwiftTests/DataImportTests.swift
+++ b/Tests/JExtractSwiftTests/DataImportTests.swift
@@ -471,7 +471,7 @@ final class DataImportTests {
          * public func receiveDataProtocol<T: DataProtocol>(dat: some DataProtocol, dat2: T?)
          * }
          */
-        public static void receiveDataProtocol(Data dat, Optional<Data> dat2) {
+        public static void receiveDataProtocol(Data dat, java.util.Optional<Data> dat2) {
           swiftjava_SwiftModule_receiveDataProtocol_dat_dat2.call(dat.$memorySegment(), SwiftRuntime.toOptionalSegmentInstance(dat2));
         }
         """,

--- a/Tests/JExtractSwiftTests/OptionalImportTests.swift
+++ b/Tests/JExtractSwiftTests/OptionalImportTests.swift
@@ -147,7 +147,7 @@ final class OptionalImportTests {
          * public func receiveOptionalDataProto(_ arg: (some DataProtocol)?)
          * }
          */
-        public static void receiveOptionalDataProto(Optional<Data> arg) {
+        public static void receiveOptionalDataProto(java.util.Optional<Data> arg) {
           swiftjava_SwiftModule_receiveOptionalDataProto__.call(SwiftRuntime.toOptionalSegmentInstance(arg));
         }
         """,


### PR DESCRIPTION
This is a minor refactoring to fix the property type of `javaParameters` in the FFM-side `TranslatedParameter`.

Currently, it is defined as an array. However, I believe this is incorrect.
This type represents the Java function interface that the user interacts with, meaning it is not yet "lowered". Therefore, the parameter count should always match the number of Swift arguments.

In practice, there wasn't a place in the codebase where multiple parameters were actually being used.

This PR changes the property to hold a single `JavaParameter`.
This aligns the implementation with the JNI side.