### PR TITLE
Fix: Identity equality for non `Equatable` clases.

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/HashableTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/HashableTest.java
@@ -70,6 +70,37 @@ public class HashableTest {
     }
 
     @Test
+    void nonEquatableReferenceTypeFallsBackToIdentity() {
+        // MySwiftClass does not conform to Swift's `Equatable`, so the JNI
+        // bridge should fall back to identity equality.
+        try (var arena = SwiftArena.ofConfined()) {
+            var a = MySwiftClass.init(42, 1, arena);
+            var b = MySwiftClass.init(42, 1, arena);
+            assertEquals(a, a);
+            assertEquals(b, b);
+            // Different instances with equal field values must NOT be equal,
+            // since the type is not Equatable
+            assertNotEquals(a, b);
+            assertNotEquals(b, a);
+            assertNotEquals(a, "foo");
+        }
+    }
+
+    @Test
+    void nonEquatableReferenceTypeHashSetUsesIdentity() {
+        try (var arena = SwiftArena.ofConfined()) {
+            var a = MySwiftClass.init(42, 1, arena);
+            var b = MySwiftClass.init(42, 1, arena);
+            var set = new HashSet<>(List.of(a, b));
+            assertTrue(set.contains(a));
+            assertTrue(set.contains(b));
+            // Two distinct instances of a non-Equatable class are distinct
+            // entries in the set
+            assertEquals(2, set.size());
+        }
+    }
+
+    @Test
     void hashSetReferenceType() {
         try (var arena = SwiftArena.ofConfined()) {
             var a = HashableClass.init(42, arena);

--- a/Sources/SwiftJava/SwiftObjects.swift
+++ b/Sources/SwiftJava/SwiftObjects.swift
@@ -102,7 +102,7 @@ extension SwiftObjects {
   @JavaMethod
   public static func equals(environment: UnsafeMutablePointer<JNIEnv?>!, lhsPointer: Int64, lhsTypePointer: Int64, rhsPointer: Int64, rhsTypePointer: Int64) -> Bool {
     // Fallback for non-equatable types (such as classes)
-    let isEquatableByIdentity = lhsPointer == rhsPointer && lhsTypePointer == rhsTypePointer
+    let isPointerIdentityEqual = lhsTypePointer == rhsTypePointer && lhsPointer == rhsPointer
 
     guard let lhsType$ = UnsafeRawPointer(bitPattern: Int(lhsTypePointer)) else {
       fatalError("lhsType metadata address was null")

--- a/Sources/SwiftJava/SwiftObjects.swift
+++ b/Sources/SwiftJava/SwiftObjects.swift
@@ -109,7 +109,7 @@ extension SwiftObjects {
     }
     let lhsMetatype = unsafeBitCast(lhsType$, to: Any.Type.self)
     guard let lhsMetatype = lhsMetatype as? (any Equatable.Type) else {
-      return isEquatableByIdentity
+      return isPointerIdentityEqual
     }
 
     guard let rhsType$ = UnsafeRawPointer(bitPattern: Int(rhsTypePointer)) else {
@@ -117,7 +117,7 @@ extension SwiftObjects {
     }
     let rhsMetatype = unsafeBitCast(rhsType$, to: Any.Type.self)
     guard let rhsMetatype = rhsMetatype as? (any Equatable.Type) else {
-      return isEquatableByIdentity
+      return isPointerIdentityEqual
     }
 
     func perform<L: Equatable, R: Equatable>(lhsType: L.Type, rhsType: R.Type) -> Bool {

--- a/Sources/SwiftJava/SwiftObjects.swift
+++ b/Sources/SwiftJava/SwiftObjects.swift
@@ -101,12 +101,15 @@ extension SwiftObjects {
 
   @JavaMethod
   public static func equals(environment: UnsafeMutablePointer<JNIEnv?>!, lhsPointer: Int64, lhsTypePointer: Int64, rhsPointer: Int64, rhsTypePointer: Int64) -> Bool {
+    // Fallback for non-equatable types (such as classes)
+    let isEquatableByIdentity = lhsPointer == rhsPointer && lhsTypePointer == rhsTypePointer
+
     guard let lhsType$ = UnsafeRawPointer(bitPattern: Int(lhsTypePointer)) else {
       fatalError("lhsType metadata address was null")
     }
     let lhsMetatype = unsafeBitCast(lhsType$, to: Any.Type.self)
     guard let lhsMetatype = lhsMetatype as? (any Equatable.Type) else {
-      return false
+      return isEquatableByIdentity
     }
 
     guard let rhsType$ = UnsafeRawPointer(bitPattern: Int(rhsTypePointer)) else {
@@ -114,7 +117,7 @@ extension SwiftObjects {
     }
     let rhsMetatype = unsafeBitCast(rhsType$, to: Any.Type.self)
     guard let rhsMetatype = rhsMetatype as? (any Equatable.Type) else {
-      return false
+      return isEquatableByIdentity
     }
 
     func perform<L: Equatable, R: Equatable>(lhsType: L.Type, rhsType: R.Type) -> Bool {


### PR DESCRIPTION
Use identity for `equals` methods for types that do not implement `Equatable`, for example classes:

**Swift:**
```swift
final class MySwiftClass {}
```

**Java:**
```java
// Extracted by jextract
public final class MySwiftClass {}

MySwiftClass c1 = MySwiftClass.init();
c1.equals(c1) // would return false before
```
