### PR TITLE
jextract: support returning JavaKit wrapped Java objects (Resolves #841)

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
@@ -99,6 +99,10 @@ public class MySwiftClass {
   public func addXWithJavaLong(_ other: JavaLong) -> Int64 {
     self.x + other.longValue()
   }
+
+  public func returnXAsJavaLong() -> JavaLong {
+    JavaLong(self.x)
+  }
 }
 
 extension MySwiftClass: CustomStringConvertible {

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -166,6 +166,15 @@ public class MySwiftClassTest {
     }
 
     @Test
+    void returnXAsJavaLong() {
+        try (var arena = SwiftArena.ofConfined()) {
+            MySwiftClass c1 = MySwiftClass.init(20, 10, arena);
+            Long javaLong = c1.returnXAsJavaLong();
+            assertEquals(20L, javaLong);
+        }
+    }
+
+    @Test
     void getAsyncVariable() throws Exception {
         try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c1 = MySwiftClass.init(20, 10, arena);

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -964,7 +964,16 @@ extension JNISwift2JavaGenerator {
         }
 
         if nominalType.isSwiftJavaWrapper {
-          throw JavaTranslationError.unsupportedSwiftType(swiftType)
+          guard let javaType = nominalTypeName.parseJavaClassFromSwiftJavaName(in: self.javaClassLookupTable) else {
+            throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(swiftType)
+          }
+          return TranslatedResult(
+            javaType: javaType,
+            nativeJavaType: javaType,
+            annotations: resultAnnotations,
+            outParameters: [],
+            conversion: .placeholder
+          )
         }
 
         let javaType = JavaType.class(
@@ -1339,8 +1348,17 @@ extension JNISwift2JavaGenerator {
           }
         }
 
-        guard !nominalType.isSwiftJavaWrapper else {
-          throw JavaTranslationError.unsupportedSwiftType(swiftType)
+        if nominalType.isSwiftJavaWrapper {
+          guard let javaType = nominalTypeName.parseJavaClassFromSwiftJavaName(in: self.javaClassLookupTable) else {
+            throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(swiftType)
+          }
+          return TranslatedResult(
+            javaType: javaType,
+            nativeJavaType: javaType,
+            annotations: annotations,
+            outParameters: [],
+            conversion: .placeholder
+          )
         }
 
       case .tuple:
@@ -1502,8 +1520,18 @@ extension JNISwift2JavaGenerator {
           )
         }
 
-        guard !nominalType.isSwiftJavaWrapper else {
-          throw JavaTranslationError.unsupportedSwiftType(elementType)
+        if nominalType.isSwiftJavaWrapper {
+          guard let javaType = nominalTypeName.parseJavaClassFromSwiftJavaName(in: self.javaClassLookupTable) else {
+            throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(elementType)
+          }
+
+          return TranslatedResult(
+            javaType: .array(javaType),
+            nativeJavaType: .array(javaType),
+            annotations: annotations,
+            outParameters: [],
+            conversion: .placeholder
+          )
         }
 
         let javaType = try translateGenericTypeParameter(

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaTranslation.swift
@@ -899,6 +899,7 @@ extension JNISwift2JavaGenerator {
 
       switch swiftType {
       case .nominal(let nominalType):
+        let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
         if let knownType = nominalType.asKnownType {
           switch knownType {
           case .optional(let wrapped):
@@ -1301,6 +1302,7 @@ extension JNISwift2JavaGenerator {
 
       switch swiftType {
       case .nominal(let nominalType):
+        let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
         if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
           if let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config),
             javaType.implementsJavaValue
@@ -1355,7 +1357,7 @@ extension JNISwift2JavaGenerator {
           return TranslatedResult(
             javaType: javaType,
             nativeJavaType: javaType,
-            annotations: annotations,
+            annotations: parameterAnnotations,
             outParameters: [],
             conversion: .placeholder
           )
@@ -1506,6 +1508,7 @@ extension JNISwift2JavaGenerator {
         )
 
       case .nominal(let nominalType):
+        let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
         if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
           guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config) else {
             throw JavaTranslationError.unsupportedSwiftType(elementType)

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -697,9 +697,17 @@ extension JNISwift2JavaGenerator {
           }
         }
 
-        guard !nominalType.isSwiftJavaWrapper else {
-          // TODO: Should be the same as above
-          throw JavaTranslationError.unsupportedSwiftType(swiftType)
+        if nominalType.isSwiftJavaWrapper {
+          guard let javaType = nominalTypeName.parseJavaClassFromSwiftJavaName(in: self.javaClassLookupTable) else {
+            throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(swiftType)
+          }
+
+          let optionalSwiftType = knownTypes.optionalSugar(swiftType)
+          return NativeResult(
+            javaType: javaType,
+            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: optionalSwiftType)),
+            outParameters: []
+          )
         }
 
       case .tuple:
@@ -871,7 +879,14 @@ extension JNISwift2JavaGenerator {
         }
 
         if nominalType.isSwiftJavaWrapper {
-          throw JavaTranslationError.unsupportedSwiftType(swiftType)
+          guard let javaType = nominalTypeName.parseJavaClassFromSwiftJavaName(in: self.javaClassLookupTable) else {
+            throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(swiftType)
+          }
+          return NativeResult(
+            javaType: javaType,
+            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: swiftType)),
+            outParameters: []
+          )
         }
 
         if nominalType.nominalTypeDecl.isGeneric {
@@ -1015,8 +1030,17 @@ extension JNISwift2JavaGenerator {
           )
         }
 
-        guard !nominalType.isSwiftJavaWrapper else {
-          throw JavaTranslationError.unsupportedSwiftType(known: .array(elementType))
+        if nominalType.isSwiftJavaWrapper {
+          guard let javaType = nominalTypeName.parseJavaClassFromSwiftJavaName(in: self.javaClassLookupTable) else {
+            throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(elementType)
+          }
+
+          let arraySwiftType = knownTypes.arraySugar(elementType)
+          return NativeResult(
+            javaType: .array(javaType),
+            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: arraySwiftType)),
+            outParameters: []
+          )
         }
 
         // Assume JExtract imported class

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -681,7 +681,7 @@ extension JNISwift2JavaGenerator {
 
           return NativeResult(
             javaType: javaType,
-            conversion: .getJNIValue(.placeholder),
+            conversion: .getJNIValue(.asOptional(.placeholder)),
             outParameters: []
           )
         }
@@ -861,7 +861,7 @@ extension JNISwift2JavaGenerator {
           }
           return NativeResult(
             javaType: javaType,
-            conversion: .getJNIValue(.placeholder),
+            conversion: .getJNIValue(.asOptional(.placeholder)),
             outParameters: []
           )
         }
@@ -1015,7 +1015,7 @@ extension JNISwift2JavaGenerator {
 
           return NativeResult(
             javaType: .array(javaType),
-            conversion: .getJNIValue(.placeholder),
+            conversion: .getJNIValue(.asOptional(.placeholder)),
             outParameters: []
           )
         }
@@ -1422,6 +1422,8 @@ extension JNISwift2JavaGenerator {
     indirect case member(NativeSwiftConversionStep, member: String)
 
     indirect case optionalMap(NativeSwiftConversionStep)
+
+    indirect case asOptional(NativeSwiftConversionStep)
 
     indirect case unwrapOptional(NativeSwiftConversionStep, name: String, fatalErrorMessage: String)
 
@@ -1910,6 +1912,10 @@ extension JNISwift2JavaGenerator {
           printer.print("return \(inner)")
         }
         return printer.finalize()
+
+      case .asOptional(let inner):
+        let inner = inner.render(&printer, placeholder)
+        return "(\(inner) as Optional)"
 
       case .unwrapOptional(let inner, let name, let fatalErrorMessage):
         let unwrappedName = "\(name)_unwrapped$"

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -649,6 +649,7 @@ extension JNISwift2JavaGenerator {
 
       switch swiftType {
       case .nominal(let nominalType):
+        let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
         if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
           if let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config),
             javaType.implementsJavaValue
@@ -702,10 +703,9 @@ extension JNISwift2JavaGenerator {
             throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(swiftType)
           }
 
-          let optionalSwiftType = knownTypes.optionalSugar(swiftType)
           return NativeResult(
             javaType: javaType,
-            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: optionalSwiftType)),
+            conversion: .getJNIValue(.placeholder),
             outParameters: []
           )
         }
@@ -820,6 +820,7 @@ extension JNISwift2JavaGenerator {
     ) throws -> NativeResult {
       switch swiftType {
       case .nominal(let nominalType):
+        let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
         if let knownType = nominalType.asKnownType {
           switch knownType {
           case .optional(let wrapped):
@@ -884,7 +885,7 @@ extension JNISwift2JavaGenerator {
           }
           return NativeResult(
             javaType: javaType,
-            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: swiftType)),
+            conversion: .getJNIValue(.placeholder),
             outParameters: []
           )
         }
@@ -1016,6 +1017,7 @@ extension JNISwift2JavaGenerator {
         )
 
       case .nominal(let nominalType):
+        let nominalTypeName = nominalType.nominalTypeDecl.qualifiedName
         if let knownType = nominalType.nominalTypeDecl.knownTypeKind {
           guard let javaType = JNIJavaTypeTranslator.translate(knownType: knownType, config: self.config),
             javaType.implementsJavaValue
@@ -1035,10 +1037,9 @@ extension JNISwift2JavaGenerator {
             throw JavaTranslationError.wrappedJavaClassTranslationNotProvided(elementType)
           }
 
-          let arraySwiftType = knownTypes.arraySugar(elementType)
           return NativeResult(
             javaType: .array(javaType),
-            conversion: .getJNIValue(.allocateSwiftValue(.placeholder, name: resultName, swiftType: arraySwiftType)),
+            conversion: .getJNIValue(.placeholder),
             outParameters: []
           )
         }

--- a/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
@@ -76,5 +76,141 @@ struct JNIJavaKitTests {
         """
       ]
     )
+  @Test
+  func functionReturn_javaBindings() throws {
+    try assertOutput(
+      input: "public func function() -> JavaLong",
+      .jni,
+      .java,
+      javaClassLookupTable: classLookupTable,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func function() -> JavaLong
+         * }
+         */
+        public static java.lang.Long function() {
+          return SwiftModule.$function();
+        }
+        """,
+        """
+        private static native java.lang.Long $function();
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func functionReturn_swiftThunks() throws {
+    try assertOutput(
+      input: "public func function() -> JavaLong",
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      javaClassLookupTable: classLookupTable,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024function")
+        public func Java_com_example_swift_SwiftModule__00024function(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
+          let result$ = SwiftModule.function()
+          return result$.getJNIValue(in: environment)
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func functionReturnOptional_javaBindings() throws {
+    try assertOutput(
+      input: "public func function() -> JavaLong?",
+      .jni,
+      .java,
+      javaClassLookupTable: classLookupTable,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func function() -> JavaLong?
+         * }
+         */
+        public static java.lang.Long function() {
+          return SwiftModule.$function();
+        }
+        """,
+        """
+        private static native java.lang.Long $function();
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func functionReturnOptional_swiftThunks() throws {
+    try assertOutput(
+      input: "public func function() -> JavaLong?",
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      javaClassLookupTable: classLookupTable,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024function")
+        public func Java_com_example_swift_SwiftModule__00024function(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
+          let result$ = SwiftModule.function()
+          return result$.getJNIValue(in: environment)
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func functionReturnArray_javaBindings() throws {
+    try assertOutput(
+      input: "public func function() -> [JavaLong]",
+      .jni,
+      .java,
+      javaClassLookupTable: classLookupTable,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func function() -> [JavaLong]
+         * }
+         */
+        public static java.lang.Long[] function() {
+          return SwiftModule.$function();
+        }
+        """,
+        """
+        private static native java.lang.Long[] $function();
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func functionReturnArray_swiftThunks() throws {
+    try assertOutput(
+      input: "public func function() -> [JavaLong]",
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      javaClassLookupTable: classLookupTable,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024function")
+        public func Java_com_example_swift_SwiftModule__00024function(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobjectArray? {
+          let result$ = SwiftModule.function()
+          return result$.getJNIValue(in: environment)
+        }
+        """
+      ]
+    )
   }
 }

--- a/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
@@ -115,7 +115,7 @@ struct JNIJavaKitTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
         public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
-          return SwiftModule.function().getJNILocalRefValue(in: environment)
+          return (SwiftModule.function() as Optional).getJNILocalRefValue(in: environment)
         }
         """
       ]
@@ -160,7 +160,7 @@ struct JNIJavaKitTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
         public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
-          return SwiftModule.function().getJNILocalRefValue(in: environment)
+          return (SwiftModule.function() as Optional).getJNILocalRefValue(in: environment)
         }
         """
       ]
@@ -205,7 +205,7 @@ struct JNIJavaKitTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
         public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobjectArray? {
-          return SwiftModule.function().getJNILocalRefValue(in: environment)
+          return (SwiftModule.function() as Optional).getJNILocalRefValue(in: environment)
         }
         """
       ]

--- a/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
@@ -17,8 +17,7 @@ import Testing
 
 @Suite
 struct JNIJavaKitTests {
-  let source =
-    """
+  let source = """
     public func function(javaLong: JavaLong, javaInteger: JavaInteger, int: Int64) {}
     """
 
@@ -76,6 +75,8 @@ struct JNIJavaKitTests {
         """
       ]
     )
+  }
+
   @Test
   func functionReturn_javaBindings() throws {
     try assertOutput(
@@ -112,10 +113,9 @@ struct JNIJavaKitTests {
       javaClassLookupTable: classLookupTable,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024function")
-        public func Java_com_example_swift_SwiftModule__00024function(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
-          let result$ = SwiftModule.function()
-          return result$.getJNIValue(in: environment)
+        @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
+        public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
+          return SwiftModule.function().getJNILocalRefValue(in: environment)
         }
         """
       ]
@@ -158,10 +158,9 @@ struct JNIJavaKitTests {
       javaClassLookupTable: classLookupTable,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024function")
-        public func Java_com_example_swift_SwiftModule__00024function(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
-          let result$ = SwiftModule.function()
-          return result$.getJNIValue(in: environment)
+        @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
+        public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
+          return SwiftModule.function().getJNILocalRefValue(in: environment)
         }
         """
       ]
@@ -204,10 +203,9 @@ struct JNIJavaKitTests {
       javaClassLookupTable: classLookupTable,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024function")
-        public func Java_com_example_swift_SwiftModule__00024function(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobjectArray? {
-          let result$ = SwiftModule.function()
-          return result$.getJNIValue(in: environment)
+        @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
+        public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobjectArray? {
+          return SwiftModule.function().getJNILocalRefValue(in: environment)
         }
         """
       ]


### PR DESCRIPTION
## Description
Resolves #841. This PR adds support for returning JavaKit-wrapped Java objects (like `JavaLong` or `JavaString`) from Swift functions back to Java.

### Approach
- **Type Detection:** Updated `translateResult`, `translateOptionalResult`, and `translateArrayResult` in both `NativeTranslation` and `JavaTranslation` to recognize types passing the `isSwiftJavaWrapper` predicate.
- **Java Shim:** Maps the return type to the corresponding underlying Java class (e.g., `java.lang.Long`) rather than throwing an unsupported type error.
- **Native Translation (C bindings):** Returns the Swift value wrapped in an `Optional`, and calls `.getJNIValue(in: environment)` to safely extract and return the underlying JNI object reference (or `NULL` if missing).
- **Tests:** Added tests to `JNIJavaKitTests` for functions returning standard wrappers, optional wrappers, and arrays of wrappers.
