### PR TITLE
Simplify returning java wrapped types source gen

### DIFF
--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/MySwiftClass.swift
@@ -103,6 +103,14 @@ public class MySwiftClass {
   public func returnXAsJavaLong() -> JavaLong {
     JavaLong(self.x)
   }
+
+  public func returnXAsOptionalJavaLong() -> JavaLong? {
+    JavaLong(self.x)
+  }
+
+  public func returnXYAsJavaLongs() -> [JavaLong] {
+    [JavaLong(self.x), JavaLong(self.y)]
+  }
 }
 
 extension MySwiftClass: CustomStringConvertible {

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/MySwiftClassTest.java
@@ -175,6 +175,26 @@ public class MySwiftClassTest {
     }
 
     @Test
+    void returnXAsOptionalJavaLong() {
+        try (var arena = SwiftArena.ofConfined()) {
+            MySwiftClass c1 = MySwiftClass.init(20, 10, arena);
+            Long javaLong = c1.returnXAsOptionalJavaLong();
+            assertEquals(20L, javaLong);
+        }
+    }
+
+    @Test
+    void returnXYAsJavaLongs() {
+        try (var arena = SwiftArena.ofConfined()) {
+            MySwiftClass c1 = MySwiftClass.init(20, 10, arena);
+            Long[] longs = c1.returnXYAsJavaLongs();
+            assertEquals(2, longs.length);
+            assertEquals(20L, longs[0]);
+            assertEquals(10L, longs[1]);
+        }
+    }
+
+    @Test
     void getAsyncVariable() throws Exception {
         try (var arena = SwiftArena.ofConfined()) {
             MySwiftClass c1 = MySwiftClass.init(20, 10, arena);

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -681,7 +681,7 @@ extension JNISwift2JavaGenerator {
 
           return NativeResult(
             javaType: javaType,
-            conversion: .getJNIValue(.asOptional(.placeholder)),
+            conversion: .getJNIValue(.placeholder),
             outParameters: []
           )
         }
@@ -861,7 +861,7 @@ extension JNISwift2JavaGenerator {
           }
           return NativeResult(
             javaType: javaType,
-            conversion: .getJNIValue(.asOptional(.placeholder)),
+            conversion: .getJNIValue(.placeholder),
             outParameters: []
           )
         }
@@ -1015,7 +1015,7 @@ extension JNISwift2JavaGenerator {
 
           return NativeResult(
             javaType: .array(javaType),
-            conversion: .getJNIValue(.asOptional(.placeholder)),
+            conversion: .getJNIValue(.placeholder),
             outParameters: []
           )
         }
@@ -1422,8 +1422,6 @@ extension JNISwift2JavaGenerator {
     indirect case member(NativeSwiftConversionStep, member: String)
 
     indirect case optionalMap(NativeSwiftConversionStep)
-
-    indirect case asOptional(NativeSwiftConversionStep)
 
     indirect case unwrapOptional(NativeSwiftConversionStep, name: String, fatalErrorMessage: String)
 
@@ -1912,10 +1910,6 @@ extension JNISwift2JavaGenerator {
           printer.print("return \(inner)")
         }
         return printer.finalize()
-
-      case .asOptional(let inner):
-        let inner = inner.render(&printer, placeholder)
-        return "(\(inner) as Optional)"
 
       case .unwrapOptional(let inner, let name, let fatalErrorMessage):
         let unwrappedName = "\(name)_unwrapped$"

--- a/Sources/SwiftJava/AnyJavaObject.swift
+++ b/Sources/SwiftJava/AnyJavaObject.swift
@@ -160,3 +160,18 @@ extension AnyJavaObject {
     }
   }
 }
+
+// ==== -----------------------------------------------------------------------
+// MARK: JNI conversions for non-optional Java objects
+
+extension AnyJavaObject {
+  /// Retrieve the underlying JNI reference for this Java object.
+  public func getJNIValue(in environment: JNIEnvironment) -> jobject {
+    self.javaThis
+  }
+
+  /// Return a fresh local reference safe for returning from a JNI thunk.
+  public func getJNILocalRefValue(in environment: JNIEnvironment) -> jobject? {
+    environment.interface.NewLocalRef(environment, self.javaThis)
+  }
+}

--- a/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIJavaKitTests.swift
@@ -115,7 +115,7 @@ struct JNIJavaKitTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
         public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
-          return (SwiftModule.function() as Optional).getJNILocalRefValue(in: environment)
+          return SwiftModule.function().getJNILocalRefValue(in: environment)
         }
         """
       ]
@@ -160,7 +160,7 @@ struct JNIJavaKitTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
         public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobject? {
-          return (SwiftModule.function() as Optional).getJNILocalRefValue(in: environment)
+          return SwiftModule.function().getJNILocalRefValue(in: environment)
         }
         """
       ]
@@ -205,7 +205,7 @@ struct JNIJavaKitTests {
         """
         @_cdecl("Java_com_example_swift_SwiftModule__00024function__")
         public func Java_com_example_swift_SwiftModule__00024function__(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass) -> jobjectArray? {
-          return (SwiftModule.function() as Optional).getJNILocalRefValue(in: environment)
+          return SwiftModule.function().getJNILocalRefValue(in: environment)
         }
         """
       ]


### PR DESCRIPTION
Follow up for https://github.com/swiftlang/swift-java/pull/851

I realized wecan of the optional as long as we allow getting the jobject out of the non-optional the same way.