### PR TITLE
Introduce String.comma constant for join separators

### DIFF
--- a/Sources/JExtractSwiftLib/CTypes/CFunction.swift
+++ b/Sources/JExtractSwiftLib/CTypes/CFunction.swift
@@ -55,7 +55,7 @@ extension CFunction: CustomStringConvertible {
 
     // Function parameters.
     result += "("
-    result += parameters.map { $0.description }.joined(separator: ", ")
+    result += parameters.map { $0.description }.joined(separator: .comma)
     CType.printFunctionParametersSuffix(
       isVariadic: isVariadic,
       hasZeroParameters: parameters.isEmpty,

--- a/Sources/JExtractSwiftLib/CTypes/CType.swift
+++ b/Sources/JExtractSwiftLib/CTypes/CType.swift
@@ -216,7 +216,7 @@ extension CType: CustomStringConvertible {
       result += "("
 
       // Render the parameter types.
-      result += parameters.map { $0.description }.joined(separator: ", ")
+      result += parameters.map { $0.description }.joined(separator: .comma)
 
       CType.printFunctionParametersSuffix(
         isVariadic: variadic,

--- a/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/JavaType+Extensions.swift
@@ -196,7 +196,7 @@ extension JavaType {
         }
       let genericClause: String =
         if !typeParameters.isEmpty {
-          "<\(typeParameters.map(\.boxedName).joined(separator: ", "))>"
+          "<\(typeParameters.map(\.boxedName).joined(separator: .comma))>"
         } else {
           ""
         }

--- a/Sources/JExtractSwiftLib/Convenience/String+Extensions.swift
+++ b/Sources/JExtractSwiftLib/Convenience/String+Extensions.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+  /// Comma-space separator; Convenience to avoid having to escape the string when joining inside other strings.
+  public static let comma: String = ", "
+}

--- a/Sources/JExtractSwiftLib/FFM/CDeclLowering/FFMSwift2JavaGenerator+FunctionLowering.swift
+++ b/Sources/JExtractSwiftLib/FFM/CDeclLowering/FFMSwift2JavaGenerator+FunctionLowering.swift
@@ -976,7 +976,7 @@ extension LoweredFunctionSignature {
     as apiKind: SwiftAPIKind,
   ) -> FunctionDeclSyntax {
 
-    let cdeclParams = allLoweredParameters.map(\.description).joined(separator: ", ")
+    let cdeclParams = allLoweredParameters.map(\.description).joined(separator: .comma)
     let cdeclReturnType = cdeclReturnTypeForThunk
     let returnClause = !cdeclReturnType.isVoid ? " -> \(cdeclReturnType.description)" : ""
 
@@ -1036,7 +1036,7 @@ extension LoweredFunctionSignature {
           let argExpr = original.parameters[i].convention == .inout ? "&\(argument)" : argument
           return LabeledExprSyntax(label: original.parameters[i].argumentLabel, expression: argExpr).description
         }
-        .joined(separator: ", ")
+        .joined(separator: .comma)
       resultExpr = "\(callee)(\(raw: arguments))"
 
     case .getter:
@@ -1056,7 +1056,7 @@ extension LoweredFunctionSignature {
         .map { (i, argument) -> String in
           LabeledExprSyntax(label: original.parameters[i].argumentLabel, expression: argument).description
         }
-        .joined(separator: ", ")
+        .joined(separator: .comma)
       resultExpr = "\(callee)[\(raw: parameters)]"
     case .subscriptSetter:
       assert(paramExprs.count >= 1)
@@ -1068,7 +1068,7 @@ extension LoweredFunctionSignature {
         .map { (i, argument) -> String in
           LabeledExprSyntax(label: original.parameters[i].argumentLabel, expression: argument).description
         }
-        .joined(separator: ", ")
+        .joined(separator: .comma)
       resultExpr = "\(callee)[\(raw: parameters)] = \(newValueArgument)"
     }
 

--- a/Sources/JExtractSwiftLib/FFM/ConversionStep.swift
+++ b/Sources/JExtractSwiftLib/FFM/ConversionStep.swift
@@ -135,7 +135,7 @@ enum ConversionStep: Equatable {
 
       // FIXME: Should be able to use structured initializers here instead
       // of splatting out text.
-      let renderedArgumentList = renderedArguments.joined(separator: ", ")
+      let renderedArgumentList = renderedArguments.joined(separator: .comma)
       return "\(raw: type.description)(\(raw: renderedArgumentList))"
 
     case .tuplify(let elements):
@@ -145,7 +145,7 @@ enum ConversionStep: Equatable {
 
       // FIXME: Should be able to use structured initializers here instead
       // of splatting out text.
-      let renderedElementList = renderedElements.joined(separator: ", ")
+      let renderedElementList = renderedElements.joined(separator: .comma)
       return "(\(raw: renderedElementList))"
 
     case .populatePointer(name: let pointer, assumingType: let type, to: let step):
@@ -185,7 +185,7 @@ enum ConversionStep: Equatable {
       }
 
       // FIXME: Should be able to use structured initializers here instead of splatting out text.
-      let renderedArgumentList = renderedArguments.joined(separator: ", ")
+      let renderedArgumentList = renderedArguments.joined(separator: .comma)
 
       let methodApply: String =
         if let methodName {
@@ -240,7 +240,7 @@ enum ConversionStep: Equatable {
       }
 
       // Call the lowered closure with lowered parameters.
-      let loweredResult = "\(placeholder)(\(args.map(\.description).joined(separator: ", ")))"
+      let loweredResult = "\(placeholder)(\(args.map(\.description).joined(separator: .comma)))"
 
       // Raise the lowered result.
       let result = resultStep.asExprSyntax(placeholder: loweredResult.description, bodyItems: &body)
@@ -249,7 +249,7 @@ enum ConversionStep: Equatable {
       // Construct the closure expression.
       var closure = ExprSyntax(
         """
-        { (\(raw: params.joined(separator: ", "))) in
+        { (\(raw: params.joined(separator: .comma))) in
           }
         """
       ).cast(ClosureExprSyntax.self)

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -136,8 +136,8 @@ extension FFMSwift2JavaGenerator {
       params.append("\(annotationsStr)\(param.type.javaType) \(name)")
       args.append(name)
     }
-    let paramsStr = params.joined(separator: ", ")
-    let argsStr = args.joined(separator: ", ")
+    let paramsStr = params.joined(separator: .comma)
+    let argsStr = args.joined(separator: .comma)
 
     printer.print(
       """
@@ -236,7 +236,7 @@ extension FFMSwift2JavaGenerator {
         """
         @FunctionalInterface
         public interface Function {
-          \(cResultType.javaType) apply(\(paramDecls.joined(separator: ", ")));
+          \(cResultType.javaType) apply(\(paramDecls.joined(separator: .comma)));
         }
         """
       )
@@ -246,7 +246,7 @@ extension FFMSwift2JavaGenerator {
           """
           public final static class Function$Impl implements Function {
             \(impl.members.joinedJavaStatements(indent: 2))
-            public \(cResultType.javaType) apply(\(paramDecls.joined(separator: ", "))) {
+            public \(cResultType.javaType) apply(\(paramDecls.joined(separator: .comma))) {
               \(impl.body)
             }
           }
@@ -319,7 +319,7 @@ extension FFMSwift2JavaGenerator {
         """
         @FunctionalInterface
         public interface \(functionType.name) {
-          \(functionType.result.javaResultType) apply(\(apiParams.joined(separator: ", ")));
+          \(functionType.result.javaResultType) apply(\(apiParams.joined(separator: .comma)));
         }
         """
       )
@@ -333,7 +333,7 @@ extension FFMSwift2JavaGenerator {
       ) { printer in
         printer.print(
           """
-          return \(cdeclDescriptor).toUpcallStub((\(cdeclParams.joined(separator: ", "))) -> {
+          return \(cdeclDescriptor).toUpcallStub((\(cdeclParams.joined(separator: .comma))) -> {
           """
         )
         printer.indent()
@@ -343,7 +343,7 @@ extension FFMSwift2JavaGenerator {
           convertedArgs.append(arg)
         }
 
-        let call = "fi.apply(\(convertedArgs.joined(separator: ", ")))"
+        let call = "fi.apply(\(convertedArgs.joined(separator: .comma)))"
         let result = functionType.result.conversion.render(&printer, call)
         if functionType.result.javaResultType == .void {
           printer.print("\(result);")
@@ -394,7 +394,7 @@ extension FFMSwift2JavaGenerator {
     if translatedSignature.canThrowSwiftIntegerOverflowException {
       throwsClauses.append(JavaType.swiftIntegerOverflowException.className!)
     }
-    let throwsClause = throwsClauses.isEmpty ? "" : " throws \(throwsClauses.joined(separator: ", "))"
+    let throwsClause = throwsClauses.isEmpty ? "" : " throws \(throwsClauses.joined(separator: .comma))"
 
     TranslatedDocumentation.printDocumentation(
       importedFunc: decl,
@@ -404,7 +404,7 @@ extension FFMSwift2JavaGenerator {
     )
     printer.printBraceBlock(
       """
-      \(annotationsStr)\(modifiers) \(returnTy) \(methodName)(\(paramDecls.joined(separator: ", ")))\(throwsClause)
+      \(annotationsStr)\(modifiers) \(returnTy) \(methodName)(\(paramDecls.joined(separator: .comma)))\(throwsClause)
       """
     ) { printer in
       if case .instance = decl.functionSignature.selfParameter {
@@ -516,7 +516,7 @@ extension FFMSwift2JavaGenerator {
     }
 
     //=== Part 3: Downcall.
-    let downCall = "\(thunkName).call(\(downCallArguments.joined(separator: ", ")))"
+    let downCall = "\(thunkName).call(\(downCallArguments.joined(separator: .comma)))"
 
     /// Helper to emit the error check after a downcall
     func printErrorCheck(_ printer: inout JavaPrinter) {
@@ -813,7 +813,7 @@ extension FFMSwift2JavaGenerator.JavaConversionStep {
           placeholderForDowncall: placeholderForDowncall,
         )
       }
-      return "\(tupleClassName)(\(args.joined(separator: ", ")))"
+      return "\(tupleClassName)(\(args.joined(separator: .comma)))"
     }
   }
 }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -180,7 +180,7 @@ extension JNISwift2JavaGenerator {
     if !self.interfaceProtocolWrappers.keys.contains(decl) && !extends.contains("JNISwiftInstance") {
       extends.append("JNISwiftInstance")
     }
-    let extendsString = extends.isEmpty ? "" : " extends \(extends.joined(separator: ", "))"
+    let extendsString = extends.isEmpty ? "" : " extends \(extends.joined(separator: .comma))"
 
     printer.printBraceBlock("public interface \(decl.effectiveJavaSimpleName)\(extendsString)") { printer in
       for initializer in decl.initializers {
@@ -270,7 +270,7 @@ extension JNISwift2JavaGenerator {
       if isEffectivelyGeneric {
         swiftPointerParams.append("selfTypePointer")
       }
-      let swiftPointerArg = swiftPointerParams.map { "long \($0)" }.joined(separator: ", ")
+      let swiftPointerArg = swiftPointerParams.map { "long \($0)" }.joined(separator: .comma)
       printer.printBraceBlock("private \(decl.effectiveJavaSimpleName)(\(swiftPointerArg), SwiftArena swiftArena)") { printer in
         for param in swiftPointerParams {
           printer.print(
@@ -304,11 +304,11 @@ extension JNISwift2JavaGenerator {
          * </ul>
          */
         public static\(genericClause) \(javaName)\(genericClause) wrapMemoryAddressUnsafe(\(swiftPointerArg), SwiftArena swiftArena) {
-          return new \(javaName)\(genericClause)(\(swiftPointerParams.joined(separator: ", ")), swiftArena);
+          return new \(javaName)\(genericClause)(\(swiftPointerParams.joined(separator: .comma)), swiftArena);
         }
 
         public static\(genericClause) \(javaName)\(genericClause) wrapMemoryAddressUnsafe(\(swiftPointerArg)) {
-          return new \(javaName)\(genericClause)(\(swiftPointerParams.joined(separator: ", ")), SwiftMemoryManagement.DEFAULT_SWIFT_JAVA_AUTO_ARENA);
+          return new \(javaName)\(genericClause)(\(swiftPointerParams.joined(separator: .comma)), SwiftMemoryManagement.DEFAULT_SWIFT_JAVA_AUTO_ARENA);
         }
         """
       )
@@ -458,7 +458,7 @@ extension JNISwift2JavaGenerator {
       .compactMap(\.asNominalTypeDeclaration)
       .filter { $0.kind == .protocol }
       .map(\.name)
-    let implementsClause = implements.joined(separator: ", ")
+    let implementsClause = implements.joined(separator: .comma)
     // Specialized types are concrete — no generic clause on the Java side
     let genericClause = decl.javaGenericClause
     printer.printBraceBlock(
@@ -510,7 +510,7 @@ extension JNISwift2JavaGenerator {
       if decl.genericParameterNames.isEmpty {
         ""
       } else {
-        "<\(decl.genericParameterNames.joined(separator: ", "))>"
+        "<\(decl.genericParameterNames.joined(separator: .comma))>"
       }
 
     printer.printBraceBlock("public sealed interface Case\(caseGenericClause)") { printer in
@@ -524,7 +524,7 @@ extension JNISwift2JavaGenerator {
         }
 
         // Print record
-        printer.print("record \(translatedCase.name)\(caseGenericClause)(\(members.joined(separator: ", "))) implements Case\(caseGenericClause) {}")
+        printer.print("record \(translatedCase.name)\(caseGenericClause)(\(members.joined(separator: .comma))) implements Case\(caseGenericClause) {}")
       }
     }
     printer.println()
@@ -591,7 +591,7 @@ extension JNISwift2JavaGenerator {
           } else {
             (0..<enumCase.parameters.count).map { i in
               "t.$\(i)"
-            }.joined(separator: ", ")
+            }.joined(separator: .comma)
           }
         let translatedResult = getAsCaseFunction.translatedFunctionSignature.result
         getAsCaseFunction.translatedFunctionSignature.result.conversion = .method(
@@ -679,7 +679,7 @@ extension JNISwift2JavaGenerator {
       """
       @FunctionalInterface
       public interface \(functionType.name) {
-        \(functionType.result.javaType) apply(\(apiParams.joined(separator: ", ")));
+        \(functionType.result.javaType) apply(\(apiParams.joined(separator: .comma)));
       }
       """
     )
@@ -732,7 +732,7 @@ extension JNISwift2JavaGenerator {
       generics.append((name, extends))
     }
     .map { "\($0) extends \($1.compactMap(\.className).joined(separator: " & "))" }
-    .joined(separator: ", ")
+    .joined(separator: .comma)
 
     if !generics.isEmpty {
       modifiers.append("<" + generics + ">")
@@ -741,7 +741,7 @@ extension JNISwift2JavaGenerator {
     var annotationsStr = translatedSignature.annotations.map({ $0.render() }).joined(separator: "\n")
     if !annotationsStr.isEmpty { annotationsStr += "\n" }
 
-    let parametersStr = parameters.joined(separator: ", ")
+    let parametersStr = parameters.joined(separator: .comma)
 
     // Print default global arena variation
     // If we have enabled javaCallbacks we must emit default
@@ -772,7 +772,7 @@ extension JNISwift2JavaGenerator {
       ) { printer in
         let globalArenaName = "SwiftMemoryManagement.DEFAULT_SWIFT_JAVA_AUTO_ARENA"
         let arguments = translatedDecl.translatedFunctionSignature.parameters.map(\.parameter.name) + [globalArenaName]
-        let call = "\(translatedDecl.name)(\(arguments.joined(separator: ", ")))"
+        let call = "\(translatedDecl.name)(\(arguments.joined(separator: .comma)))"
         if translatedDecl.translatedFunctionSignature.result.javaType.isVoid {
           printer.print("\(call);")
         } else {
@@ -794,7 +794,7 @@ extension JNISwift2JavaGenerator {
       )
     }
     let signature =
-      "\(annotationsStr)\(modifiers.joined(separator: " ")) \(resultType) \(translatedDecl.name)(\(parameters.joined(separator: ", ")))\(throwsClause)"
+      "\(annotationsStr)\(modifiers.joined(separator: " ")) \(resultType) \(translatedDecl.name)(\(parameters.joined(separator: .comma)))\(throwsClause)"
     if skipMethodBody {
       printer.print("\(signature);")
     } else {
@@ -820,7 +820,7 @@ extension JNISwift2JavaGenerator {
 
     let renderedParameters = parameters.map { javaParameter in
       "\(javaParameter.type) \(javaParameter.name)"
-    }.joined(separator: ", ")
+    }.joined(separator: .comma)
 
     printer.print("private static native \(resultType) \(translatedDecl.nativeFunctionName)(\(renderedParameters));")
   }
@@ -862,7 +862,7 @@ extension JNISwift2JavaGenerator {
     // TODO: If we always generate a native method and a "public" method, we can actually choose our own thunk names
     // using the registry?
     let downcall =
-      "\(translatedDecl.parentName).\(translatedDecl.nativeFunctionName)(\(arguments.joined(separator: ", ")))"
+      "\(translatedDecl.parentName).\(translatedDecl.nativeFunctionName)(\(arguments.joined(separator: .comma)))"
 
     //=== Part 4: Convert the return value.
     if translatedFunctionSignature.result.javaType.isVoid {

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -114,7 +114,7 @@ extension JNISwift2JavaGenerator {
 
       let associatedValueTypes = enumCase.parameters.map { param in
         param.type.description
-      }.joined(separator: ", ")
+      }.joined(separator: .comma)
       let javaCaseClassName = enumCase.name.firstCharacterUppercased
       let resultType = knownTypes.optionalSugar(
         .tuple(
@@ -1830,7 +1830,7 @@ extension JNISwift2JavaGenerator {
         return "\(placeholder)_\(component)"
 
       case .commaSeparated(let list):
-        return list.map({ $0.render(&printer, placeholder) }).joined(separator: ", ")
+        return list.map({ $0.render(&printer, placeholder) }).joined(separator: .comma)
 
       case .valueMemoryAddress:
         return "\(placeholder).$memoryAddress()"
@@ -1850,7 +1850,7 @@ extension JNISwift2JavaGenerator {
         }
         let genericClause =
           if !typeParameters.isEmpty {
-            "<\(typeParameters.map(\.description).joined(separator: ", "))>"
+            "<\(typeParameters.map(\.description).joined(separator: .comma))>"
           } else {
             ""
           }
@@ -1870,7 +1870,7 @@ extension JNISwift2JavaGenerator {
       case .method(let inner, let methodName, let arguments):
         let inner = inner.render(&printer, placeholder)
         let args = arguments.map { $0.render(&printer, placeholder) }
-        let argsStr = args.joined(separator: ", ")
+        let argsStr = args.joined(separator: .comma)
         return "\(inner).\(methodName)(\(argsStr))"
 
       case .member(let inner, let fieldName):
@@ -1917,7 +1917,7 @@ extension JNISwift2JavaGenerator {
       case .subscriptOf(let inner, let arguments):
         let inner = inner.render(&printer, placeholder)
         let arguments = arguments.map { $0.render(&printer, placeholder) }
-        return "\(inner)[\(arguments.joined(separator: ", "))]"
+        return "\(inner)[\(arguments.joined(separator: .comma))]"
 
       case .aggregate(let variable, let steps):
         precondition(!steps.isEmpty, "Aggregate must contain steps")
@@ -1951,7 +1951,7 @@ extension JNISwift2JavaGenerator {
 
       case .lambda(let args, let body):
         var printer = JavaPrinter()
-        printer.printBraceBlock("(\(args.joined(separator: ", "))) ->") { printer in
+        printer.printBraceBlock("(\(args.joined(separator: .comma))) ->") { printer in
           let body = body.render(&printer, placeholder)
           if !body.isEmpty {
             printer.print("return \(body);")
@@ -1976,7 +1976,7 @@ extension JNISwift2JavaGenerator {
           let converted = element.elementConversion.render(&printer, "\(element.outParamName)[0]")
           args.append(converted)
         }
-        return "new \(tupleClassName)(\(args.joined(separator: ", ")))"
+        return "new \(tupleClassName)(\(args.joined(separator: .comma)))"
 
       case .placeToVar(let inner, let name, let type):
         let inner = inner.render(&printer, placeholder)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+LabeledTuples.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+LabeledTuples.swift
@@ -58,15 +58,15 @@ extension JNISwift2JavaGenerator {
 
     // Generic type parameter names: T0, T1, ...
     let typeParams = (0..<arity).map { "T\($0)" }
-    let typeParamsClause = "<\(typeParams.joined(separator: ", "))>"
+    let typeParamsClause = "<\(typeParams.joined(separator: .comma))>"
     let baseTupleClass = "org.swift.swiftkit.core.tuple.Tuple\(arity)"
 
     // Constructor parameters: T0 param0, T1 param1, ...
     // Use paramN names (not $0, $1) because `$N` is invalid as a Swift parameter name,
     // and the wrap-java generator copies parameter names verbatim into Swift wrappers
     let paramNames = (0..<arity).map { "param\($0)" }
-    let ctorParams = zip(typeParams, paramNames).map { "\($0) \($1)" }.joined(separator: ", ")
-    let superArgs = paramNames.joined(separator: ", ")
+    let ctorParams = zip(typeParams, paramNames).map { "\($0) \($1)" }.joined(separator: .comma)
+    let superArgs = paramNames.joined(separator: .comma)
 
     printer.printBraceBlock("public static final class \(rawClassName)\(typeParamsClause) extends \(baseTupleClass)\(typeParamsClause)") { printer in
       // Constructor

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -1130,7 +1130,7 @@ extension JNISwift2JavaGenerator {
         if nominalType.genericArguments.isEmpty {
           return bridgeName
         } else {
-          return "\(bridgeName)<\(nominalType.genericArguments.map(\.description).joined(separator: ", "))>"
+          return "\(bridgeName)<\(nominalType.genericArguments.map(\.description).joined(separator: .comma))>"
         }
 
       case .genericParameter:
@@ -1401,7 +1401,7 @@ extension JNISwift2JavaGenerator {
               return
                 "\(nominalTypeDecl.javaInterfaceVariableName): \(nominalTypeDecl.javaInterfaceName)(javaThis: \(inner)!, environment: environment)"
             }
-            printer.print("\(variableName) = \(swiftWrapperClassName)(\(arguments.joined(separator: ", ")))")
+            printer.print("\(variableName) = \(swiftWrapperClassName)(\(arguments.joined(separator: .comma)))")
           }
         } else {
           printStandardJExtractBlock(&printer)
@@ -1507,7 +1507,7 @@ extension JNISwift2JavaGenerator {
         )
 
         let names = parameters.flatMap { $0.parameters.map(\.name) }
-        let closureParameters = !parameters.isEmpty ? "\(names.joined(separator: ", ")) in" : ""
+        let closureParameters = !parameters.isEmpty ? "\(names.joined(separator: .comma)) in" : ""
         printer.print("{ \(closureParameters)")
         printer.indent()
 
@@ -1521,7 +1521,7 @@ extension JNISwift2JavaGenerator {
           let class$ = environment.interface.GetObjectClass(environment, \(placeholder))
           let methodID$ = environment.interface.GetMethodID(environment, class$, "apply", "\(methodSignature.mangledName)")!
           environment.interface.DeleteLocalRef(environment, class$)
-          let arguments$: [jvalue] = [\(arguments.joined(separator: ", "))]
+          let arguments$: [jvalue] = [\(arguments.joined(separator: .comma))]
           """
         )
 
@@ -1547,7 +1547,7 @@ extension JNISwift2JavaGenerator {
         let parameterNames = fn.parameters.enumerated().map { idx, param in
           param.parameterName ?? "_\(idx)"
         }
-        let closureParameters = parameterNames.joined(separator: ", ")
+        let closureParameters = parameterNames.joined(separator: .comma)
         let isVoid = fn.resultType == .tuple([])
 
         // Build upcall arguments using UpcallConversionStep conversions
@@ -1563,7 +1563,7 @@ extension JNISwift2JavaGenerator {
         // Note: The Java interface is synchronous even for async closures.
         // The async nature is on the Swift side, inferred from the expected type.
         var resultPrinter = SwiftPrinter()
-        let upcallExpr = "javaInterface$.apply(\(upcallArguments.joined(separator: ", ")))"
+        let upcallExpr = "javaInterface$.apply(\(upcallArguments.joined(separator: .comma)))"
         let resultConverted = syntheticFunction.resultConversion.render(&resultPrinter, upcallExpr)
         let resultPrefix = resultPrinter.finalize()
 
@@ -1689,7 +1689,7 @@ extension JNISwift2JavaGenerator {
             return value
           }
         }
-        let argsStr = args.joined(separator: ", ")
+        let argsStr = args.joined(separator: .comma)
         return "\(swiftType)(\(argsStr))"
 
       case .method(let inner, let methodName, let arguments):
@@ -1702,7 +1702,7 @@ extension JNISwift2JavaGenerator {
             return value
           }
         }
-        let argsStr = args.joined(separator: ", ")
+        let argsStr = args.joined(separator: .comma)
         return "\(inner).\(methodName)(\(argsStr))"
 
       case .member(let inner, let member):
@@ -1923,7 +1923,7 @@ extension JNISwift2JavaGenerator {
             return converted
           }
         }
-        return "(\(parts.joined(separator: ", ")))"
+        return "(\(parts.joined(separator: .comma)))"
 
       case .tupleDestructure(let elements):
         let tupleVar = "tupleResult$"

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+SwiftThunkPrinting.swift
@@ -185,7 +185,7 @@ extension JNISwift2JavaGenerator {
     let inheritedWrappers = self.inheritedProtocols(of: translatedWrapper.importedType).compactMap { self.interfaceProtocolWrappers[$0] }
     let inheritedTypes = [translatedWrapper.swiftName] + inheritedWrappers.map(\.wrapperName)
 
-    printer.printBraceBlock("protocol \(translatedWrapper.wrapperName): \(inheritedTypes.joined(separator: ", "))") { printer in
+    printer.printBraceBlock("protocol \(translatedWrapper.wrapperName): \(inheritedTypes.joined(separator: .comma))") { printer in
       printer.print(
         "var \(translatedWrapper.javaInterfaceVariableName): \(translatedWrapper.javaInterfaceName) { get }"
       )
@@ -260,7 +260,7 @@ extension JNISwift2JavaGenerator {
 
         let tryClause = function.originalFunctionSignature.isThrowing ? "try " : ""
         let javaUpcall =
-          "\(tryClause)\(wrapper.javaInterfaceVariableName).\(function.swiftFunctionName)(\(upcallArguments.joined(separator: ", ")))"
+          "\(tryClause)\(wrapper.javaInterfaceVariableName).\(function.swiftFunctionName)(\(upcallArguments.joined(separator: .comma)))"
 
         let result = function.resultConversion.render(&printer, javaUpcall)
         printer.print("\(returnStmt)\(result)")
@@ -425,11 +425,11 @@ extension JNISwift2JavaGenerator {
       printer.printBraceBlock("extension \(enumType.effectiveSwiftTypeName)") { printer in
         let associatedValueTypes = enumCase.original.parameters.map { param in
           param.type.description
-        }.joined(separator: ", ")
+        }.joined(separator: .comma)
         printer.printBraceBlock("fileprivate func getAs\(enumCase.name)() -> (\(associatedValueTypes))?") { printer in
           let params = enumCase.original.parameters.enumerated().map { i, param in
             param.name ?? "_\(i)"
-          }.joined(separator: ", ")
+          }.joined(separator: .comma)
           printer.printIfBlock("case let .\(enumCase.original.name)(\(params)) = self") { printer in
             printer.print("return (\(params))")
           }
@@ -524,7 +524,7 @@ extension JNISwift2JavaGenerator {
         parameterName: parameterName,
         parentName: decl.parentType?.asNominalType?.nominalTypeDecl.qualifiedTypeName ?? SwiftQualifiedTypeName(swiftModuleName),
       )
-      let implementingProtocols = protocolWrappers.map(\.wrapperName).joined(separator: ", ")
+      let implementingProtocols = protocolWrappers.map(\.wrapperName).joined(separator: .comma)
 
       printer.printBraceBlock("final class \(swiftClassName): \(implementingProtocols)") { printer in
         let variables: [(String, String)] = protocolWrappers.map { wrapper in
@@ -534,7 +534,7 @@ extension JNISwift2JavaGenerator {
           printer.print("let \(name): \(type)")
         }
         printer.println()
-        let initializerParameters = variables.map { "\($0): \($1)" }.joined(separator: ", ")
+        let initializerParameters = variables.map { "\($0): \($1)" }.joined(separator: .comma)
 
         printer.printBraceBlock("init(\(initializerParameters))") { printer in
           for (name, _) in variables {
@@ -635,7 +635,7 @@ extension JNISwift2JavaGenerator {
         let label = originalParam.argumentLabel.map { "\($0): " } ?? ""
         return "\(label)\(argument)"
       }
-      .joined(separator: ", ")
+      .joined(separator: .comma)
       result = "\(tryClause)\(callee).\(decl.name)(\(downcallArguments))"
 
     case .enumCase:
@@ -647,7 +647,7 @@ extension JNISwift2JavaGenerator {
         return "\(label)\(argument)"
       }
 
-      let associatedValues = !downcallArguments.isEmpty ? "(\(downcallArguments.joined(separator: ", ")))" : ""
+      let associatedValues = !downcallArguments.isEmpty ? "(\(downcallArguments.joined(separator: .comma)))" : ""
       result = "\(callee).\(decl.name)\(associatedValues)"
 
     case .getter:
@@ -667,7 +667,7 @@ extension JNISwift2JavaGenerator {
         let label = originalParam.argumentLabel.map { "\($0): " } ?? ""
         return "\(label)\(argument)"
       }
-      .joined(separator: ", ")
+      .joined(separator: .comma)
       result = "\(callee)[\(parameters)]"
     case .subscriptSetter:
       guard let newValueArgument = arguments.last else {
@@ -683,7 +683,7 @@ extension JNISwift2JavaGenerator {
         let label = originalParam.argumentLabel.map { "\($0): " } ?? ""
         return "\(label)\(argument)"
       }
-      .joined(separator: ", ")
+      .joined(separator: .comma)
       result = "\(callee)[\(parameters)] = \(newValueArgument)"
     }
 
@@ -792,7 +792,7 @@ extension JNISwift2JavaGenerator {
       @diagnose(DeprecatedDeclaration, as: ignored)
       #endif
       @_cdecl("\(cName)")
-      public func \(cName)(\(thunkParameters.joined(separator: ", ")))\(thunkReturnType)
+      public func \(cName)(\(thunkParameters.joined(separator: .comma)))\(thunkReturnType)
       """
     ) { printer in
       body(&printer)
@@ -851,7 +851,7 @@ extension JNISwift2JavaGenerator {
       if type.genericParameterNames.isEmpty {
         type.effectiveSwiftTypeName
       } else {
-        "\(type.baseTypeName)<\(type.swiftNominal.genericParameters.map(\.packExpansionName).joined(separator: ", "))>"
+        "\(type.baseTypeName)<\(type.swiftNominal.genericParameters.map(\.packExpansionName).joined(separator: .comma))>"
       }
     let parentProtocol = isEffectivelyGeneric ? "JextractedGenericTypeBridge" : "JextractedTypeBridge"
 
@@ -1008,7 +1008,7 @@ extension JNISwift2JavaGenerator {
       + parameters.map { javaParameter in
         "\(javaParameter.name): \(javaParameter.name)"
       }
-    let call = "openerType.\(decl.openerMethodName)(\(openerArguments.joined(separator: ", ")))"
+    let call = "openerType.\(decl.openerMethodName)(\(openerArguments.joined(separator: .comma)))"
 
     if !decl.functionSignature.result.type.isVoid {
       printer.print("return \(call)")
@@ -1047,7 +1047,7 @@ extension JNISwift2JavaGenerator {
         ] + translatedParameters
       let thunkReturnType = resultType != .void ? " -> \(resultType.jniTypeName)" : ""
 
-      let signature = #"static func \#(decl.openerMethodName)(\#(thunkParameters.joined(separator: ", ")))\#(thunkReturnType)"#
+      let signature = #"static func \#(decl.openerMethodName)(\#(thunkParameters.joined(separator: .comma)))\#(thunkReturnType)"#
       if !skipMethodBody {
         printer.printBraceBlock(signature) { printer in
           printFunctionDowncall(&printer, decl)


### PR DESCRIPTION
Minor thing but typing out the ", " by hand all the time was getting tedious. Instead, introduce a constant for it so we don't miss adding the space etc.