### PR TITLE
jextract: Skip generating specialization for generic enum types

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/GenericType.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/GenericType.swift
@@ -88,7 +88,7 @@ public func makeIntGenericEnum() -> GenericEnum<Int> {
   if Bool.random() { return .foo } else { return .bar }
 }
 
-public typealias IntGenericEnum = GenericEnum<Int>
+public typealias IntGenericEnum = GenericEnum<Int> // This specialization is not supported yet.
 
 public enum GenericEnumWithValue<T> {
   case some(T)

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/GenericType.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/GenericType.swift
@@ -88,6 +88,8 @@ public func makeIntGenericEnum() -> GenericEnum<Int> {
   if Bool.random() { return .foo } else { return .bar }
 }
 
+public typealias IntGenericEnum = GenericEnum<Int>
+
 public enum GenericEnumWithValue<T> {
   case some(T)
   case none

--- a/Sources/SwiftExtract/ExtractedDecls.swift
+++ b/Sources/SwiftExtract/ExtractedDecls.swift
@@ -191,6 +191,13 @@ public final class ExtractedNominalType: ExtractedSwiftDecl {
         message: "Missing type arguments for: \(missingParams) when specializing \(baseTypeName) as \(specializedName)"
       )
     }
+
+    if swiftNominal.kind == .enum {
+      throw SpecializationError(
+        message: "Specialization for enums are not yet supported: '\(baseTypeName)' as '\(specializedName)'"
+      )
+    }
+
     return ExtractedNominalType(
       base: self,
       specializedTypeName: specializedName,

--- a/Sources/SwiftJavaDocumentation/Documentation.docc/SupportedFeatures.md
+++ b/Sources/SwiftJavaDocumentation/Documentation.docc/SupportedFeatures.md
@@ -465,6 +465,10 @@ public final class FishBox ... {
 > NOTE: Currently no helpers are available to convert between unspecialized types to specialized ones, but this can be offered 
 >       as additional `box.as(FishBox.class)` conversion methods in the future.
 
+
+> NOTE: Currently specialization for generic enums are not yet supported.
+
+
 ### Evaluating `#if`
 
 In jextract, `#if` branches are evaluated using [SwiftIfConfig](https://github.com/swiftlang/swift-syntax/blob/main/Sources/SwiftIfConfig/SwiftIfConfig.docc/SwiftIfConfig.md).

--- a/Tests/JExtractSwiftTests/SpecializationTests.swift
+++ b/Tests/JExtractSwiftTests/SpecializationTests.swift
@@ -364,15 +364,38 @@ struct SpecializationTests {
     let fish = try #require(translator.extractedTypes["Fish"])
     #expect(!fish.swiftNominal.isGeneric)
 
-    #expect(throws: SpecializationError.self) {
-      _ = try fish.specialize(as: "FancyFish", with: ["T": "Int"])
-    }
-
     do {
       _ = try fish.specialize(as: "FancyFish", with: ["T": "Int"])
+      Issue.record("Error not thrown")
     } catch let error as SpecializationError {
       #expect(error.message.contains("Unable to specialize non-generic type"))
       #expect(error.message.contains("Fish"))
+    }
+  }
+
+  @Test("Specializing a enum type throws an error")
+  func specializeEnumTypeThrows() throws {
+    var config = Configuration()
+    config.swiftModule = "SwiftModule"
+    let translator = makeSwiftJavaAnalyzer(config: config)
+    try translator.analyze(
+      path: "/fake/Fake.swiftinterface",
+      text: """
+        public enum Foo<T> {
+          case foo
+        }
+        """,
+    )
+
+    let foo = try #require(translator.extractedTypes["Foo"])
+    #expect(foo.swiftNominal.kind == .enum)
+
+    do {
+      _ = try foo.specialize(as: "IntFoo", with: ["T": "Int"])
+      Issue.record("Error not thrown")
+    } catch let error as SpecializationError {
+      #expect(error.message.contains("Specialization for enums are not yet supported"))
+      #expect(error.message.contains("Foo"))
     }
   }
 }


### PR DESCRIPTION
Currently, specialization for generic enum types is not working correctly, leading to compilation errors in the generated code.

```
.../IntGenericEnum.java:82: error: cannot find symbol
  public Case<T> getCase() {
              ^
```

```
.../FlapjackValues+SwiftJava.swift:1461:103: error: conflicting conformance of 'APIResponseResult<Success, Failure>' to protocol '_RawDiscriminatorRepresentable'; there cannot be more than one conformance, even with different conditional bounds
1390 | } // printOpenerProtocol(_:_:) @ JExtractSwiftLib/JNISwift2JavaGenerator+SwiftThunkPrinting.swift:1053
1391 | 
1392 | extension APIResponseResult: _RawDiscriminatorRepresentable {
     | `- note: 'APIResponseResult<Success, Failure>' declares conformance to protocol '_RawDiscriminatorRepresentable' here
1393 |   public var _rawDiscriminator: Int32 {
1394 |     switch self {
     :
1459 | 
```

As additional implementation is required to fully support generic enum specialization, this PR temporarily skips the generation of these specializations to prevent the aforementioned build errors. 
