### PR TITLE
Remove self-conflicting dynamic SwiftJava product declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,12 +30,11 @@ let package = Package(
     .macOS(.v13)
   ],
   products: [
-    // ==== SwiftJava (i.e. calling Java directly Swift utilities)
-    .library(
-      name: "SwiftJava",
-      type: .dynamic,
-      targets: ["SwiftJava", "SwiftJavaRuntimeSupport"]
-    ),
+    // NOTE: the dynamic "SwiftJava" product (targets: ["SwiftJava", "SwiftJavaRuntimeSupport"]) has been
+    // removed here (local edit, not upstream) because it self-conflicts under SwiftPM's duplicate-static-
+    // linkage check whenever another dynamic product (e.g. AndroidSwiftUI's SwiftAndroidApp.so) is also
+    // being built in the same graph: SwiftJavaRuntimeSupport statically depends on SwiftJava, which is
+    // also directly listed in this same dynamic product. Use "SwiftJavaStatic" instead.
 
     // EXPERIMENTAL
     //


### PR DESCRIPTION
## Summary
The `SwiftJava` product (`type: .dynamic`, targets: `["SwiftJava", "SwiftJavaRuntimeSupport"]`) is self-conflicting: `SwiftJavaRuntimeSupport` statically depends on the `SwiftJava` target, which is also directly listed in the same dynamic product. SwiftPM's duplicate-linkage check rejects this whenever any other dynamic library product exists in the same resolved graph — which happens for any consumer that embeds swift-java (directly or transitively, e.g. via PureSwift/Android's AndroidKit) into its own single dynamic `.so`, such as a JNI-bridged Android app.

`SwiftJavaStatic` already exists as the documented static-linking variant with the same target list, so this removes the conflicting dynamic declaration rather than adding a new product.

## Test plan
- [x] Consumers previously hitting `error: Swift package product 'SwiftJavaJNICore-product' is linked as a static library by ... and 'SwiftJava-product'` build successfully once switched to `SwiftJavaStatic` and this product is removed.