### PR TITLE
jextract: Thunks must ignore deprecation warnings

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/CDeclLowering/FFMSwift2JavaGenerator+FunctionLowering.swift
+++ b/Sources/JExtractSwiftLib/FFM/CDeclLowering/FFMSwift2JavaGenerator+FunctionLowering.swift
@@ -979,6 +979,9 @@ extension LoweredFunctionSignature {
 
     var loweredCDecl = try! FunctionDeclSyntax(
       """
+      #if compiler(>=6.4)
+      @diagnose(DeprecatedDeclaration, as: ignored)
+      #endif
       @_cdecl(\(literal: cName))
       public func \(raw: cName)(\(raw: cdeclParams))\(raw: returnClause) {
       }

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -241,6 +241,9 @@ struct SwiftThunkTranslator {
 
     return
       """
+      #if compiler(>=6.4)
+      @diagnose(DeprecatedDeclaration, as: ignored)
+      #endif
       @_cdecl("\(raw: funcName)")
       public func \(raw: funcName)() -> UnsafeMutableRawPointer /* Any.Type */ {
         return unsafeBitCast(\(raw: nominal.swiftNominal.qualifiedName).self, to: UnsafeMutableRawPointer.self)
@@ -285,6 +288,9 @@ struct SwiftThunkTranslator {
 
     let copyBytesThunk: DeclSyntax =
       """
+      #if compiler(>=6.4)
+      @diagnose(DeprecatedDeclaration, as: ignored)
+      #endif
       @_cdecl("\(raw: thunkName)")
       public func \(raw: thunkName)(
           selfPointer: UnsafeRawPointer,

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -788,6 +788,9 @@ extension JNISwift2JavaGenerator {
       #if compiler(>=6.3)
       @used
       #endif
+      #if compiler(>=6.4)
+      @diagnose(DeprecatedDeclaration, as: ignored)
+      #endif
       @_cdecl("\(cName)")
       public func \(cName)(\(thunkParameters.joined(separator: ", ")))\(thunkReturnType)
       """

--- a/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/LoweringAssertions.swift
@@ -18,6 +18,13 @@ import SwiftJavaConfigurationShared
 import SwiftSyntax
 import Testing
 
+private let thunkDiagnoseAttribute = """
+  #if compiler(>=6.4)
+  @diagnose(DeprecatedDeclaration, as: ignored)
+  #endif
+
+  """
+
 /// Assert that the lowering of the function function declaration to a @_cdecl
 /// entrypoint matches the expected form.
 func assertLoweredFunction(
@@ -79,7 +86,7 @@ func assertLoweredFunction(
   )
 
   #expect(
-    loweredCDecl.description == expectedCDecl.description,
+    loweredCDecl.description == thunkDiagnoseAttribute + expectedCDecl.description,
     sourceLocation: Testing.SourceLocation(
       fileID: fileID,
       filePath: filePath,
@@ -147,7 +154,7 @@ func assertLoweredVariableAccessor(
   )
 
   #expect(
-    loweredCDecl?.description == expectedCDecl?.description,
+    loweredCDecl?.description == expectedCDecl.map { thunkDiagnoseAttribute + $0.description },
     sourceLocation: Testing.SourceLocation(
       fileID: fileID,
       filePath: filePath,

--- a/Tests/JExtractSwiftTests/JNI/JNICDeclAttributesTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNICDeclAttributesTests.swift
@@ -19,7 +19,7 @@ import Testing
 struct JNICDeclAttributesTests {
 
   @Test
-  func globalFunc_hasUsedAttribute() throws {
+  func globalFunc_hasThunkAttributes() throws {
     try assertOutput(
       input: "public func hello()",
       .jni,
@@ -29,6 +29,9 @@ struct JNICDeclAttributesTests {
         #if compiler(>=6.3)
         @used
         #endif
+        #if compiler(>=6.4)
+        @diagnose(DeprecatedDeclaration, as: ignored)
+        #endif
         @_cdecl("Java_com_example_swift_SwiftModule__00024hello__")
         ...
         """
@@ -37,7 +40,7 @@ struct JNICDeclAttributesTests {
   }
 
   @Test
-  func globalFuncWithArgs_hasUsedAttribute() throws {
+  func globalFuncWithArgs_hasThunkAttributes() throws {
     try assertOutput(
       input: "public func add(a: Int64, b: Int64) -> Int64",
       .jni,
@@ -46,6 +49,9 @@ struct JNICDeclAttributesTests {
         """
         #if compiler(>=6.3)
         @used
+        #endif
+        #if compiler(>=6.4)
+        @diagnose(DeprecatedDeclaration, as: ignored)
         #endif
         @_cdecl("Java_com_example_swift_SwiftModule__00024add__JJ")
         ...


### PR DESCRIPTION
Otherwise we get absolutely flooded with deprecation warnings since we're bridging to deprecated APIs which we do want to keep, but do not want to be warned about this;