### PR TITLE
CI: Optimize builds and cancel in flight builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -243,6 +243,26 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare CI Environment
         uses: ./.github/actions/prepare_env
+      - name: Compute sample cache hash
+        id: sample_hash
+        shell: bash
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then SUM="sha256sum"; else SUM="shasum -a 256"; fi
+          hash="$( {
+            find Sources Plugins -type f -name '*.swift' 2>/dev/null
+            find "Samples/${{ matrix.sample_app }}" -type f \( -name '*.swift' -o -name '*.config' -o -name 'Package.swift' -o -name 'ci-validate.sh' \) 2>/dev/null
+            printf '%s\n' Package.swift Package.resolved
+          } | LC_ALL=C sort -u | xargs $SUM 2>/dev/null | $SUM | cut -d' ' -f1 )"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+      - name: Cache sample .build
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: Samples/${{ matrix.sample_app }}/.build
+          key: ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-${{ steps.sample_hash.outputs.hash }}
+          restore-keys: |
+            ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-
+            ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-
       - name: "Verify sample: ${{ matrix.sample_app }}"
         run: .github/scripts/validate_sample.sh Samples/${{ matrix.sample_app }}
 
@@ -273,6 +293,26 @@ jobs:
         run: ./.github/scripts/install_swiftly.sh
         env:
           SWIFT_VERSION: "${{ matrix.swift_version }}"
+      - name: Compute sample cache hash
+        id: sample_hash
+        shell: bash
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then SUM="sha256sum"; else SUM="shasum -a 256"; fi
+          hash="$( {
+            find Sources Plugins -type f -name '*.swift' 2>/dev/null
+            find "Samples/${{ matrix.sample_app }}" -type f \( -name '*.swift' -o -name '*.config' -o -name 'Package.swift' -o -name 'ci-validate.sh' \) 2>/dev/null
+            printf '%s\n' Package.swift Package.resolved
+          } | LC_ALL=C sort -u | xargs $SUM 2>/dev/null | $SUM | cut -d' ' -f1 )"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+      - name: Cache sample .build
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: Samples/${{ matrix.sample_app }}/.build
+          key: ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-${{ steps.sample_hash.outputs.hash }}
+          restore-keys: |
+            ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-
+            ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-
       - name: "Verify sample ${{ matrix.sample_app }}"
         run: .github/scripts/validate_sample.sh Samples/${{ matrix.sample_app }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        swift_version: ['6.2', '6.3', 'nightly']
+        swift_version: ['6.3', 'nightly']
         os_version: ['jammy']
         jdk_vendor: ['corretto']
     container:
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        swift_version: ['6.2', '6.3']
+        swift_version: ['6.3']
         os_version: ['macos']
         jdk_vendor: ['corretto']
     env:
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['6.1.3', '6.2', '6.3', 'nightly']
+        swift_version: ['6.1.3', '6.3', 'nightly']
         os_version: ['jammy']
         jdk_vendor: ['corretto']
     container:
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['6.2.3', '6.3']
+        swift_version: ['6.3']
         os_version: ['macos']
         jdk_vendor: ['corretto']
     env:
@@ -225,7 +225,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['6.1.3', '6.2', '6.3', 'nightly']
+        swift_version: ['6.3']
         os_version: ['jammy']
         jdk_vendor: ['corretto']
         sample_app: [  # TODO: use a reusable-workflow to generate those names
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['6.2', '6.3']  # no nightly testing on macOS
+        swift_version: ['6.3']  # no nightly testing on macOS
         os_version: ['macos']
         jdk_vendor: ['corretto']
         sample_app: [  # TODO: use a reusable-workflow to generate those names

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -243,23 +243,12 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare CI Environment
         uses: ./.github/actions/prepare_env
-      - name: Compute sample cache hash
-        id: sample_hash
-        shell: bash
-        run: |
-          if command -v sha256sum >/dev/null 2>&1; then SUM="sha256sum"; else SUM="shasum -a 256"; fi
-          hash="$( {
-            find Sources Plugins -type f -name '*.swift' 2>/dev/null
-            find "Samples/${{ matrix.sample_app }}" -type f \( -name '*.swift' -o -name '*.config' -o -name 'Package.swift' -o -name 'ci-validate.sh' \) 2>/dev/null
-            printf '%s\n' Package.swift Package.resolved
-          } | LC_ALL=C sort -u | xargs $SUM 2>/dev/null | $SUM | cut -d' ' -f1 )"
-          echo "hash=$hash" >> "$GITHUB_OUTPUT"
       - name: Cache sample .build
         uses: actions/cache@v4
         continue-on-error: true
         with:
           path: Samples/${{ matrix.sample_app }}/.build
-          key: ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-${{ steps.sample_hash.outputs.hash }}
+          key: ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-${{ hashFiles('Sources/**/*.swift', 'Plugins/**/*.swift', 'Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-
             ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-
@@ -293,23 +282,12 @@ jobs:
         run: ./.github/scripts/install_swiftly.sh
         env:
           SWIFT_VERSION: "${{ matrix.swift_version }}"
-      - name: Compute sample cache hash
-        id: sample_hash
-        shell: bash
-        run: |
-          if command -v sha256sum >/dev/null 2>&1; then SUM="sha256sum"; else SUM="shasum -a 256"; fi
-          hash="$( {
-            find Sources Plugins -type f -name '*.swift' 2>/dev/null
-            find "Samples/${{ matrix.sample_app }}" -type f \( -name '*.swift' -o -name '*.config' -o -name 'Package.swift' -o -name 'ci-validate.sh' \) 2>/dev/null
-            printf '%s\n' Package.swift Package.resolved
-          } | LC_ALL=C sort -u | xargs $SUM 2>/dev/null | $SUM | cut -d' ' -f1 )"
-          echo "hash=$hash" >> "$GITHUB_OUTPUT"
       - name: Cache sample .build
         uses: actions/cache@v4
         continue-on-error: true
         with:
           path: Samples/${{ matrix.sample_app }}/.build
-          key: ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-${{ steps.sample_hash.outputs.hash }}
+          key: ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-${{ hashFiles('Sources/**/*.swift', 'Plugins/**/*.swift', 'Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-${{ matrix.sample_app }}-
             ${{ runner.os }}-swift${{ matrix.swift_version }}-sample-

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   soundness:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
We have too many builds now, because we test every sample and on many platforms and swift versions. This is too extreme since they don't really differ much.

- macOS only tests 6.3 Swift now
- total saved 32 jobs (53 matrix-driven jobs -> 21)

We want to cancel in progress jobs since we dont really need them; just always run on the latest pushed code immediately, freeing up resources more eagerly

We also improve build caching for the samples