### PR TITLE
jextract: Support Java DoublePredicate func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -72,6 +72,10 @@ public func globalCallMeLongPredicate(run: (Int64) -> Bool) -> Bool {
   run(1)
 }
 
+public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
+  run(1.0)
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -104,4 +104,10 @@ public class MySwiftLibraryTest {
         boolean result = MySwiftLibrary.globalCallMeLongPredicate((long a) -> { return true; });
         assertEquals(true, result);
     }
+
+    @Test
+    void call_globalCallMeDoublePredicate_noThrow() {
+        boolean result = MySwiftLibrary.globalCallMeDoublePredicate((double a) -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -84,6 +84,10 @@ public func globalCallMeLongPredicate(run: (Int64) -> Bool) -> Bool {
   run(1)
 }
 
+public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
+  run(1.0)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -216,4 +216,10 @@ public class MySwiftLibraryTest {
         boolean result = MySwiftLibrary.globalCallMeLongPredicate((long a) -> { return true; });
         assertEquals(true, result);
     }
+
+    @Test
+    void call_globalCallMeDoublePredicate_noThrow() {
+        boolean result = MySwiftLibrary.globalCallMeDoublePredicate((double a) -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -57,6 +57,10 @@ public func globalCallMeLongPredicate(run: (Int64) -> Bool) -> Bool {
   run(1)
 }
 
+public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
+  run(1.0)
+}
+
 public func closureMultipleArguments(
   input1: Int64,
   input2: Int64,

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -98,4 +98,10 @@ public class ClosuresTest {
         boolean result = MySwiftLibrary.globalCallMeLongPredicate((long a) -> { return true; });
         assertEquals(true, result);
     }
+
+    @Test
+    void globalCallMeDoublePredicate() {
+        boolean result = MySwiftLibrary.globalCallMeDoublePredicate((double a) -> { return true; });
+        assertEquals(true, result);
+    }
 }

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -79,6 +79,10 @@ public func globalCallMeLongPredicate(run: (Int64) -> Bool) -> Bool {
   run(1)
 }
 
+public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
+  run(1.0)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -75,6 +75,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "LongPredicate")
   }
 
+  /// The description of the type java.util.function.DoublePredicate.
+  static var javaUtilFunctionDoublePredicate: JavaType {
+    .class(package: "java.util.function", name: "DoublePredicate")
+  }
+
   /// The description of the type java.lang.Class.
   static var javaLangClass: JavaType {
     .class(package: "java.lang", name: "Class")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -92,6 +92,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .boolean
   )
 
+  static let doublePredicate = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionDoublePredicate,
+    method: "test",
+    parameters: [.double],
+    result: .boolean
+  )
+
   static let all: [KnownJavaFunctionalInterface] = [
     .runnable,
     .booleanSupplier,
@@ -103,6 +110,7 @@ struct KnownJavaFunctionalInterface: Sendable {
     .doubleConsumer,
     .intPredicate,
     .longPredicate,
+    .doublePredicate,
   ]
 
   static func find(parameters: [JavaType], result: JavaType) -> KnownJavaFunctionalInterface? {
@@ -170,6 +178,8 @@ struct KnownJavaFunctionalInterface: Sendable {
         intPredicate
       case _ where parameter.isInt64:
         longPredicate
+      case _ where parameter.isDouble:
+        doublePredicate
       default:
         nil
       }

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -45,6 +45,7 @@ final class FuncCallbackImportTests {
 
     public func callMeIntPredicate(callback: (Int32) -> Bool)
     public func callMeLongPredicate(callback: (Int64) -> Bool)
+    public func callMeDoublePredicate(callback: (Double) -> Bool)
 
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
@@ -666,6 +667,49 @@ final class FuncCallbackImportTests {
         public static void callMeLongPredicate(java.util.function.LongPredicate callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMeLongPredicate_callback.call(callMeLongPredicate.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
+    )
+  }
+
+  @Test("Import: public func callMecallMeDoublePredicateFunc(callback: (Double) -> Bool)")
+  func func_callMecallMeDoublePredicateFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeDoublePredicate" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeDoublePredicate(callback: (Double) -> Bool)
+         * }
+         */
+        public static void callMeDoublePredicate(java.util.function.DoublePredicate callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeDoublePredicate_callback.call(callMeDoublePredicate.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -31,6 +31,7 @@ struct JNIClosureTests {
 
     public func closureIntPredicate(closure: (Int32) -> Bool) {}
     public func closureLongPredicate(closure: (Int64) -> Bool) {}
+    public func closureDoublePredicate(closure: (Double) -> Bool) {}
 
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
@@ -286,6 +287,31 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureDoublePredicate_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureDoublePredicate(closure: (Double) -> Bool)
+         * }
+         */
+        public static void closureDoublePredicate(java.util.function.DoublePredicate closure) {
+          SwiftModule.$closureDoublePredicate(closure);
+        }
+        """,
+        """
+        private static native void $closureDoublePredicate(java.util.function.DoublePredicate closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
   func emptyClosure_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -461,6 +487,31 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureDoubleConsumer_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureDoubleConsumer__Ljava_util_function_DoubleConsumer_2")
+        public func Java_com_example_swift_SwiftModule__00024closureDoubleConsumer__Ljava_util_function_DoubleConsumer_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureDoubleConsumer(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "accept", "(D)V")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = [_0.getJValue(in: environment)]
+            environment.interface.CallVoidMethodA(environment, closure, methodID$, arguments$)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
   func closureIntPredicate_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -511,7 +562,7 @@ struct JNIClosureTests {
   }
 
   @Test
-  func closureDoubleConsumer_swiftThunks() throws {
+  func closureDoublePredicate_swiftThunks() throws {
     try assertOutput(
       input: source,
       .jni,
@@ -519,14 +570,14 @@ struct JNIClosureTests {
       detectChunkByInitialLines: 1,
       expectedChunks: [
         """
-        @_cdecl("Java_com_example_swift_SwiftModule__00024closureDoubleConsumer__Ljava_util_function_DoubleConsumer_2")
-        public func Java_com_example_swift_SwiftModule__00024closureDoubleConsumer__Ljava_util_function_DoubleConsumer_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
-          SwiftModule.closureDoubleConsumer(closure: {
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureDoublePredicate__Ljava_util_function_DoublePredicate_2")
+        public func Java_com_example_swift_SwiftModule__00024closureDoublePredicate__Ljava_util_function_DoublePredicate_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureDoublePredicate(closure: {
             let class$ = environment.interface.GetObjectClass(environment, closure)
-            let methodID$ = environment.interface.GetMethodID(environment, class$, "accept", "(D)V")!
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "test", "(D)Z")!
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = [_0.getJValue(in: environment)]
-            environment.interface.CallVoidMethodA(environment, closure, methodID$, arguments$)
+            return Bool(fromJNI: environment.interface.CallBooleanMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift (Double) -> Boolean to the Java DoublePredicate functional interface