### PR TITLE
jextract: Support Java IntPredicate func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -64,6 +64,10 @@ public func globalCallMeDoubleConsumer(run: (Double) -> Void) {
   run(1.0)
 }
 
+public func globalCallMeIntPredicate(run: (Int32) -> Bool) -> Bool {
+  run(1)
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -92,4 +92,10 @@ public class MySwiftLibraryTest {
     void call_globalCallMeDoubleConsumer_noThrow() {
         MySwiftLibrary.globalCallMeDoubleConsumer((double a) -> { });
     }
+
+    @Test
+    void call_globalCallMeIntPredicate_noThrow() {
+        boolean result = MySwiftLibrary.globalCallMeIntPredicate((int a) -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -76,6 +76,10 @@ public func globalCallMeDoubleConsumer(run: (Double) -> Void) {
   run(1.0)
 }
 
+public func globalCallMeIntPredicate(run: (Int32) -> Bool) -> Bool {
+  run(1)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -204,4 +204,10 @@ public class MySwiftLibraryTest {
     void call_globalCallMeDoubleConsumer_noThrow() {
         MySwiftLibrary.globalCallMeDoubleConsumer((double a) -> { });
     }
+
+    @Test
+    void call_globalCallMeIntPredicate_noThrow() {
+        boolean result = MySwiftLibrary.globalCallMeIntPredicate((int a) -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -49,6 +49,10 @@ public func globalCallMeDoubleConsumer(run: (Double) -> Void) {
   run(1.0)
 }
 
+public func globalCallMeIntPredicate(run: (Int32) -> Bool) -> Bool {
+  run(1)
+}
+
 public func closureMultipleArguments(
   input1: Int64,
   input2: Int64,

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -86,4 +86,10 @@ public class ClosuresTest {
     void globalCallMeDoubleConsumer() {
         MySwiftLibrary.globalCallMeDoubleConsumer((double a) -> {});
     }
+
+    @Test
+    void globalCallMeIntPredicate() {
+        boolean result = MySwiftLibrary.globalCallMeIntPredicate((int a) -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -71,6 +71,10 @@ public func globalCallMeDoubleConsumer(run: (Double) -> Void) {
   run(1.0)
 }
 
+public func globalCallMeIntPredicate(run: (Int32) -> Bool) -> Bool {
+  run(1)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -65,6 +65,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "DoubleConsumer")
   }
 
+  /// The description of the type java.util.function.IntPredicate.
+  static var javaUtilFunctionIntPredicate: JavaType {
+    .class(package: "java.util.function", name: "IntPredicate")
+  }
+
   /// The description of the type java.lang.Class.
   static var javaLangClass: JavaType {
     .class(package: "java.lang", name: "Class")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -78,6 +78,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .void
   )
 
+  static let intPredicate = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionIntPredicate,
+    method: "test",
+    parameters: [.int],
+    result: .boolean
+  )
+
   static let all: [KnownJavaFunctionalInterface] = [
     .runnable,
     .booleanSupplier,
@@ -87,6 +94,7 @@ struct KnownJavaFunctionalInterface: Sendable {
     .intConsumer,
     .longConsumer,
     .doubleConsumer,
+    .intPredicate,
   ]
 
   static func find(parameters: [JavaType], result: JavaType) -> KnownJavaFunctionalInterface? {
@@ -141,6 +149,17 @@ struct KnownJavaFunctionalInterface: Sendable {
         longConsumer
       case _ where parameter.isDouble:
         doubleConsumer
+      default:
+        nil
+      }
+    }
+
+    // Predicates
+    if parameters.count == 1 && result.isBoolean {
+      let parameter = parameters[0].type
+      return switch () {
+      case _ where parameter.isInt32:
+        intPredicate
       default:
         nil
       }

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -43,6 +43,8 @@ final class FuncCallbackImportTests {
     public func callMeLongConsumer(callback: (Int64) -> Void)
     public func callMeDoubleConsumer(callback: (Double) -> Void)
 
+    public func callMeIntPredicate(callback: (Int32) -> Bool)
+
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
     """
@@ -581,6 +583,49 @@ final class FuncCallbackImportTests {
           }
         }
         """
+    )
+  }
+
+  @Test("Import: public func callMecallMeIntPredicateFunc(callback: (Int32) -> Bool)")
+  func func_callMecallMeIntPredicateFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeIntPredicate" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeIntPredicate(callback: (Int32) -> Bool)
+         * }
+         */
+        public static void callMeIntPredicate(java.util.function.IntPredicate callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeIntPredicate_callback.call(callMeIntPredicate.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
     )
   }
 

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -29,6 +29,8 @@ struct JNIClosureTests {
     public func closureLongConsumer(closure: (Int64) -> Void) {}
     public func closureDoubleConsumer(closure: (Double) -> Void) {}
 
+    public func closureIntPredicate(closure: (Int32) -> Bool) {}
+
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
 
@@ -233,6 +235,32 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureIntPredicate_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureIntPredicate(closure: (Int32) -> Bool)
+         * }
+         */
+        public static void closureIntPredicate(java.util.function.IntPredicate closure) {
+          SwiftModule.$closureIntPredicate(closure);
+        }
+        """,
+        """
+        private static native void $closureIntPredicate(java.util.function.IntPredicate closure);
+        """,
+      ]
+    )
+  }
+
+
+  @Test
   func emptyClosure_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -406,6 +434,32 @@ struct JNIClosureTests {
       ]
     )
   }
+
+  @Test
+  func closureIntPredicate_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureIntPredicate__Ljava_util_function_IntPredicate_2")
+        public func Java_com_example_swift_SwiftModule__00024closureIntPredicate__Ljava_util_function_IntPredicate_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureIntPredicate(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "test", "(I)Z")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = [_0.getJValue(in: environment)]
+            return Bool(fromJNI: environment.interface.CallBooleanMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
 
   @Test
   func closureDoubleConsumer_swiftThunks() throws {


### PR DESCRIPTION
Add support for translating Swift (Int32) -> Boolean to the Java IntPredicate functional interface