### PR TITLE
jextract/jni: Propagate generic parameters to Case types of generic enums

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -494,7 +494,14 @@ extension JNISwift2JavaGenerator {
       return
     }
 
-    printer.printBraceBlock("public sealed interface Case") { printer in
+    let caseGenericClause =
+      if decl.genericParameterNames.isEmpty {
+        ""
+      } else {
+        "<\(decl.genericParameterNames.joined(separator: ", "))>"
+      }
+
+    printer.printBraceBlock("public sealed interface Case\(caseGenericClause)") { printer in
       for enumCase in decl.cases {
         guard let translatedCase = self.translatedEnumCase(for: enumCase) else {
           continue
@@ -505,7 +512,7 @@ extension JNISwift2JavaGenerator {
         }
 
         // Print record
-        printer.print("record \(translatedCase.name)(\(members.joined(separator: ", "))) implements Case {}")
+        printer.print("record \(translatedCase.name)\(caseGenericClause)(\(members.joined(separator: ", "))) implements Case\(caseGenericClause) {}")
       }
     }
     printer.println()
@@ -514,13 +521,13 @@ extension JNISwift2JavaGenerator {
       self.translatedEnumCase(for: $0)
     }.contains(where: \.requiresSwiftArena)
 
-    printer.printBraceBlock("public Case getCase(\(requiresSwiftArena ? "SwiftArena swiftArena" : ""))") { printer in
+    printer.printBraceBlock("public Case\(caseGenericClause) getCase(\(requiresSwiftArena ? "SwiftArena swiftArena" : ""))") { printer in
       printer.printBraceBlock("return switch (this.getDiscriminator())", .semicolonNewLine) { printer in
         for enumCase in decl.cases {
           if let translatedCase = self.translatedEnumCase(for: enumCase) {
             if enumCase.parameters.isEmpty {
               printer.print(
-                "case \(enumCase.name.uppercased()) -> new Case.\(translatedCase.name)();"
+                "case \(enumCase.name.uppercased()) -> new Case.\(translatedCase.name)\(caseGenericClause)();"
               )
             } else {
               let arenaArgument = translatedCase.requiresSwiftArena ? "swiftArena" : ""
@@ -552,12 +559,16 @@ extension JNISwift2JavaGenerator {
   }
 
   private func printEnumCases(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
+    let caseTypeParameters: [JavaType] = decl.genericParameterNames.map {
+      .class(package: nil, name: $0)
+    }
+
     for enumCase in decl.cases {
       guard let translatedCase = self.translatedEnumCase(for: enumCase) else {
         continue
       }
 
-      let caseType = JavaType.class(package: nil, name: "Case.\(translatedCase.name)")
+      let caseType = JavaType.class(package: nil, name: "Case.\(translatedCase.name)", typeParameters: caseTypeParameters)
       let resultType = JavaType.optional(caseType)
       if let getAsCaseFunctionDecl = translatedCase.getAsCaseFunction,
         var getAsCaseFunction = self.translatedDecl(for: getAsCaseFunctionDecl)
@@ -591,7 +602,7 @@ extension JNISwift2JavaGenerator {
             if (getDiscriminator() != Discriminator.\(enumCase.name.uppercased())) {
               return java.util.Optional.empty();
             }
-            return java.util.Optional.of(new Case.\(translatedCase.name)());
+            return java.util.Optional.of(new Case.\(translatedCase.name)\(caseTypeParameters.isEmpty ? "" : "<>")());
           }
           """
         )

--- a/Sources/SwiftJavaToolLib/JavaTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaTranslator.swift
@@ -158,7 +158,8 @@ extension JavaTranslator {
     substitution: SubstitutionMap?,
     preferValueTypes: Bool,
     outerOptional: OptionalKind,
-    eraseTypeArguments: Bool = false
+    eraseTypeArguments: Bool = false,
+    eraseRawOwnerTypeArguments: Bool = false
   ) throws -> String {
     // Replace if it is a type variable and we have a substitution for it.
     let javaType = substitution?.resolve(javaType) ?? javaType
@@ -181,7 +182,9 @@ extension JavaTranslator {
         bound,
         substitution: substitution,
         preferValueTypes: preferValueTypes,
-        outerOptional: outerOptional
+        outerOptional: outerOptional,
+        eraseTypeArguments: eraseTypeArguments,
+        eraseRawOwnerTypeArguments: eraseRawOwnerTypeArguments
       )
     }
 
@@ -192,7 +195,9 @@ extension JavaTranslator {
           arrayType.getGenericComponentType()!,
           substitution: substitution,
           preferValueTypes: preferValueTypes,
-          outerOptional: .optional
+          outerOptional: .optional,
+          eraseTypeArguments: eraseTypeArguments,
+          eraseRawOwnerTypeArguments: eraseRawOwnerTypeArguments
         )
         return "[\(elementType)]"
       }
@@ -213,7 +218,9 @@ extension JavaTranslator {
           rawJavaType,
           substitution: substitution,
           preferValueTypes: false,
-          outerOptional: outerOptional
+          outerOptional: outerOptional,
+          eraseTypeArguments: false,
+          eraseRawOwnerTypeArguments: false
         )
 
         let optionalSuffix: String
@@ -225,34 +232,16 @@ extension JavaTranslator {
         }
 
         if let ownerType = parameterizedType.getOwnerType() {
-          var ownerSwiftType = try getSwiftTypeNameAsString(
-            method: method,
-            ownerType,
-            substitution: substitution,
-            preferValueTypes: false,
-            outerOptional: .nonoptional,
-            eraseTypeArguments: eraseTypeArguments
-          )
-
-          if ownerType.as(ParameterizedType.self) == nil,
-            let ownerClass = ownerType.as(JavaClass<JavaObject>.self),
-            ownerClass.getDeclaringClass() != nil
-          {
-            var ownerTypeArguments: [String] = []
-            for typeParam in ownerClass.getTypeParameters() {
-              guard let typeParam else { continue }
-              if eraseTypeArguments {
-                ownerTypeArguments.append("JavaObject")
-              } else {
-                ownerTypeArguments.append(typeParam.getName())
-              }
-            }
-
-            if !ownerTypeArguments.isEmpty {
-              ownerSwiftType += "<\(ownerTypeArguments.joined(separator: ", "))>"
-            }
-          }
-
+          let ownerSwiftType =
+            try getSwiftTypeNameAsString(
+              method: method,
+              ownerType,
+              substitution: substitution,
+              preferValueTypes: false,
+              outerOptional: .nonoptional,
+              eraseTypeArguments: eraseTypeArguments,
+              eraseRawOwnerTypeArguments: ownerType.is(JavaClass<JavaObject>.self)
+            )
           rawSwiftType = "\(ownerSwiftType).\(rawSwiftType.splitSwiftTypeName().name)"
         }
 
@@ -267,7 +256,9 @@ extension JavaTranslator {
             typeArg,
             substitution: substitution,
             preferValueTypes: false,
-            outerOptional: .nonoptional
+            outerOptional: .nonoptional,
+            eraseTypeArguments: eraseTypeArguments,
+            eraseRawOwnerTypeArguments: eraseRawOwnerTypeArguments
           )
 
           // FIXME: improve the get instead...
@@ -297,7 +288,25 @@ extension JavaTranslator {
       throw TranslationError.unhandledJavaType(javaType)
     }
 
-    let (swiftName, isOptional) = try getSwiftTypeName(javaClass, preferValueTypes: preferValueTypes)
+    var (swiftName, isOptional) = try getSwiftTypeName(javaClass, preferValueTypes: preferValueTypes)
+    if eraseRawOwnerTypeArguments, let declaringClass = javaClass.getDeclaringClass() {
+      let ownerSwiftType = try getSwiftTypeNameAsString(
+        declaringClass.as(Type.self),
+        substitution: substitution,
+        preferValueTypes: preferValueTypes,
+        outerOptional: .nonoptional,
+        eraseTypeArguments: eraseTypeArguments,
+        eraseRawOwnerTypeArguments: true
+      )
+      swiftName = "\(ownerSwiftType).\(swiftName.splitSwiftTypeName().name)"
+    }
+
+    if eraseTypeArguments || eraseRawOwnerTypeArguments {
+      let typeParameterCount = javaClass.getTypeParameters().count
+      if typeParameterCount > 0 {
+        swiftName += "<\((0..<typeParameterCount).map { _ in "JavaObject" }.joined(separator: ", "))>"
+      }
+    }
     let resultString =
       if isOptional {
         outerOptional.adjustTypeName(swiftName)

--- a/Sources/SwiftJavaToolLib/JavaTranslator.swift
+++ b/Sources/SwiftJavaToolLib/JavaTranslator.swift
@@ -224,6 +224,38 @@ extension JavaTranslator {
           optionalSuffix = ""
         }
 
+        if let ownerType = parameterizedType.getOwnerType() {
+          var ownerSwiftType = try getSwiftTypeNameAsString(
+            method: method,
+            ownerType,
+            substitution: substitution,
+            preferValueTypes: false,
+            outerOptional: .nonoptional,
+            eraseTypeArguments: eraseTypeArguments
+          )
+
+          if ownerType.as(ParameterizedType.self) == nil,
+            let ownerClass = ownerType.as(JavaClass<JavaObject>.self),
+            ownerClass.getDeclaringClass() != nil
+          {
+            var ownerTypeArguments: [String] = []
+            for typeParam in ownerClass.getTypeParameters() {
+              guard let typeParam else { continue }
+              if eraseTypeArguments {
+                ownerTypeArguments.append("JavaObject")
+              } else {
+                ownerTypeArguments.append(typeParam.getName())
+              }
+            }
+
+            if !ownerTypeArguments.isEmpty {
+              ownerSwiftType += "<\(ownerTypeArguments.joined(separator: ", "))>"
+            }
+          }
+
+          rawSwiftType = "\(ownerSwiftType).\(rawSwiftType.splitSwiftTypeName().name)"
+        }
+
         let typeArguments: [String] = try parameterizedType.getActualTypeArguments().compactMap { typeArg in
           guard let typeArg else { return nil }
           if eraseTypeArguments {
@@ -250,6 +282,10 @@ extension JavaTranslator {
           }
 
           return mappedSwiftName
+        }
+
+        if typeArguments.isEmpty {
+          return "\(rawSwiftType)\(optionalSuffix)"
         }
 
         return "\(rawSwiftType)<\(typeArguments.joined(separator: ", "))>\(optionalSuffix)"

--- a/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIGenericTypeTests.swift
@@ -319,15 +319,15 @@ struct JNIGenericTypeTests {
         }
         """,
         """
-        public sealed interface Case {
-          record None() implements Case {}
+        public sealed interface Case<Wrapped> {
+          record None<Wrapped>() implements Case<Wrapped> {}
         }
         """,
         """
-        public Case getCase() {
+        public Case<Wrapped> getCase() {
           return switch (this.getDiscriminator()) {
            case SOME -> throw new UnsupportedOperationException("MyOptional.some contains unsupported values.");
-           case NONE -> new Case.None();
+           case NONE -> new Case.None<Wrapped>();
           };
         }
         """,

--- a/Tests/SwiftJavaToolLibTests/JavaTranslatorTests.swift
+++ b/Tests/SwiftJavaToolLibTests/JavaTranslatorTests.swift
@@ -62,11 +62,42 @@ class JavaTranslatorTests: XCTestCase {
       """
       package com.example;
 
+      class MyString {}
+      class MyInt {}
+
+      class Outer<T> {
+        class Inner<U> {
+        }
+
+        Outer<MyString>.Inner<MyInt> foo() { return null; }
+        Outer<MyInt>.Inner<T> bar() { return null; }
+      }
+      """
+    )
+
+    try assertWrapJavaOutput(
+      javaClassNames: [
+        "com.example.MyString",
+        "com.example.MyInt",
+        "com.example.Outer$Inner",
+        "com.example.Outer",
+      ],
+      classpath: [classpathURL],
+      expectedChunks: [
+        "func foo() -> Outer<MyString>.Inner<MyInt>!",
+        "func bar() -> Outer<MyInt>.Inner<T>!",
+      ]
+    )
+  }
+
+  func testTranslateNestedParameterizedStaticTypes() async throws {
+    let classpathURL = try await compileJava(
+      """
+      package com.example;
+
       class MyOptional<Wrapped> {
         interface Case<Wrapped> {
-          final class None<Wrapped> implements Case<Wrapped> {
-            None() {}
-          }
+          record None<Wrapped>() implements Case<Wrapped> {}
         }
 
         Case<Wrapped> getCase() { return null; }
@@ -87,8 +118,8 @@ class JavaTranslatorTests: XCTestCase {
       ],
       classpath: [classpathURL],
       expectedChunks: [
-        "func getCase() -> MyOptional.Case<Wrapped>!",
-        "func getAsNone() -> MyOptional.Case<Wrapped>.None<Wrapped>!",
+        "func getCase() -> MyOptional<JavaObject>.Case<Wrapped>!",
+        "func getAsNone() -> MyOptional<JavaObject>.Case<JavaObject>.None<Wrapped>!",
       ]
     )
   }

--- a/Tests/SwiftJavaToolLibTests/JavaTranslatorTests.swift
+++ b/Tests/SwiftJavaToolLibTests/JavaTranslatorTests.swift
@@ -22,7 +22,7 @@ import XCTest // NOTE: Workaround for https://github.com/swiftlang/swift-java/is
 
 class JavaTranslatorTests: XCTestCase {
 
-  func testTranslateGenericMethodParameters() async throws {
+  func translateGenericMethodParameters() async throws {
     let classpathURL = try await compileJava(
       """
       package com.example;

--- a/Tests/SwiftJavaToolLibTests/JavaTranslatorTests.swift
+++ b/Tests/SwiftJavaToolLibTests/JavaTranslatorTests.swift
@@ -22,7 +22,7 @@ import XCTest // NOTE: Workaround for https://github.com/swiftlang/swift-java/is
 
 class JavaTranslatorTests: XCTestCase {
 
-  func translateGenericMethodParameters() async throws {
+  func testTranslateGenericMethodParameters() async throws {
     let classpathURL = try await compileJava(
       """
       package com.example;
@@ -55,5 +55,41 @@ class JavaTranslatorTests: XCTestCase {
     ) { translator in
 
     }
+  }
+
+  func testTranslateNestedParameterizedTypes() async throws {
+    let classpathURL = try await compileJava(
+      """
+      package com.example;
+
+      class MyOptional<Wrapped> {
+        interface Case<Wrapped> {
+          final class None<Wrapped> implements Case<Wrapped> {
+            None() {}
+          }
+        }
+
+        Case<Wrapped> getCase() { return null; }
+        Case.None<Wrapped> getAsNone() { return null; }
+      }
+      """
+    )
+
+    try assertWrapJavaOutput(
+      javaClassNames: [
+        "com.example.MyOptional$Case",
+        "com.example.MyOptional$Case$None",
+        "com.example.MyOptional",
+      ],
+      classNameMappings: [
+        "com.example.MyOptional$Case": "MyOptional.Case",
+        "com.example.MyOptional$Case$None": "MyOptional.Case.None",
+      ],
+      classpath: [classpathURL],
+      expectedChunks: [
+        "func getCase() -> MyOptional.Case<Wrapped>!",
+        "func getAsNone() -> MyOptional.Case<Wrapped>.None<Wrapped>!",
+      ]
+    )
   }
 }


### PR DESCRIPTION

This PR is the first step toward supporting the extraction of generic associated values from generic enum.


Currently, the generated `Case` types for generic enums do not carry generic parameters.
While this isn't causing immediate issues, these parameters will be necessary in the future when we want to extract generic associated values from the `Case`.

```java
public sealed interface Case {
  // `Wrapped` is not usable from the static context
  record Some(Wrapped arg0) implements Case {}
  record None() implements Case {}
}
```

This PR focuses solely on propagating the generic parameters of the enum type down to its `Case` type. 

During this work, I encountered and fixed an issue in wrap-java where translation was failing when a nested type's parent type was generic.

---

## Note

I have loved contributing to `swift-java` for a half year, but unfortunately, I have run out of time to continue doing so.
While I will keep following the development of `swift-java`, I won't be able to actively contribute as I did before. 

Thank you so much for all your valuable code reviews.
