### PR TITLE
Support installing docc plugin via env var

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,19 @@ if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", branch: "main")
 }
 
+// Set SWIFTJAVA_DOCC_PLUGIN_INSTALL=1 to install the docc-plugin automatically.
+// This is a workaround because swift-subprocess includes the plugin explicitly,
+// which breaks tools trying to add `swift package add-dependency` the plugin
+// to swift-java because it thinks the plugin was already added, but it is not.
+let extraDependencies: [Package.Dependency]
+if Context.environment["SWIFTJAVA_DOCC_PLUGIN_INSTALL"] == "1" {
+  extraDependencies = [
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.5.0")
+  ]
+} else {
+  extraDependencies = []
+}
+
 let package = Package(
   name: "swift-java",
   platforms: [
@@ -159,7 +172,7 @@ let package = Package(
 
     // Benchmarking
     .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),
-  ],
+  ] + extraDependencies,
   targets: [
     .target(
       name: "SwiftJavaDocumentation",

--- a/Sources/JavaStdlib/JavaLangReflect/generated/Executable.swift
+++ b/Sources/JavaStdlib/JavaLangReflect/generated/Executable.swift
@@ -2,6 +2,7 @@
 import SwiftJava
 import SwiftJavaJNICore
 
+/// Java `sealed class`, permits: `java.lang.reflect.Constructor`, `java.lang.reflect.Method`
 @JavaClass("java.lang.reflect.Executable", implements: GenericDeclaration.self)
 open class Executable: AccessibleObject {
   /// Java method `getAnnotatedExceptionTypes`.

--- a/Sources/SwiftJava/generated/ByteBuffer.swift
+++ b/Sources/SwiftJava/generated/ByteBuffer.swift
@@ -38,6 +38,7 @@ extension JavaClass<ByteBuffer> {
   @JavaStaticMethod
   public func wrap(_ arg0: [Int8], _ arg1: Int32, _ arg2: Int32) -> ByteBuffer!
 }
+/// Java `sealed class`, permits: `java.nio.HeapByteBuffer`, `java.nio.MappedByteBuffer`
 @JavaClass("java.nio.ByteBuffer")
 open class ByteBuffer: JavaObject {
   /// Java method `alignedSlice`.

--- a/Sources/SwiftJava/generated/JavaThread.swift
+++ b/Sources/SwiftJava/generated/JavaThread.swift
@@ -383,6 +383,7 @@ open class JavaThread: JavaObject {
   open override func toString() -> String
 }
 extension JavaThread {
+  /// Java `sealed interface`, permits: `java.lang.Thread$Builder$OfPlatform`, `java.lang.Thread$Builder$OfVirtual`
   @JavaInterface("java.lang.Thread$Builder")
   public struct Builder {
     /// Java method `inheritInheritableThreadLocals`.
@@ -423,6 +424,7 @@ extension JavaThread {
   }
 }
 extension JavaThread.Builder {
+  /// Java `sealed interface`, permits: `java.lang.ThreadBuilders$PlatformThreadBuilder`
   @JavaInterface("java.lang.Thread$Builder$OfPlatform", extends: JavaThread.Builder.self)
   public struct OfPlatform {
     /// Java method `daemon`.
@@ -499,6 +501,7 @@ extension JavaThread.Builder {
   }
 }
 extension JavaThread.Builder {
+  /// Java `sealed interface`, permits: `java.lang.ThreadBuilders$VirtualThreadBuilder`
   @JavaInterface("java.lang.Thread$Builder$OfVirtual", extends: JavaThread.Builder.self)
   public struct OfVirtual {
     /// Java method `inheritInheritableThreadLocals`.


### PR DESCRIPTION
This is a workaround for `swift package add-dependency` not working due to swift-subprocess pulling it in explicitly:

```
[swift-java] -> % swift package add-dependency https://github.com/swiftlang/swift-docc-plugin --from 1.1.0
error: unable to add dependency 'https://github.com/swiftlang/swift-docc-plugin' because it already exists in the list of dependencies
```

even though

```
-> % swift package generate-documentation
error: Unknown subcommand or plugin name 'generate-documentation'
Usage: swift package <options> <subcommand>
```

So this is a workaround to enable the plugin in this package