### PR TITLE
jextract: Remove emitting interface decl for known func interface

### DIFF
--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -232,36 +232,38 @@ extension FFMSwift2JavaGenerator {
       private static class \(name)
       """
     ) { printer in
-      printer.print(
-        """
-        @FunctionalInterface
-        public interface Function {
-          \(cResultType.javaType) apply(\(paramDecls.joined(separator: .comma)));
+      let (interfaceName, methodName, isKnownFuncInterface) =
+        if let known = KnownJavaFunctionalInterface.find(parameters: cParameterTypes, result: cResultType) {
+          (known.javaType.description, known.method, true)
+        } else {
+          ("Function", "apply", false)
         }
-        """
-      )
 
-      if let impl {
+      if !isKnownFuncInterface {
         printer.print(
           """
-          public final static class Function$Impl implements Function {
-            \(impl.members.joinedJavaStatements(indent: 2))
-            public \(cResultType.javaType) apply(\(paramDecls.joined(separator: .comma))) {
-              \(impl.body)
-            }
+          @FunctionalInterface
+          public interface Function {
+            \(cResultType.javaType) apply(\(paramDecls.joined(separator: .comma)));
           }
           """
         )
+
+        if let impl {
+          printer.print(
+            """
+            public final static class Function$Impl implements Function {
+              \(impl.members.joinedJavaStatements(indent: 2))
+              public \(cResultType.javaType) apply(\(paramDecls.joined(separator: .comma))) {
+                \(impl.body)
+              }
+            }
+            """
+          )
+        }
       }
 
       printFunctionDescriptorDefinition(&printer, cResultType, cParams)
-      let (interfaceName, methodName) =
-        if let known = KnownJavaFunctionalInterface.find(parameters: cParameterTypes, result: cResultType) {
-          (known.javaType.description, known.method)
-        } else {
-          ("Function", "apply")
-        }
-
       printer.print(
         """
         private static final MethodHandle HANDLE = SwiftRuntime.upcallHandle(\(interfaceName).class, "\(methodName)", DESC);

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -305,23 +305,27 @@ extension FFMSwift2JavaGenerator {
   ) {
     let cdeclDescriptor = "\(bindingDescriptorName).$\(functionType.name)"
     if functionType.isCompatibleWithC {
-      if !functionType.swiftType.isEscaping && functionType.parameters.isEmpty && functionType.swiftType.resultType.isVoid {
+      let (interfaceName, isKnownFuncInterface) =
+        if let known = KnownJavaFunctionalInterface.find(functionType) {
+          (known.javaType.description, true)
+        } else {
+          (functionType.name, false)
+        }
+
+      if !isKnownFuncInterface {
+        // If the user-facing functional interface is C ABI compatible, just extend
+        // the lowered function pointer parameter interface.
         printer.print(
           """
-          private static MemorySegment $toUpcallStub(java.lang.Runnable fi, Arena arena) {
-            return \(bindingDescriptorName).$\(functionType.name).toUpcallStub(fi, arena);
-          }
+          @FunctionalInterface
+          public interface \(interfaceName) extends \(cdeclDescriptor).Function {}
           """
         )
-        return
       }
-      // If the user-facing functional interface is C ABI compatible, just extend
-      // the lowered function pointer parameter interface.
+
       printer.print(
         """
-        @FunctionalInterface
-        public interface \(functionType.name) extends \(cdeclDescriptor).Function {}
-        private static MemorySegment $toUpcallStub(\(functionType.name) fi, Arena arena) {
+        private static MemorySegment $toUpcallStub(\(interfaceName) fi, Arena arena) {
           return \(bindingDescriptorName).$\(functionType.name).toUpcallStub(fi, arena);
         }
         """

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -791,8 +791,10 @@ extension JNISwift2JavaGenerator {
       return
     }
 
-    // If it's contain one function type and it's known java functional interface type, we don't need to print the whole class
-    if translated.functionTypes.count == 1 && KnownJavaFunctionalInterface.find(translated.functionTypes[0]) != nil {
+    // If contains one function type and it's known java functional interface type, we don't need to print the whole class
+    if translated.functionTypes.count == 1, 
+       let ty = translated.functionTypes.first, 
+       KnownJavaFunctionalInterface.find(ty) != nil {
       return
     }
 

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -791,12 +791,21 @@ extension JNISwift2JavaGenerator {
       return
     }
 
+    // If it's contain one function type and it's known java functional interface type, we don't need to print the whole class
+    if translated.functionTypes.count == 1 && KnownJavaFunctionalInterface.find(translated.functionTypes[0]) != nil {
+      return
+    }
+
     printer.printBraceBlock(
       """
       public static class \(translated.name)
       """
     ) { printer in
       for functionType in translated.functionTypes {
+        if KnownJavaFunctionalInterface.find(functionType) != nil {
+          continue
+        }
+
         printJavaBindingWrapperFunctionTypeHelper(&printer, functionType)
       }
     }

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -792,9 +792,10 @@ extension JNISwift2JavaGenerator {
     }
 
     // If contains one function type and it's known java functional interface type, we don't need to print the whole class
-    if translated.functionTypes.count == 1, 
-       let ty = translated.functionTypes.first, 
-       KnownJavaFunctionalInterface.find(ty) != nil {
+    if translated.functionTypes.count == 1,
+      let ty = translated.functionTypes.first,
+      KnownJavaFunctionalInterface.find(ty) != nil
+    {
       return
     }
 

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -55,6 +55,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     return find(parameters: functionType.parameters, result: functionType.result)
   }
 
+  static func find(_ functionType: FFMSwift2JavaGenerator.TranslatedFunctionType) -> KnownJavaFunctionalInterface? {
+    if functionType.swiftType.isEscaping {
+      return nil
+    }
+    return find(parameters: functionType.parameters.map(\.parameter.type.javaType), result: functionType.result.javaResultType)
+  }
+
   init(_ javaType: JavaType, method: String, parameters: [JavaType], result: JavaType) {
     self.javaType = javaType
     self.method = method

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -40,8 +40,19 @@ struct KnownJavaFunctionalInterface: Sendable {
     find(parameters: parameters.map(\.javaType), result: result.javaType)
   }
 
+  static func find(parameters: [JNISwift2JavaGenerator.TranslatedParameter], result: JNISwift2JavaGenerator.TranslatedResult) -> KnownJavaFunctionalInterface? {
+    find(parameters: parameters.map(\.parameter.type.javaType), result: result.javaType)
+  }
+
   static func find(_ methodSignature: MethodSignature) -> KnownJavaFunctionalInterface? {
     find(parameters: methodSignature.parameterTypes, result: methodSignature.resultType)
+  }
+
+  static func find(_ functionType: JNISwift2JavaGenerator.TranslatedFunctionType) -> KnownJavaFunctionalInterface? {
+    if functionType.isEscaping {
+      return nil
+    }
+    return find(parameters: functionType.parameters, result: functionType.result)
   }
 
   init(_ javaType: JavaType, method: String, parameters: [JavaType], result: JavaType) {

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -95,10 +95,6 @@ final class FuncCallbackImportTests {
            * }
            */
           private static class $callback {
-            @FunctionalInterface
-            public interface Function {
-              void apply();
-            }
             private static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid();
             private static final MethodHandle HANDLE = SwiftRuntime.upcallHandle(java.lang.Runnable.class, "run", DESC);
             private static MemorySegment toUpcallStub(java.lang.Runnable fi, Arena arena) {
@@ -203,10 +199,6 @@ final class FuncCallbackImportTests {
            * }
            */
           private static class $fn {
-            @FunctionalInterface
-            public interface Function {
-              void apply();
-            }
             private static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid();
             private static final MethodHandle HANDLE = SwiftRuntime.upcallHandle(java.lang.Runnable.class, "run", DESC);
             private static MemorySegment toUpcallStub(java.lang.Runnable fi, Arena arena) {

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -31,15 +31,6 @@ struct JNIClosureTests {
       .java,
       expectedChunks: [
         """
-        public static class emptyClosure {
-          /** Corresponds to the Swift closure parameter of type {@code () -> ()}. */
-          @FunctionalInterface
-          public interface closure {
-            void apply();
-          }
-        }
-        """,
-        """
         /**
          * Downcall to Swift:
          * {@snippet lang=swift :

--- a/Tests/JExtractSwiftTests/JNI/JNIEscapingClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIEscapingClosureTests.swift
@@ -174,29 +174,6 @@ struct JNIEscapingClosureTests {
   }
 
   @Test
-  func nonEscapingClosure_stillWorks() throws {
-    let source =
-      """
-      public func call(closure: () -> Void) {}
-      """
-
-    try assertOutput(
-      input: source,
-      .jni,
-      .java,
-      expectedChunks: [
-        """
-        /** Corresponds to the Swift closure parameter of type {@code () -> Void}. */
-        @FunctionalInterface
-        public interface closure {
-          void apply();
-        }
-        """
-      ]
-    )
-  }
-
-  @Test
   func escapingClosureWithParametersAndResult_swiftThunks() throws {
     let source =
       """


### PR DESCRIPTION
Eliminate generating unnecessary functional interface declarations when it's known java functional interface

Issue #811