### PR TITLE
Commit workaround for LSP lazy indexing issues

### DIFF
--- a/.sourcekit-lsp/config.json
+++ b/.sourcekit-lsp/config.json
@@ -1,0 +1,3 @@
+{
+  "backgroundPreparationMode": "noLazy"
+}


### PR DESCRIPTION
Without this vscode is broken for editing, See the root cause here: https://github.com/swiftlang/sourcekit-lsp/issues/2696

Commit this rather than everyone having to reinvent the workaround themselves