### PR TITLE
[Android] Add proguard rules

### DIFF
--- a/SwiftKitCore/src/main/resources/META-INF/proguard/consumer-proguard-rules.pro
+++ b/SwiftKitCore/src/main/resources/META-INF/proguard/consumer-proguard-rules.pro
@@ -1,0 +1,3 @@
+# R8/ProGuard rules
+-keep class org.swift.swiftkit.** { *; }
+-keep interface org.swift.swiftkit.** { *; }


### PR DESCRIPTION
Since swift-java uses reflection, we need to tell R8 to not strip the library types, otherwise we would get a runtime crash. 