### PR TITLE
SwiftExtract: fix compiler version check for @nonexhaustive

### DIFF
--- a/Sources/SwiftExtractConfigurationShared/AccessLevelMode.swift
+++ b/Sources/SwiftExtractConfigurationShared/AccessLevelMode.swift
@@ -18,7 +18,7 @@
 /// layer and language-specific configuration layers (e.g. swift-java's
 /// `SwiftJavaConfigurationShared`) can both depend on it without dragging
 /// SwiftSyntax into the latter.
-#if compiler(>=6.2)
+#if compiler(>=6.2.3)
 @nonexhaustive
 #endif
 public enum AccessLevelMode: String, Codable, Sendable {


### PR DESCRIPTION
According to https://github.com/swiftlang/swift-evolution/blob/main/proposals/0487-extensible-enums.md this was added in swift 6.2.3