### PR TITLE
Show "Interoperability" eyebrow on the Swift-Java documentation landing page

### DIFF
--- a/Sources/SwiftJavaDocumentation/Documentation.docc/index.md
+++ b/Sources/SwiftJavaDocumentation/Documentation.docc/index.md
@@ -2,6 +2,7 @@
 
 @Metadata {
     @DisplayName("Swift Java Documentation")
+    @TitleHeading("Interoperability")
 }
 
 The Swift-Java project enables interoperability between Swift and Java.


### PR DESCRIPTION
## Summary
- The `SwiftJavaDocumentation` catalog belongs to the "Interoperability" nav group in the combined swift.org docs, but its title heading was unset, so no eyebrow was shown on the landing page.
- Sets `@TitleHeading("Interoperability")` in the catalog's `@Metadata` block to match its nav group.

## Test plan
- [ ] Preview the DocC catalog and confirm the "Interoperability" eyebrow appears above the title on the landing page.