### PR TITLE
[WIP] Add java.net.HttpURLConnection to JavaNet

### DIFF
--- a/Sources/JavaStdlib/JavaNet/swift-java.config
+++ b/Sources/JavaStdlib/JavaNet/swift-java.config
@@ -3,5 +3,6 @@
     "java.net.URI" : "URI",
     "java.net.URLClassLoader" : "URLClassLoader",
     "java.net.URLConnection" : "URLConnection",
+    "java.net.HttpURLConnection" : "HttpURLConnection",
   }
 }


### PR DESCRIPTION
[`java.net.HttpURLConnection`](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html) is very useful because it provides access to the Android-native HTTP connection handling APIs.

Leaving as draft for discussion.