### PR TITLE
Remove swift-java product from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,11 +73,6 @@ let package = Package(
       targets: ["JavaLangReflect"]
     ),
 
-    .executable(
-      name: "swift-java",
-      targets: ["swift-java"]
-    ),
-
     .library(
       name: "SwiftJavaDocumentation",
       targets: ["SwiftJavaDocumentation"]


### PR DESCRIPTION
Executable targets are already automatically promoted to products by SwiftPM.
This removes the redundant swift-java product from the package manifest.