### PR TITLE
jextract: Support Java DoubleSupplier func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -40,6 +40,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
+  run()
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -59,4 +59,10 @@ public class MySwiftLibraryTest {
         boolean result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return true; });
         assertEquals(true, result);
     }
+
+    @Test
+    void call_globalCallMeDoubleSupplier_noThrow() {
+        double result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return 2.0; });
+        assertEquals(2.0, result);
+    }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -52,6 +52,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
+  run()
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -146,9 +146,15 @@ public class MySwiftLibraryTest {
         );
     }
 
-   @Test
+    @Test
     void call_globalCallMeBooleanSupplier_noThrow() {
         boolean result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return true; });
         assertEquals(true, result);
+    }
+
+    @Test
+    void call_globalCallMeDoubleSupplier_noThrow() {
+        double result = MySwiftLibrary.globalCallMeDoubleSupplier(() -> { return 2.0; });
+        assertEquals(2.0, result);
     }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -24,6 +24,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
+  run()
+}
+
 public func closureMultipleArguments(
   input1: Int64,
   input2: Int64,

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -47,4 +47,10 @@ public class ClosuresTest {
         boolean result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> true);
         assertEquals(true, result);
     }
+
+    @Test
+    void globalCallMeDoubleSupplier() {
+        double result = MySwiftLibrary.globalCallMeDoubleSupplier(() -> 2.0);
+        assertEquals(2.0, result);
+    }
 }

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -47,6 +47,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
+  run()
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -35,6 +35,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "BooleanSupplier")
   }
 
+  /// The description of the type java.util.function.DoubleSupplier.
+  static var javaUtilFunctionDoubleSupplier: JavaType {
+    .class(package: "java.util.function", name: "DoubleSupplier")
+  }
+
   /// The description of the type java.lang.Class.
   static var javaLangClass: JavaType {
     .class(package: "java.lang", name: "Class")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -36,9 +36,17 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .boolean
   )
 
+  static let doubleSupplier = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionDoubleSupplier,
+    method: "getAsDouble",
+    parameters: [],
+    result: .double
+  )
+
   static let all: [KnownJavaFunctionalInterface] = [
     .runnable,
     .booleanSupplier,
+    .doubleSupplier,
   ]
 
   static func find(parameters: [JavaType], result: JavaType) -> KnownJavaFunctionalInterface? {
@@ -69,6 +77,8 @@ struct KnownJavaFunctionalInterface: Sendable {
       runnable
     case ([], _) where result.isBoolean:
       booleanSupplier
+    case ([], _) where result.isDouble:
+      doubleSupplier
     default:
       nil
     }

--- a/Sources/SwiftExtract/SwiftTypes/SwiftType.swift
+++ b/Sources/SwiftExtract/SwiftTypes/SwiftType.swift
@@ -105,6 +105,13 @@ public enum SwiftType: Equatable {
     return false
   }
 
+  public var isDouble: Bool {
+    if case let .nominal(nominal) = self {
+      return nominal.nominalTypeDecl.knownTypeKind == .double
+    }
+    return false
+  }
+
   /// Whether this is a pointer type. I.e 'Unsafe[Mutable][Raw]Pointer'
   public var isPointer: Bool {
     switch self {

--- a/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
+++ b/Tests/JExtractSwiftTests/Asserts/TextAssertions.swift
@@ -107,6 +107,31 @@ func assertOutput(
     }
   }
 
+  assertOutput(
+    output,
+    dump: dump,
+    expectedChunks: expectedChunks,
+    notExpectedChunks: notExpectedChunks,
+    detectChunkByInitialLines: _detectChunkByInitialLines,
+    fileID: fileID,
+    filePath: filePath,
+    line: line,
+    column: column
+  )
+}
+
+/// Asserts that `output` contains each of `expectedChunks` and that it contains none of `notExpectedChunks`.
+func assertOutput(
+  _ output: String,
+  dump: Bool = false,
+  expectedChunks: [String],
+  notExpectedChunks: [String] = [],
+  detectChunkByInitialLines _detectChunkByInitialLines: Int = 4,
+  fileID: String = #fileID,
+  filePath: String = #filePath,
+  line: Int = #line,
+  column: Int = #column
+) {
   let sourceLocation = SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
   for notExpectedChunk in notExpectedChunks {
     let outputNotContainsNotExpectedChunk = !output.contains(notExpectedChunk)
@@ -114,7 +139,7 @@ func assertOutput(
       outputNotContainsNotExpectedChunk,
       """
       \("error: Output must not contain not expected chunk!".red)
-      ==== Not Expected output -----------------------------------------------  
+      ==== Not Expected output -----------------------------------------------
       \(notExpectedChunk.yellow)
       ==== Got output ----------------------------------------------------
       \(output)
@@ -161,7 +186,7 @@ func assertOutput(
         outputContainsExpectedChunk,
         """
         \("error: Output did not contain expected chunk!".red)
-        ==== Expected output -----------------------------------------------  
+        ==== Expected output -----------------------------------------------
         \(expectedChunk.yellow)
         ==== Got output ----------------------------------------------------
         \(output)

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -35,6 +35,7 @@ final class FuncCallbackImportTests {
 
     public func callMe(callback: () -> Void)
     public func callMeBoolSupplier(callback: () -> Bool)
+    public func callMeDoubleSupplier(callback: () -> Double)
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
     """
@@ -203,6 +204,92 @@ final class FuncCallbackImportTests {
         public static void callMeBoolSupplier(java.util.function.BooleanSupplier callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMeBoolSupplier_callback.call(callMeBoolSupplier.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+    )
+  }
+
+  @Test("Import: public func callMeDoubleSupplier(callback: () -> Double)")
+  func func_callMeDoubleSupplierFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeDoubleSupplier" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expected:
+        """
+        // ==== --------------------------------------------------
+        // callMeDoubleSupplier
+        /**
+         * {@snippet lang=c :
+         * void swiftjava___FakeModule_callMeDoubleSupplier_callback(double (*callback)(void))
+         * }
+         */
+        private static class swiftjava___FakeModule_callMeDoubleSupplier_callback {
+          private static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+            /* callback: */SwiftValueLayout.SWIFT_POINTER
+          );
+          private static final MemorySegment ADDR =
+            __FakeModule.findOrThrow("swiftjava___FakeModule_callMeDoubleSupplier_callback");
+          private static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+          public static void call(java.lang.foreign.MemorySegment callback) {
+            try {
+              if (CallTraces.TRACE_DOWNCALLS) {
+                CallTraces.traceDowncall(callback);
+              }
+              HANDLE.invokeExact(callback);
+            } catch (Throwable ex$) {
+              throw new AssertionError("should not reach here", ex$);
+            }
+          }
+          /**
+           * {snippet lang=c :
+           * double (*)(void)
+           * }
+           */
+          private static class $callback {
+            private static final FunctionDescriptor DESC = FunctionDescriptor.of(
+              /* -> */SwiftValueLayout.SWIFT_DOUBLE
+            );
+            private static final MethodHandle HANDLE = SwiftRuntime.upcallHandle(java.util.function.DoubleSupplier.class, "getAsDouble", DESC);
+            private static MemorySegment toUpcallStub(java.util.function.DoubleSupplier fi, Arena arena) {
+              return Linker.nativeLinker().upcallStub(HANDLE.bindTo(fi), DESC, arena);
+            }
+          }
+        }
+        public static class callMeDoubleSupplier {
+          private static MemorySegment $toUpcallStub(java.util.function.DoubleSupplier fi, Arena arena) {
+            return swiftjava___FakeModule_callMeDoubleSupplier_callback.$callback.toUpcallStub(fi, arena);
+          }
+        }
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeDoubleSupplier(callback: () -> Double)
+         * }
+         */
+        public static void callMeDoubleSupplier(java.util.function.DoubleSupplier callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeDoubleSupplier_callback.call(callMeDoubleSupplier.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -235,52 +235,8 @@ final class FuncCallbackImportTests {
 
     assertOutput(
       output,
-      expected:
+      expectedChunks: [
         """
-        // ==== --------------------------------------------------
-        // callMeDoubleSupplier
-        /**
-         * {@snippet lang=c :
-         * void swiftjava___FakeModule_callMeDoubleSupplier_callback(double (*callback)(void))
-         * }
-         */
-        private static class swiftjava___FakeModule_callMeDoubleSupplier_callback {
-          private static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            /* callback: */SwiftValueLayout.SWIFT_POINTER
-          );
-          private static final MemorySegment ADDR =
-            __FakeModule.findOrThrow("swiftjava___FakeModule_callMeDoubleSupplier_callback");
-          private static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
-          public static void call(java.lang.foreign.MemorySegment callback) {
-            try {
-              if (CallTraces.TRACE_DOWNCALLS) {
-                CallTraces.traceDowncall(callback);
-              }
-              HANDLE.invokeExact(callback);
-            } catch (Throwable ex$) {
-              throw new AssertionError("should not reach here", ex$);
-            }
-          }
-          /**
-           * {snippet lang=c :
-           * double (*)(void)
-           * }
-           */
-          private static class $callback {
-            private static final FunctionDescriptor DESC = FunctionDescriptor.of(
-              /* -> */SwiftValueLayout.SWIFT_DOUBLE
-            );
-            private static final MethodHandle HANDLE = SwiftRuntime.upcallHandle(java.util.function.DoubleSupplier.class, "getAsDouble", DESC);
-            private static MemorySegment toUpcallStub(java.util.function.DoubleSupplier fi, Arena arena) {
-              return Linker.nativeLinker().upcallStub(HANDLE.bindTo(fi), DESC, arena);
-            }
-          }
-        }
-        public static class callMeDoubleSupplier {
-          private static MemorySegment $toUpcallStub(java.util.function.DoubleSupplier fi, Arena arena) {
-            return swiftjava___FakeModule_callMeDoubleSupplier_callback.$callback.toUpcallStub(fi, arena);
-          }
-        }
         /**
          * Downcall to Swift:
          * {@snippet lang=swift :
@@ -293,6 +249,7 @@ final class FuncCallbackImportTests {
           }
         }
         """
+      ]
     )
   }
 

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -21,6 +21,7 @@ struct JNIClosureTests {
     """
     public func emptyClosure(closure: () -> ()) {}
     public func closureBoolSupplier(closure: () -> Bool) {}
+    public func closureDoubleSupplier(closure: () -> Double) {}
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
 
@@ -75,6 +76,31 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureDoubleSupplier_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureDoubleSupplier(closure: () -> Double)
+         * }
+         */
+        public static void closureDoubleSupplier(java.util.function.DoubleSupplier closure) {
+          SwiftModule.$closureDoubleSupplier(closure);
+        }
+        """,
+        """
+        private static native void $closureDoubleSupplier(java.util.function.DoubleSupplier closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
   func emptyClosure_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -116,6 +142,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = []
             return Bool(fromJNI: environment.interface.CallBooleanMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureDoubleSupplier_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureDoubleSupplier__Ljava_util_function_DoubleSupplier_2")
+        public func Java_com_example_swift_SwiftModule__00024closureDoubleSupplier__Ljava_util_function_DoubleSupplier_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureDoubleSupplier(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "getAsDouble", "()D")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = []
+            return Double(fromJNI: environment.interface.CallDoubleMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift () -> Double to the Java DoubleSupplier functional interface