### PR TITLE
Derive Maven version from git describe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ BuildLogic/out/
 **/build/
 lib/
 
+# Though make sure we include actual sources, even if they are ignored because e.g. /build/ in the path
+!**/src/main/kotlin/**
+
 # Ignore JVM crash logs
 **/*.log
 

--- a/BuildLogic/.gitignore
+++ b/BuildLogic/.gitignore
@@ -1,2 +1,2 @@
-build
+/build/
 .gradle

--- a/BuildLogic/src/main/kotlin/org/swift/build/utils/gitVersion.kt
+++ b/BuildLogic/src/main/kotlin/org/swift/build/utils/gitVersion.kt
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package org.swift.build.utils
+
+import org.gradle.api.Project
+
+/**
+ * Resolve the publication version for swift-java's Java artifacts.
+ *
+ * Resolution order:
+ * 1. `-PswiftkitVersion=<value>` project property, for CI/release overrides.
+ * 2. `git describe --tags --always`, for normal local builds with full git history.
+ * 3. `GITHUB_SHA` (truncated) — useful in shallow CI checkouts where git history is not available.
+ * 4. `0.0.0-SNAPSHOT` fallback.
+ *
+ * `git describe` is allowed to fail without breaking the build, because some CI
+ * environments do not have a full checkout (e.g. `fetch-depth: 1`) or any tags
+ * reachable, in which case the command exits with code 128.
+ */
+fun Project.resolveSwiftKitVersion(): String {
+    findProperty("swiftkitVersion")?.toString()?.takeIf { it.isNotBlank() }?.let { return it }
+
+    val gitVersion = runCatching {
+        providers.exec {
+            commandLine("git", "describe", "--tags", "--always")
+            workingDir = rootDir
+            isIgnoreExitValue = true
+        }.standardOutput.asText.get().trim()
+    }.getOrNull()
+    if (!gitVersion.isNullOrBlank()) return gitVersion
+
+    System.getenv("GITHUB_SHA")?.take(12)?.takeIf { it.isNotBlank() }?.let { return it }
+
+    return "0.0.0-SNAPSHOT"
+}

--- a/SwiftKitCore/build.gradle.kts
+++ b/SwiftKitCore/build.gradle.kts
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import org.swift.build.utils.resolveSwiftKitVersion
+
 plugins {
     id("build-logic.java-application-conventions")
     id("me.champeau.jmh") version "0.7.2"
@@ -19,7 +21,9 @@ plugins {
 }
 
 group = "org.swift.swiftkit"
-version = "1.0-SNAPSHOT"
+
+version = resolveSwiftKitVersion()
+
 base {
     archivesName = "swiftkit-core"
 }
@@ -34,8 +38,6 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = group as? String
             artifactId = "swiftkit-core"
-            version = "1.0-SNAPSHOT"
-
             from(components["java"])
         }
     }

--- a/SwiftKitFFM/build.gradle.kts
+++ b/SwiftKitFFM/build.gradle.kts
@@ -12,13 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+import org.swift.build.utils.resolveSwiftKitVersion
+
 plugins {
     id("build-logic.java-application-conventions")
     `maven-publish`
 }
 
 group = "org.swift.swiftkit"
-version = "1.0-SNAPSHOT"
+
+version = resolveSwiftKitVersion()
 
 base {
     archivesName = "swiftkit-ffm"
@@ -34,8 +37,6 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = group as? String
             artifactId = "swiftkit-ffm"
-            version = "1.0-SNAPSHOT"
-
             from(components["java"])
         }
     }


### PR DESCRIPTION
SwiftKitCore and SwiftKitFFM compute their Maven version directly from the current checkout via `git describe --tags --always`. A checkout on an exact SemVer tag (e.g. `0.4.2`) publishes that version; off-tag working trees publish a tag-prefixed identifier such as `0.4.1-52-g8f0d0794`, this replaces the hardcoded `1.0-SNAPSHOT` we had before.

We'll do -SNAPSHOT once we actually start publishing them nightly though I think...