### PR TITLE
jextract: Support Java IntSupplier func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -40,6 +40,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeIntSupplier(run: () -> Int32) -> Int32 {
+  run()
+}
+
 public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
   run()
 }

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -61,6 +61,12 @@ public class MySwiftLibraryTest {
     }
 
     @Test
+    void call_globalCallMeIntSupplier_noThrow() {
+        int result = MySwiftLibrary.globalCallMeIntSupplier(() -> { return 1; });
+        assertEquals(1, result);
+    }
+
+    @Test
     void call_globalCallMeDoubleSupplier_noThrow() {
         double result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return 2.0; });
         assertEquals(2.0, result);

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -52,6 +52,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeIntSupplier(run: () -> Int32) -> Int32 {
+  run()
+}
+
 public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
   run()
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -173,6 +173,12 @@ public class MySwiftLibraryTest {
     }
 
     @Test
+    void call_globalCallMeIntSupplier_noThrow() {
+        int result = MySwiftLibrary.globalCallMeIntSupplier(() -> { return 2; });
+        assertEquals(2, result);
+    }
+
+    @Test
     void call_globalCallMeDoubleSupplier_noThrow() {
         double result = MySwiftLibrary.globalCallMeDoubleSupplier(() -> { return 2.0; });
         assertEquals(2.0, result);

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -25,6 +25,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeIntSupplier(run: () -> Int32) -> Int32 {
+  run()
+}
+
 public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
   run()
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -55,6 +55,12 @@ public class ClosuresTest {
     }
 
     @Test
+    void globalCallMeIntSupplier() {
+        int result = MySwiftLibrary.globalCallMeIntSupplier(() -> 2);
+        assertEquals(2, result);
+    }
+
+    @Test
     void globalCallMeDoubleSupplier() {
         double result = MySwiftLibrary.globalCallMeDoubleSupplier(() -> 2.0);
         assertEquals(2.0, result);

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -47,6 +47,10 @@ public func globalCallMeBooleanSupplier(run: () -> Bool) -> Bool {
   run()
 }
 
+public func globalCallMeIntSupplier(run: () -> Int32) -> Int32 {
+  run()
+}
+
 public func globalCallMeDoubleSupplier(run: () -> Double) -> Double {
   run()
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -35,6 +35,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "BooleanSupplier")
   }
 
+  /// The description of the type java.util.function.IntSupplier.
+  static var javaUtilFunctionIntSupplier: JavaType {
+    .class(package: "java.util.function", name: "IntSupplier")
+  }
+
   /// The description of the type java.util.function.DoubleSupplier.
   static var javaUtilFunctionDoubleSupplier: JavaType {
     .class(package: "java.util.function", name: "DoubleSupplier")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -36,6 +36,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .boolean
   )
 
+  static let intSupplier = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionIntSupplier,
+    method: "getAsInt",
+    parameters: [],
+    result: .int
+  )
+
   static let doubleSupplier = KnownJavaFunctionalInterface(
     JavaType.javaUtilFunctionDoubleSupplier,
     method: "getAsDouble",
@@ -46,6 +53,7 @@ struct KnownJavaFunctionalInterface: Sendable {
   static let all: [KnownJavaFunctionalInterface] = [
     .runnable,
     .booleanSupplier,
+    .intSupplier,
     .doubleSupplier,
   ]
 
@@ -77,6 +85,8 @@ struct KnownJavaFunctionalInterface: Sendable {
       runnable
     case ([], _) where result.isBoolean:
       booleanSupplier
+    case ([], _) where result.isInt32:
+      intSupplier
     case ([], _) where result.isDouble:
       doubleSupplier
     default:

--- a/Sources/SwiftExtract/SwiftTypes/SwiftType.swift
+++ b/Sources/SwiftExtract/SwiftTypes/SwiftType.swift
@@ -140,6 +140,17 @@ public enum SwiftType: Equatable {
     }
   }
 
+  public var isInt32: Bool {
+    switch self {
+    case .nominal(let nominal):
+      switch nominal.nominalTypeDecl.knownTypeKind {
+      case .int32, .uint32: true
+      default: false
+      }
+    default: false
+    }
+  }
+
   public var isUnsignedInteger: Bool {
     switch self {
     case .nominal(let nominal):

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -35,6 +35,7 @@ final class FuncCallbackImportTests {
 
     public func callMe(callback: () -> Void)
     public func callMeBoolSupplier(callback: () -> Bool)
+    public func callMeIntSupplier(callback: () -> Int32)
     public func callMeDoubleSupplier(callback: () -> Double)
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
@@ -207,6 +208,49 @@ final class FuncCallbackImportTests {
           }
         }
         """
+    )
+  }
+
+  @Test("Import: public func callMeIntSupplier(callback: () -> Int32)")
+  func func_callMeIntSupplierFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeIntSupplier" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeIntSupplier(callback: () -> Int32)
+         * }
+         */
+        public static void callMeIntSupplier(java.util.function.IntSupplier callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeIntSupplier_callback.call(callMeIntSupplier.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
     )
   }
 

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -21,6 +21,7 @@ struct JNIClosureTests {
     """
     public func emptyClosure(closure: () -> ()) {}
     public func closureBoolSupplier(closure: () -> Bool) {}
+    public func closureIntSupplier(closure: () -> Int32) {}
     public func closureDoubleSupplier(closure: () -> Double) {}
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
@@ -70,6 +71,31 @@ struct JNIClosureTests {
         """,
         """
         private static native void $closureBoolSupplier(java.util.function.BooleanSupplier closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func closureIntSupplier_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureIntSupplier(closure: () -> Int32)
+         * }
+         */
+        public static void closureIntSupplier(java.util.function.IntSupplier closure) {
+          SwiftModule.$closureIntSupplier(closure);
+        }
+        """,
+        """
+        private static native void $closureIntSupplier(java.util.function.IntSupplier closure);
         """,
       ]
     )
@@ -142,6 +168,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = []
             return Bool(fromJNI: environment.interface.CallBooleanMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureIntSupplier_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureIntSupplier__Ljava_util_function_IntSupplier_2")
+        public func Java_com_example_swift_SwiftModule__00024closureIntSupplier__Ljava_util_function_IntSupplier_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureIntSupplier(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "getAsInt", "()I")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = []
+            return Int32(fromJNI: environment.interface.CallIntMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift `() -> Int32` and `() -> UInt32` to the Java IntSupplier functional interface