### PR TITLE
Import FoundationEssentials if available

### DIFF
--- a/Sources/JavaStdlib/JavaNet/JavaURL+Extensions.swift
+++ b/Sources/JavaStdlib/JavaNet/JavaURL+Extensions.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftJava
 import SwiftJavaJNICore
 

--- a/Sources/JavaStdlib/JavaNet/JavaURL+Extensions.swift
+++ b/Sources/JavaStdlib/JavaNet/JavaURL+Extensions.swift
@@ -12,13 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftJava
+import SwiftJavaJNICore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import SwiftJava
-import SwiftJavaJNICore
 
 extension JavaURL {
   @JavaMethod


### PR DESCRIPTION
We really don't want to drag in the full Foundation on non-Apple platforms.