### PR TITLE
Add regression coverage for overloaded initializer Java names

### DIFF
--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -668,6 +668,44 @@ final class MethodImportTests {
     )
   }
 
+  let overloadedInitializers_interfaceFile =
+    """
+    import Swift
+
+    public class OverloadedInitializerClass {
+      public init(throwing: Swift.Bool) throws
+      public init?(doInit: Swift.Bool)
+    }
+    """
+
+  let overloadedFFMInitializers_interfaceFile =
+    """
+    import Swift
+
+    public class OverloadedFFMInitializerClass {
+      public init(throwing: Swift.Bool) throws
+      public init(doInit: Swift.Bool)
+    }
+    """
+
+  @Test("FFM: Overloaded initializers with same Java signature get suffixed Java names")
+  func ffm_overloaded_initializers_suffixed() throws {
+    try assertOutput(
+      input: overloadedFFMInitializers_interfaceFile,
+      .ffm,
+      .java,
+      swiftModuleName: "OverloadModule",
+      expectedChunks: [
+        "public static OverloadedFFMInitializerClass initThrowing(boolean throwing, AllocatingSwiftArena swiftArena)",
+        "public static OverloadedFFMInitializerClass initDoInit(boolean doInit, AllocatingSwiftArena swiftArena)",
+      ],
+      notExpectedChunks: [
+        "public static OverloadedFFMInitializerClass init(boolean throwing, AllocatingSwiftArena swiftArena)",
+        "public static OverloadedFFMInitializerClass init(boolean doInit, AllocatingSwiftArena swiftArena)",
+      ]
+    )
+  }
+
   // ==== -------------------------------------------------------------------
   // MARK: JNI overloaded method disambiguation
 
@@ -773,6 +811,24 @@ final class MethodImportTests {
       expectedChunks: [
         "public static long takeValueOuter(java.lang.String name)",
         "public static long takeValueAnother(java.lang.String name)",
+      ]
+    )
+  }
+
+  @Test("JNI: Overloaded initializers with same Java signature get suffixed Java names")
+  func jni_overloaded_initializers_suffixed() throws {
+    try assertOutput(
+      input: overloadedInitializers_interfaceFile,
+      .jni,
+      .java,
+      swiftModuleName: "OverloadModule",
+      expectedChunks: [
+        "public static OverloadedInitializerClass initThrowing(boolean throwing, SwiftArena swiftArena) throws Exception",
+        "public static java.util.Optional<OverloadedInitializerClass> initDoInit(boolean doInit, SwiftArena swiftArena)",
+      ],
+      notExpectedChunks: [
+        "public static OverloadedInitializerClass init(boolean throwing, SwiftArena swiftArena)",
+        "public static java.util.Optional<OverloadedInitializerClass> init(boolean doInit, SwiftArena swiftArena)",
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -678,9 +678,12 @@ final class MethodImportTests {
     }
     """
 
-  @Test("Overloaded initializers with same Java signature get suffixed Java names", arguments: [
-    JExtractGenerationMode.jni, .ffm
-  ])
+  @Test(
+    "Overloaded initializers with same Java signature get suffixed Java names",
+    arguments: [
+      JExtractGenerationMode.jni, .ffm,
+    ]
+  )
   func overloaded_initializers_suffixed(mode: JExtractGenerationMode) throws {
     let expectedChunks: [String]
     let notExpectedChunks: [String]

--- a/Tests/JExtractSwiftTests/MethodImportTests.swift
+++ b/Tests/JExtractSwiftTests/MethodImportTests.swift
@@ -674,35 +674,45 @@ final class MethodImportTests {
 
     public class OverloadedInitializerClass {
       public init(throwing: Swift.Bool) throws
-      public init?(doInit: Swift.Bool)
-    }
-    """
-
-  let overloadedFFMInitializers_interfaceFile =
-    """
-    import Swift
-
-    public class OverloadedFFMInitializerClass {
-      public init(throwing: Swift.Bool) throws
       public init(doInit: Swift.Bool)
     }
     """
 
-  @Test("FFM: Overloaded initializers with same Java signature get suffixed Java names")
-  func ffm_overloaded_initializers_suffixed() throws {
+  @Test("Overloaded initializers with same Java signature get suffixed Java names", arguments: [
+    JExtractGenerationMode.jni, .ffm
+  ])
+  func overloaded_initializers_suffixed(mode: JExtractGenerationMode) throws {
+    let expectedChunks: [String]
+    let notExpectedChunks: [String]
+
+    switch mode {
+    case .ffm:
+      expectedChunks = [
+        "public static OverloadedInitializerClass initThrowing(boolean throwing, AllocatingSwiftArena swiftArena)",
+        "public static OverloadedInitializerClass initDoInit(boolean doInit, AllocatingSwiftArena swiftArena)",
+      ]
+      notExpectedChunks = [
+        "public static OverloadedInitializerClass init(boolean throwing, AllocatingSwiftArena swiftArena)",
+        "public static OverloadedInitializerClass init(boolean doInit, AllocatingSwiftArena swiftArena)",
+      ]
+    case .jni:
+      expectedChunks = [
+        "public static OverloadedInitializerClass initThrowing(boolean throwing, SwiftArena swiftArena) throws Exception",
+        "public static OverloadedInitializerClass initDoInit(boolean doInit, SwiftArena swiftArena)",
+      ]
+      notExpectedChunks = [
+        "public static OverloadedInitializerClass init(boolean throwing, SwiftArena swiftArena)",
+        "public static OverloadedInitializerClass init(boolean doInit, SwiftArena swiftArena)",
+      ]
+    }
+
     try assertOutput(
-      input: overloadedFFMInitializers_interfaceFile,
-      .ffm,
+      input: overloadedInitializers_interfaceFile,
+      mode,
       .java,
       swiftModuleName: "OverloadModule",
-      expectedChunks: [
-        "public static OverloadedFFMInitializerClass initThrowing(boolean throwing, AllocatingSwiftArena swiftArena)",
-        "public static OverloadedFFMInitializerClass initDoInit(boolean doInit, AllocatingSwiftArena swiftArena)",
-      ],
-      notExpectedChunks: [
-        "public static OverloadedFFMInitializerClass init(boolean throwing, AllocatingSwiftArena swiftArena)",
-        "public static OverloadedFFMInitializerClass init(boolean doInit, AllocatingSwiftArena swiftArena)",
-      ]
+      expectedChunks: expectedChunks,
+      notExpectedChunks: notExpectedChunks
     )
   }
 
@@ -815,21 +825,4 @@ final class MethodImportTests {
     )
   }
 
-  @Test("JNI: Overloaded initializers with same Java signature get suffixed Java names")
-  func jni_overloaded_initializers_suffixed() throws {
-    try assertOutput(
-      input: overloadedInitializers_interfaceFile,
-      .jni,
-      .java,
-      swiftModuleName: "OverloadModule",
-      expectedChunks: [
-        "public static OverloadedInitializerClass initThrowing(boolean throwing, SwiftArena swiftArena) throws Exception",
-        "public static java.util.Optional<OverloadedInitializerClass> initDoInit(boolean doInit, SwiftArena swiftArena)",
-      ],
-      notExpectedChunks: [
-        "public static OverloadedInitializerClass init(boolean throwing, SwiftArena swiftArena)",
-        "public static java.util.Optional<OverloadedInitializerClass> init(boolean doInit, SwiftArena swiftArena)",
-      ]
-    )
-  }
 }


### PR DESCRIPTION
Adds regression coverage for #425.
This covers the reported initializer-collision where distinct Swift initializers could otherwise produce duplicate Java `init(...)` signatures. The added tests assert that the generated FFM/JNI Java names are disambiguated, e.g. `initThrowing` and `initDoInit`, and that the raw duplicate `init(...)` signatures are absent.

Closes #425.

Test:
- `swift test --filter MethodImportTests`