### PR TITLE
jextract/jni: Support protocol inheritance

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/ProtocolB.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/ProtocolB.swift
@@ -27,3 +27,7 @@ public func takeGenericProtocol<First: ProtocolA, Second: ProtocolB>(_ proto1: F
 public func takeCombinedGenericProtocol<T: ProtocolA & ProtocolB>(_ proto: T) -> Int64 {
   proto.constantA + proto.constantB
 }
+
+public func takeProtocolB(_ proto: some ProtocolB) -> Int64 {
+  proto.constantB
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/ProtocolC.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/ProtocolC.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public protocol ProtocolC: ProtocolB {
+  var constantC: Int64 { get }
+}
+
+public struct ConcreteProtocolC: ProtocolC {
+  public var constantB: Int64
+  public var constantC: Int64
+  public init(b: Int64, c: Int64) {
+    constantB = b
+    constantC = c
+  }
+}

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ProtocolTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ProtocolTest.java
@@ -81,6 +81,14 @@ public class ProtocolTest {
         }
     }
 
+    @Test
+    void useChildProtocolAsParentProtocol() {
+        try (var arena = SwiftArena.ofConfined()) {
+            ProtocolC protoC = ConcreteProtocolC.init(3, 5, arena);
+            assertEquals(3, MySwiftLibrary.takeProtocolB(protoC));
+        }
+    }
+
     static class JavaStorage implements Storage {
         StorageItem item;
 

--- a/Sources/JExtractSwiftLib/Convenience/Collection+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/Collection+Extensions.swift
@@ -49,16 +49,3 @@ extension Collection where Element == Int {
     return s
   }
 }
-
-extension Sequence where Element: Hashable {
-  func uniqued() -> [Element] {
-    var seen: Set<Element> = []
-    var result: [Element] = []
-    for element in self {
-      if seen.insert(element).inserted {
-        result.append(element)
-      }
-    }
-    return result
-  }
-}

--- a/Sources/JExtractSwiftLib/Convenience/Collection+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/Collection+Extensions.swift
@@ -49,3 +49,16 @@ extension Collection where Element == Int {
     return s
   }
 }
+
+extension Sequence where Element: Hashable {
+  func uniqued() -> [Element] {
+    var seen: Set<Element> = []
+    var result: [Element] = []
+    for element in self {
+      if seen.insert(element).inserted {
+        result.append(element)
+      }
+    }
+    return result
+  }
+}

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -171,12 +171,12 @@ extension JNISwift2JavaGenerator {
   }
 
   private func printProtocol(_ printer: inout CodePrinter, _ decl: ImportedNominalType) {
-    var extends = [String]()
+    var extends = self.inheritedProtocols(of: decl).map(\.effectiveJavaSimpleName)
 
     // If we cannot generate Swift wrappers
     // that allows the user to implement the wrapped interface in Java
     // then we require only JExtracted types can conform to this.
-    if !self.interfaceProtocolWrappers.keys.contains(decl) {
+    if !self.interfaceProtocolWrappers.keys.contains(decl) && !extends.contains("JNISwiftInstance") {
       extends.append("JNISwiftInstance")
     }
     let extendsString = extends.isEmpty ? "" : " extends \(extends.joined(separator: ", "))"

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -181,13 +181,23 @@ extension JNISwift2JavaGenerator {
     _ printer: inout CodePrinter,
     _ translatedWrapper: JavaInterfaceSwiftWrapper,
   ) throws {
-    printer.printBraceBlock("protocol \(translatedWrapper.wrapperName): \(translatedWrapper.swiftName)") { printer in
+    let inheritedWrappers = self.inheritedProtocols(of: translatedWrapper.importedType).compactMap { self.interfaceProtocolWrappers[$0] }
+    let inheritedTypes = [translatedWrapper.swiftName] + inheritedWrappers.map(\.wrapperName)
+
+    printer.printBraceBlock("protocol \(translatedWrapper.wrapperName): \(inheritedTypes.joined(separator: ", "))") { printer in
       printer.print(
         "var \(translatedWrapper.javaInterfaceVariableName): \(translatedWrapper.javaInterfaceName) { get }"
       )
     }
     printer.println()
     try printer.printBraceBlock("extension \(translatedWrapper.wrapperName)") { printer in
+      for inherited in inheritedWrappers {
+        printer.printBraceBlock("var \(inherited.javaInterfaceVariableName): \(inherited.javaInterfaceName)") { printer in
+          printer.print("\(translatedWrapper.javaInterfaceVariableName)")
+        }
+        printer.println()
+      }
+
       for function in translatedWrapper.functions {
         try printInterfaceWrapperFunctionImpl(&printer, function, inside: translatedWrapper)
         printer.println()

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
@@ -141,4 +141,14 @@ extension JNISwift2JavaGenerator {
   static func indirectVariableName(for parameterName: String) -> String {
     "\(parameterName)$indirect"
   }
+
+  func inheritedProtocols(of type: ImportedNominalType) -> [ImportedNominalType] {
+    type.inheritedTypes
+      .compactMap(\.asNominalTypeDeclaration)
+      .filter { $0.kind == .protocol }
+      .compactMap {
+        self.analysis.importedTypes[$0.qualifiedName]
+      }
+      .uniqued()
+  }
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator.swift
@@ -149,6 +149,5 @@ extension JNISwift2JavaGenerator {
       .compactMap {
         self.analysis.importedTypes[$0.qualifiedName]
       }
-      .uniqued()
   }
 }

--- a/Tests/JExtractSwiftTests/JNI/JNIProtocolTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIProtocolTests.swift
@@ -41,6 +41,16 @@ struct JNIProtocolTests {
       public func takeComposite(x: any SomeProtocol & B)
     """
 
+  let protocolInheritanceSource = """
+      public protocol ParentProtocol {
+        public func parentMethod()
+      }
+
+      public protocol ChildProtocol: ParentProtocol {
+        public func childMethod()
+      }
+    """
+
   @Test
   func generatesJavaInterface() throws {
     try assertOutput(
@@ -65,6 +75,33 @@ struct JNIProtocolTests {
           public void method();
           ...
           public SomeClass withObject(SomeClass c, SwiftArena swiftArena);
+          ...
+        }
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func generatesJavaInterfaceWithInheritedProtocol() throws {
+    try assertOutput(
+      input: protocolInheritanceSource,
+      config: config,
+      .jni,
+      .java,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        public interface ParentProtocol {
+          ...
+          public void parentMethod();
+          ...
+        }
+        """,
+        """
+        public interface ChildProtocol extends ParentProtocol {
+          ...
+          public void childMethod();
           ...
         }
         """,
@@ -343,6 +380,39 @@ struct JNIProtocolTests {
         """,
         """
         extension SwiftJavaBWrapper {
+        }
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func generatesProtocolWrappersWithInheritedProtocol() throws {
+    try assertOutput(
+      input: protocolInheritanceSource,
+      config: config,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        protocol SwiftJavaParentProtocolWrapper: ParentProtocol {
+          var _javaParentProtocolInterface: JavaParentProtocol { get }
+        }
+        """,
+        """
+        protocol SwiftJavaChildProtocolWrapper: ChildProtocol, SwiftJavaParentProtocolWrapper {
+          var _javaChildProtocolInterface: JavaChildProtocol { get }
+        }
+        """,
+        """
+        extension SwiftJavaChildProtocolWrapper {
+          var _javaParentProtocolInterface: JavaParentProtocol {
+            _javaChildProtocolInterface
+          }
+          public func childMethod() {
+            ...
+          }
         }
         """,
       ]


### PR DESCRIPTION
Currently, when an inheritance relationship exists between protocols, the generated Java class only expresses conformance to the child protocol.
The parent protocol relationship is lost.

This PR updates the generator to properly represent protocol inheritance within the generated Java interfaces.
