### PR TITLE
Lock swift-subprocess to 0.4 while we support 6.1 until 6.4 is released

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-system", from: "1.4.0"),
     .package(url: "https://github.com/apple/swift-log", from: "1.2.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.3.0"), // primarily for ordered collections
-    .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0", traits: ["SubprocessFoundation"]),
+    .package(url: "https://github.com/swiftlang/swift-subprocess.git", "0.4.0"..<"0.5.0", traits: ["SubprocessFoundation"]),
 
     // Benchmarking
     .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),

--- a/Sources/SwiftJavaTool/Commands/JavaCallbacksBuildCommand.swift
+++ b/Sources/SwiftJavaTool/Commands/JavaCallbacksBuildCommand.swift
@@ -269,8 +269,8 @@ private func runSubprocess(
     .path(FilePath(executable)),
     arguments: .init(arguments),
     environment: environment,
-    output: .standardOutput,
-    error: .standardError,
+    output: FileDescriptorOutput.standardOutput,
+    error: FileDescriptorOutput.standardError,
   )
   guard result.terminationStatus.isSuccess else {
     throw JavaCallbacksBuildError(


### PR DESCRIPTION
For now sticking to supporting 6.1 still by locking subprocess to 0.4