### PR TITLE
Fix a small typo in the "SwiftJava macros" section of the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ SwiftJava is a Swift library offering macros which simplify writing JNI code "by
 It is possible to generate Swift bindings to Java libraries using SwiftJava by using the `swift-java wrap-java` command.
 
 Required language/runtime versions:
-- **JDK 17+**, any recent JDK installation should be sufficient, as only general reflection and JNI APIs are used by this integratio
+- **JDK 17+**, any recent JDK installation should be sufficient, as only general reflection and JNI APIs are used by this integration
 - **Swift 6.2.x**, because the library uses modern Swift macros
 
 **swift-java jextract** 


### PR DESCRIPTION
As part of the Swift Mentorship Program, I started reading the README of this Java project while preparing for my first open-source contribution. While reading it, I noticed a small typo that I would like to fix. It adds the missing letter "n" in the word  "integration".