### PR TITLE
Detect double destruction and generalize $createDestroyFunction

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -383,8 +383,6 @@ extension JNISwift2JavaGenerator {
         """
       )
       printer.println()
-
-      printDestroyFunction(&printer, decl)
     }
   }
 
@@ -872,58 +870,6 @@ extension JNISwift2JavaGenerator {
         // INFO: We are omitting `CallTraces.traceDowncall` here.
         // It internally calls `toString`, which in turn calls `$typeMetadataAddress`, creating an infinite loop.
         printer.print("return \(type.effectiveJavaSimpleName).$typeMetadataAddressDowncall();")
-      }
-    }
-  }
-
-  /// Prints the destroy function for a `JNISwiftInstance`
-  private func printDestroyFunction(_ printer: inout CodePrinter, _ type: ImportedNominalType) {
-    let funcName = "$createDestroyFunction"
-    let isEffectivelyGeneric = type.swiftNominal.isGeneric && !type.isSpecialization
-    let typeName = type.effectiveJavaSimpleName
-    printer.print("@Override")
-    printer.printBraceBlock("public Runnable \(funcName)()") { printer in
-      printer.print("long self$ = this.$memoryAddress();")
-      printer.print("long selfType$ = this.$typeMetadataAddress();")
-      if isEffectivelyGeneric {
-        printer.print(
-          """
-          if (CallTraces.TRACE_DOWNCALLS) {
-            CallTraces.traceDowncall("\(typeName).\(funcName)",
-                "this", this,
-                "self", self$,
-                "selfType", selfType$);
-          }
-          return new Runnable() {
-            @Override
-            public void run() {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall("\(typeName).$destroy", "self", self$, "selfType", selfType$);
-              }
-              SwiftObjects.destroy(self$, selfType$);
-            }
-          };
-          """
-        )
-      } else {
-        printer.print(
-          """
-          if (CallTraces.TRACE_DOWNCALLS) {
-            CallTraces.traceDowncall("\(typeName).\(funcName)",
-                "this", this,
-                "self", self$);
-          }
-          return new Runnable() {
-            @Override
-            public void run() {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall("\(typeName).$destroy", "self", self$);
-              }
-              SwiftObjects.destroy(self$, selfType$);
-            }
-          };
-          """
-        )
       }
     }
   }

--- a/Sources/SwiftJava/SwiftObjects.swift
+++ b/Sources/SwiftJava/SwiftObjects.swift
@@ -89,4 +89,13 @@ extension SwiftObjects {
     }
     return perform(as: typeMetadata)
   }
+
+  @JavaMethod
+  public static func typeDescription(environment: UnsafeMutablePointer<JNIEnv?>!, selfTypePointer: Int64) -> String {
+    guard let selfType$ = UnsafeRawPointer(bitPattern: Int(selfTypePointer)) else {
+      fatalError("selfType metadata address was null")
+    }
+    let typeMetadata = unsafeBitCast(selfType$, to: Any.Type.self)
+    return String(describing: typeMetadata)
+  }
 }

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstance.java
@@ -27,15 +27,38 @@ public interface JNISwiftInstance extends SwiftInstance {
      *
      * @return a function that is called when the value should be destroyed.
      */
-    Runnable $createDestroyFunction();
+    default Runnable $createDestroyFunction() {
+        var memoryAddress = $memoryAddress();
+        var typeMetadataAddress = $typeMetadataAddress();
+        if (CallTraces.TRACE_DOWNCALLS) {
+            CallTraces.trace(
+                    "this", this,
+                    "self", memoryAddress,
+                    "selfType", SwiftObjects.typeDescription(typeMetadataAddress)
+            );
+        }
+        return () -> {
+            if (CallTraces.TRACE_DOWNCALLS) {
+                CallTraces.traceDowncall(
+                        "SwiftObjects.destroy",
+                        "self", memoryAddress,
+                        "selfType", SwiftObjects.typeDescription(typeMetadataAddress)
+                );
+            }
+            SwiftObjects.destroy(memoryAddress, typeMetadataAddress);
+        };
+    }
 
+    /**
+     * The Swift type metadata address of this type.
+     */
     long $typeMetadataAddress();
 
     @Override
     default SwiftInstanceCleanup $createCleanup() {
-        var statusDestroyedFlag = $statusDestroyedFlag();
-        Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
-
-        return new JNISwiftInstanceCleanup(this.$createDestroyFunction(), markAsDestroyed);
+        return new JNISwiftInstanceCleanup(
+                $createDestroyFunction(),
+                $statusDestroyedFlag()
+        );
     }
 }

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstanceCleanup.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/JNISwiftInstanceCleanup.java
@@ -14,18 +14,23 @@
 
 package org.swift.swiftkit.core;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 class JNISwiftInstanceCleanup implements SwiftInstanceCleanup {
     private final Runnable destroyFunction;
-    private final Runnable markAsDestroyed;
+    private final AtomicBoolean statusDestroyedFlag;
 
-    public JNISwiftInstanceCleanup(Runnable destroyFunction, Runnable markAsDestroyed) {
+    public JNISwiftInstanceCleanup(Runnable destroyFunction, AtomicBoolean statusDestroyedFlag) {
         this.destroyFunction = destroyFunction;
-        this.markAsDestroyed = markAsDestroyed;
+        this.statusDestroyedFlag = statusDestroyedFlag;
     }
 
     @Override
     public void run() {
-        markAsDestroyed.run();
-        destroyFunction.run();
+        if (statusDestroyedFlag.compareAndSet(false, true)) {
+            destroyFunction.run();
+        } else {
+            throw new IllegalStateException("Double destruction attempt detected!");
+        }
     }
 }

--- a/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftObjects.java
+++ b/SwiftKitCore/src/main/java/org/swift/swiftkit/core/SwiftObjects.java
@@ -28,4 +28,5 @@ public class SwiftObjects {
     public static native String toString(long selfPointer, long selfTypePointer);
     public static native String toDebugString(long selfPointer, long selfTypePointer);
     public static native void destroy(long selfPointer, long selfTypePointer);
+    public static native String typeDescription(long selfTypePointer);
 }

--- a/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftErrorInstance.java
+++ b/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftErrorInstance.java
@@ -61,13 +61,10 @@ public abstract class FFMSwiftErrorInstance extends Exception implements SwiftIn
 
     @Override
     public SwiftInstanceCleanup $createCleanup() {
-        var statusDestroyedFlag = $statusDestroyedFlag();
-        Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
-
         return new FFMSwiftInstanceCleanup(
                 $memorySegment(),
                 $swiftType(),
-                markAsDestroyed
+                $statusDestroyedFlag()
         );
     }
 }

--- a/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftInstance.java
+++ b/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftInstance.java
@@ -70,13 +70,10 @@ public abstract class FFMSwiftInstance implements SwiftInstance {
 
     @Override
     public SwiftInstanceCleanup $createCleanup() {
-        var statusDestroyedFlag = $statusDestroyedFlag();
-        Runnable markAsDestroyed = () -> statusDestroyedFlag.set(true);
-
         return new FFMSwiftInstanceCleanup(
                 $memorySegment(),
                 $swiftType(),
-                markAsDestroyed
+                $statusDestroyedFlag()
         );
     }
 

--- a/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftInstanceCleanup.java
+++ b/SwiftKitFFM/src/main/java/org/swift/swiftkit/ffm/FFMSwiftInstanceCleanup.java
@@ -19,26 +19,29 @@ import org.swift.swiftkit.core.SwiftInstanceCleanup;
 import static org.swift.swiftkit.ffm.SwiftJavaLogGroup.LIFECYCLE;
 
 import java.lang.foreign.MemorySegment;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FFMSwiftInstanceCleanup implements SwiftInstanceCleanup {
     private final MemorySegment memoryAddress;
     private final SwiftAnyType type;
-    private final Runnable markAsDestroyed;
+    private final AtomicBoolean statusDestroyedFlag;
 
-    public FFMSwiftInstanceCleanup(MemorySegment memoryAddress, SwiftAnyType type, Runnable markAsDestroyed) {
+    public FFMSwiftInstanceCleanup(MemorySegment memoryAddress, SwiftAnyType type, AtomicBoolean statusDestroyedFlag) {
         this.memoryAddress = memoryAddress;
         this.type = type;
-        this.markAsDestroyed = markAsDestroyed;
+        this.statusDestroyedFlag = statusDestroyedFlag;
     }
 
     @Override
     public void run() {
-        markAsDestroyed.run();
-
-        // Allow null pointers just for AutoArena tests.
-        if (type != null && memoryAddress != null) {
-            SwiftRuntime.log(LIFECYCLE, "Destroy swift value [" + type.getSwiftName() + "]: " + memoryAddress);
-            SwiftValueWitnessTable.destroy(type, memoryAddress);
+        if (statusDestroyedFlag.compareAndSet(false, true)) {
+            // Allow null pointers just for AutoArena tests.
+            if (type != null && memoryAddress != null) {
+                SwiftRuntime.log(LIFECYCLE, "Destroy swift value [" + type.getSwiftName() + "]: " + memoryAddress);
+                SwiftValueWitnessTable.destroy(type, memoryAddress);
+            }
+        } else {
+            throw new IllegalStateException("Double destruction attempt detected!");
         }
     }
 }

--- a/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassTests.swift
@@ -97,33 +97,6 @@ struct JNIClassTests {
         """,
       ]
     )
-    try assertOutput(
-      input: source,
-      .jni,
-      .java,
-      expectedChunks: [
-        """
-        @Override
-        public Runnable $createDestroyFunction() {
-          long self$ = this.$memoryAddress();
-          long selfType$ = this.$typeMetadataAddress();
-          if (CallTraces.TRACE_DOWNCALLS) {
-            CallTraces.traceDowncall("MyClass.$createDestroyFunction",
-                "this", this,
-                "self", self$);
-          }
-          return new Runnable() {
-            @Override
-            public void run() {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall("MyClass.$destroy", "self", self$);
-              }
-              SwiftObjects.destroy(self$, selfType$);
-            }
-          };
-        """
-      ]
-    )
   }
 
   @Test

--- a/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEnumTests.swift
@@ -83,27 +83,6 @@ struct JNIEnumTests {
           return new MyEnum(selfPointer, swiftArena);
         }
         """,
-        """
-        @Override
-        public Runnable $createDestroyFunction() {
-          long self$ = this.$memoryAddress();
-          long selfType$ = this.$typeMetadataAddress();
-          if (CallTraces.TRACE_DOWNCALLS) {
-            CallTraces.traceDowncall("MyEnum.$createDestroyFunction",
-                "this", this,
-                "self", self$);
-          }
-          return new Runnable() {
-            @Override
-            public void run() {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall("MyEnum.$destroy", "self", self$);
-              }
-              SwiftObjects.destroy(self$, selfType$);
-            }
-          };
-        }
-        """,
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
@@ -76,28 +76,6 @@ struct JNIGenericTypeTests {
           return this.selfTypePointer;
         }
         """,
-        """
-        @Override
-        public Runnable $createDestroyFunction() {
-          long self$ = this.$memoryAddress();
-          long selfType$ = this.$typeMetadataAddress();
-          if (CallTraces.TRACE_DOWNCALLS) {
-            CallTraces.traceDowncall("MyID.$createDestroyFunction",
-              "this", this,
-              "self", self$,
-              "selfType", selfType$);
-          }
-          return new Runnable() {
-            @Override
-            public void run() {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall("MyID.$destroy", "self", self$, "selfType", selfType$);
-              }
-              SwiftObjects.destroy(self$, selfType$);
-            }
-          };
-        }
-        """,
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIStructTests.swift
@@ -83,34 +83,6 @@ struct JNIStructTests {
         """,
       ]
     )
-    try assertOutput(
-      input: source,
-      .jni,
-      .java,
-      expectedChunks: [
-        """
-        @Override
-        public Runnable $createDestroyFunction() {
-          long self$ = this.$memoryAddress();
-          long selfType$ = this.$typeMetadataAddress();
-          if (CallTraces.TRACE_DOWNCALLS) {
-            CallTraces.traceDowncall("MyStruct.$createDestroyFunction",
-                "this", this,
-                "self", self$);
-          }
-          return new Runnable() {
-            @Override
-            public void run() {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall("MyStruct.$destroy", "self", self$);
-              }
-              SwiftObjects.destroy(self$, selfType$);
-            }
-          };
-        }
-        """
-      ]
-    )
   }
 
   @Test


### PR DESCRIPTION
This PR introduces two improvements to the destruction process of Swift instances.

### 1. Detect double destruction

Currently, if a double destruction occurs due to an implementation error, the process simply crashes without any diagnostics.
To throw an error, this PR passes the `statusDestroyedFlag` directly to the cleanup instance instead of `markAsDestroyed`.

### 2. Generalize `$createDestroyFunction`

Previously, a unique `destroy` function was generated for each individual class.
However, we have transitioned to a shared invocation of `SwiftObjects.destroy` (in #582 ).
Since there is no longer a reason to generate a separate `$createDestroyFunction` implementation for every single class, this PR provides a default implementation to minimize the footprint of the generated code.

Note: Unlike the FFM side, `$createDestroyFunction` is still required here because certain classes still implement their own custom `destroy` logic.