### PR TITLE
jextract: Support Java BooleanSupplier functional interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -37,7 +37,7 @@ public func globalCallMeRunnable(run: () -> Void) {
 }
 
 public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
-  return run()
+  run()
 }
 
 // ==== Internal helpers

--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -36,6 +36,10 @@ public func globalCallMeRunnable(run: () -> Void) {
   run()
 }
 
+public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
+  return run()
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -54,4 +54,9 @@ public class MySwiftLibraryTest {
         assertEquals(0, countDownLatch.getCount());
     }
 
+    @Test
+    void call_globalCallMeBooleanSupplier_noThrow() {
+        boolean result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -48,6 +48,10 @@ public func globalCallMeRunnable(run: () -> Void) {
   run()
 }
 
+public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
+  return run()
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -49,7 +49,7 @@ public func globalCallMeRunnable(run: () -> Void) {
 }
 
 public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
-  return run()
+  run()
 }
 
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -73,8 +73,6 @@ public class MySwiftLibraryTest {
         assertEquals("", result);
     }
 
-
-
     @Test
     @Disabled("Upcalls not yet implemented in new scheme")
     @SuppressWarnings({"Convert2Lambda", "Convert2MethodRef"})
@@ -148,4 +146,9 @@ public class MySwiftLibraryTest {
         );
     }
 
+   @Test
+    void call_globalCallMeBooleanSupplier_noThrow() {
+        boolean result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -20,6 +20,10 @@ public func closureWithInt(input: Int64, closure: (Int64) -> Int64) -> Int64 {
   closure(input)
 }
 
+public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
+  return run()
+}
+
 public func closureMultipleArguments(
   input1: Int64,
   input2: Int64,

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -21,7 +21,7 @@ public func closureWithInt(input: Int64, closure: (Int64) -> Int64) -> Int64 {
 }
 
 public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
-  return run()
+  run()
 }
 
 public func closureMultipleArguments(

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -41,4 +41,10 @@ public class ClosuresTest {
         long result = MySwiftLibrary.closureMultipleArguments(5, 10, (a, b) -> a + b);
         assertEquals(15, result);
     }
+
+    @Test
+    void globalCallMeBooleanSupplier() {
+        boolean result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> true);
+        assertEquals(true, result);
+    }
 }

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -44,7 +44,7 @@ public func globalCallMeRunnable(run: () -> Void) {
 }
 
 public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
-  return run()
+  run()
 }
 
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -43,6 +43,10 @@ public func globalCallMeRunnable(run: () -> Void) {
   run()
 }
 
+public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
+  return run()
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -31,7 +31,7 @@ extension JavaType {
   }
 
   /// The description of the type java.util.function.BooleanSupplier.
-  static var javaFunctionBooleanSupplier: JavaType {
+  static var javaUtilFunctionBooleanSupplier: JavaType {
     .class(package: "java.util.function", name: "BooleanSupplier")
   }
 

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -30,6 +30,11 @@ extension JavaType {
     .class(package: "java.lang", name: "Runnable")
   }
 
+  /// The description of the type java.util.function.BooleanSupplier.
+  static var javaFunctionBooleanSupplier: JavaType {
+    .class(package: "java.util.function", name: "BooleanSupplier")
+  }
+
   /// The description of the type java.lang.Class.
   static var javaLangClass: JavaType {
     .class(package: "java.lang", name: "Class")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -29,8 +29,16 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .void
   )
 
+  static let booleanSupplier = KnownJavaFunctionalInterface(
+    JavaType.javaFunctionBooleanSupplier,
+    method: "getAsBoolean",
+    parameters: [],
+    result: .boolean
+  )
+
   static let all: [KnownJavaFunctionalInterface] = [
-    .runnable
+    .runnable,
+    .booleanSupplier,
   ]
 
   static func find(parameters: [JavaType], result: JavaType) -> KnownJavaFunctionalInterface? {
@@ -59,6 +67,8 @@ struct KnownJavaFunctionalInterface: Sendable {
     return switch (parameters, result) {
     case ([], _) where result.isVoid:
       runnable
+    case ([], _) where result.isBoolean:
+      booleanSupplier
     default:
       nil
     }

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -30,7 +30,7 @@ struct KnownJavaFunctionalInterface: Sendable {
   )
 
   static let booleanSupplier = KnownJavaFunctionalInterface(
-    JavaType.javaFunctionBooleanSupplier,
+    JavaType.javaUtilFunctionBooleanSupplier,
     method: "getAsBoolean",
     parameters: [],
     result: .boolean

--- a/Sources/SwiftExtract/SwiftTypes/SwiftType.swift
+++ b/Sources/SwiftExtract/SwiftTypes/SwiftType.swift
@@ -98,6 +98,13 @@ public enum SwiftType: Equatable {
     }
   }
 
+  public var isBoolean: Bool {
+    if case let .nominal(nominal) = self {
+      return nominal.nominalTypeDecl.knownTypeKind == .bool
+    }
+    return false
+  }
+
   /// Whether this is a pointer type. I.e 'Unsafe[Mutable][Raw]Pointer'
   public var isPointer: Bool {
     switch self {

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -34,6 +34,7 @@ final class FuncCallbackImportTests {
     import _SwiftConcurrencyShims
 
     public func callMe(callback: () -> Void)
+    public func callMeBoolSupplier(callback: () -> Bool)
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
     """
@@ -116,6 +117,92 @@ final class FuncCallbackImportTests {
         public static void callMe(java.lang.Runnable callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMe_callback.call(callMe.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+    )
+  }
+
+  @Test("Import: public func callMeBoolSupplier(callback: () -> Bool)")
+  func func_callMeBoolSupplierFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeBoolSupplier" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expected:
+        """
+        // ==== --------------------------------------------------
+        // callMeBoolSupplier
+        /**
+         * {@snippet lang=c :
+         * void swiftjava___FakeModule_callMeBoolSupplier_callback(_Bool (*callback)(void))
+         * }
+         */
+        private static class swiftjava___FakeModule_callMeBoolSupplier_callback {
+          private static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+            /* callback: */SwiftValueLayout.SWIFT_POINTER
+          );
+          private static final MemorySegment ADDR =
+            __FakeModule.findOrThrow("swiftjava___FakeModule_callMeBoolSupplier_callback");
+          private static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+          public static void call(java.lang.foreign.MemorySegment callback) {
+            try {
+              if (CallTraces.TRACE_DOWNCALLS) {
+                CallTraces.traceDowncall(callback);
+              }
+              HANDLE.invokeExact(callback);
+            } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+            }
+          }
+          /**
+           * {snippet lang=c :
+           * _Bool (*)(void)
+           * }
+           */
+          private static class $callback {
+            private static final FunctionDescriptor DESC = FunctionDescriptor.of(
+              /* -> */SwiftValueLayout.SWIFT_BOOL
+            );
+            private static final MethodHandle HANDLE = SwiftRuntime.upcallHandle(java.util.function.BooleanSupplier.class, "getAsBoolean", DESC);
+            private static MemorySegment toUpcallStub(java.util.function.BooleanSupplier fi, Arena arena) {
+              return Linker.nativeLinker().upcallStub(HANDLE.bindTo(fi), DESC, arena);
+            }
+          }
+        }
+        public static class callMeBoolSupplier {
+          private static MemorySegment $toUpcallStub(java.util.function.BooleanSupplier fi, Arena arena) {
+            return swiftjava___FakeModule_callMeBoolSupplier_callback.$callback.toUpcallStub(fi, arena);
+          }
+        }
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeBoolSupplier(callback: () -> Bool)
+         * }
+         */
+        public static void callMeBoolSupplier(java.util.function.BooleanSupplier callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeBoolSupplier_callback.call(callMeBoolSupplier.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -20,6 +20,7 @@ struct JNIClosureTests {
   let source =
     """
     public func emptyClosure(closure: () -> ()) {}
+    public func closureBoolSupplier(closure: () -> Bool) {}
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
 
@@ -49,6 +50,31 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureBoolSupplier_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureBoolSupplier(closure: () -> Bool)
+         * }
+         */
+        public static void closureBoolSupplier(java.util.function.BooleanSupplier closure) {
+          SwiftModule.$closureBoolSupplier(closure);
+        }
+        """,
+        """
+        private static native void $closureBoolSupplier(java.util.function.BooleanSupplier closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
   func emptyClosure_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -65,6 +91,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = []
             environment.interface.CallVoidMethodA(environment, closure, methodID$, arguments$)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureBoolSupplier_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureBoolSupplier__Ljava_util_function_BooleanSupplier_2")
+        public func Java_com_example_swift_SwiftModule__00024closureBoolSupplier__Ljava_util_function_BooleanSupplier_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureBoolSupplier(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "getAsBoolean", "()Z")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = []
+            return Bool(fromJNI: environment.interface.CallBooleanMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift () -> bool to the Java BooleanSupplier functional interface