### PR TITLE
jextract: Implement fromByteBuffer helper for the foundation Data

### DIFF
--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/DataImportTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/DataImportTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.swift.swiftkit.ffm.AllocatingSwiftArena;
 
 import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -86,6 +87,16 @@ public class DataImportTest {
         try (var arena = AllocatingSwiftArena.ofConfined()) {
             byte[] original = new byte[] { 1, 2, 3, 4, 5 };
             var data = Data.fromByteArray(original, arena);
+            assertEquals(5, data.getCount());
+        }
+    }
+
+    @Test
+    void test_Data_fromByteBuffer() {
+        try (var arena = AllocatingSwiftArena.ofConfined()) {
+            byte[] original = new byte[] { 1, 2, 3, 4, 5 };
+            ByteBuffer buffer = ByteBuffer.wrap(original);
+            var data = Data.fromByteBuffer(buffer, arena);
             assertEquals(5, data.getCount());
         }
     }

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+FoundationData.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+FoundationData.swift
@@ -47,7 +47,21 @@ extension FFMSwift2JavaGenerator {
       """
     )
 
-    // TODO: Implement a fromByteBuffer as well
+    printer.print(
+      """
+      /**
+       * Creates a new Swift {@link \(typeName)} instance from a {@link ByteBuffer}.
+       *
+       * @param buffer The ByteBuffer to copy byte from it into the \(typeName)
+       * @param arena The arena for memory management
+       * @return A new \(typeName) instance containing a copy of the bytes
+       */
+      public static \(typeName) fromByteBuffer(java.nio.ByteBuffer buffer, AllocatingSwiftArena arena) {
+        Objects.requireNonNull(buffer, "buffer cannot be null");
+        return Data.init(buffer.array(), arena);
+      }
+      """
+    )
 
     // Print the descriptor class for copyBytes native call using the shared helper
     let copyBytesCFunc = CFunction(

--- a/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+FoundationData.swift
+++ b/Sources/JExtractSwiftLib/FFM/FFMSwift2JavaGenerator+FoundationData.swift
@@ -58,7 +58,7 @@ extension FFMSwift2JavaGenerator {
        */
       public static \(typeName) fromByteBuffer(java.nio.ByteBuffer buffer, AllocatingSwiftArena arena) {
         Objects.requireNonNull(buffer, "buffer cannot be null");
-        return Data.init(buffer.array(), arena);
+        return \(typeName).init(buffer.array(), arena);
       }
       """
     )


### PR DESCRIPTION
Implement the `fromByteBuffer` helper for the foundation Data in FFM