### PR TITLE
jextract: Support Java LongBinaryOperator func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -80,6 +80,10 @@ public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32
   run(1, 2)
 }
 
+public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int64 {
+  run(1, 2)
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -116,4 +116,10 @@ public class MySwiftLibraryTest {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);
     }
+
+    @Test
+    void call_globalCallMeLongBinaryOperator_noThrow() {
+        long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a, long b) -> { return a + b; });
+        assertEquals(3L, result);
+    }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -92,6 +92,10 @@ public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32
   run(1, 2)
 }
 
+public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int64 {
+  run(1, 2)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -228,4 +228,10 @@ public class MySwiftLibraryTest {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);
     }
+
+    @Test
+    void call_globalCallMeLongBinaryOperator_noThrow() {
+        long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a, long b) -> { return a + b; });
+        assertEquals(3L, result);
+    }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -65,6 +65,10 @@ public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32
   run(1, 2)
 }
 
+public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int64 {
+  run(1, 2)
+}
+
 public func closureMultipleArguments(
   input1: Int64,
   input2: Int64,

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -110,4 +110,10 @@ public class ClosuresTest {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);
     }
+
+    @Test
+    void globalCallMeLongBinaryOperator() {
+        long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a, long b) -> { return a + b; });
+        assertEquals(3L, result);
+    }
 }

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -87,6 +87,10 @@ public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32
   run(1, 2)
 }
 
+public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int64 {
+  run(1, 2)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -85,6 +85,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "IntBinaryOperator")
   }
 
+  /// The description of the type java.util.function.LongBinaryOperator.
+  static var javaUtilFunctionLongBinaryOperator: JavaType {
+    .class(package: "java.util.function", name: "LongBinaryOperator")
+  }
+
   /// The description of the type java.lang.Class.
   static var javaLangClass: JavaType {
     .class(package: "java.lang", name: "Class")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -106,6 +106,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .int
   )
 
+  static let longBinaryOperator = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionLongBinaryOperator,
+    method: "applyAsLong",
+    parameters: [.long, .long],
+    result: .long
+  )
+
   static let all: [KnownJavaFunctionalInterface] = [
     .runnable,
     .booleanSupplier,
@@ -119,6 +126,7 @@ struct KnownJavaFunctionalInterface: Sendable {
     .longPredicate,
     .doublePredicate,
     .intBinaryOperator,
+    .longBinaryOperator,
   ]
 
   static func find(parameters: [JavaType], result: JavaType) -> KnownJavaFunctionalInterface? {
@@ -199,6 +207,8 @@ struct KnownJavaFunctionalInterface: Sendable {
       return switch () {
       case _ where parameter.isInt32:
         intBinaryOperator
+      case _ where parameter.isInt64:
+        longBinaryOperator
       default:
         nil
       }

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -48,6 +48,7 @@ final class FuncCallbackImportTests {
     public func callMeDoublePredicate(callback: (Double) -> Bool)
 
     public func callMeIntBinaryOperator(callback: (Int32, Int32) -> Int32)
+    public func callMeLongBinaryOperator(callback: (Int64, Int64) -> Int64)
 
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
@@ -755,6 +756,49 @@ final class FuncCallbackImportTests {
         public static void callMeIntBinaryOperator(java.util.function.IntBinaryOperator callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMeIntBinaryOperator_callback.call(callMeIntBinaryOperator.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
+    )
+  }
+
+  @Test("Import: public func callMecallMeLongBinaryOperatorFunc(callback: (Int64, Int64) -> Int64)")
+  func func_callMecallMeLongBinaryOperatorFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeLongBinaryOperator" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeLongBinaryOperator(callback: (Int64, Int64) -> Int64)
+         * }
+         */
+        public static void callMeLongBinaryOperator(java.util.function.LongBinaryOperator callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeLongBinaryOperator_callback.call(callMeLongBinaryOperator.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -34,6 +34,7 @@ struct JNIClosureTests {
     public func closureDoublePredicate(closure: (Double) -> Bool) {}
 
     public func closureIntBinaryOperator(closure: (Int32, Int32) -> Int32) {}
+    public func closureLongBinaryOperator(closure: (Int64, Int64) -> Int64) {}
 
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
@@ -339,6 +340,31 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureLongBinaryOperator_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureLongBinaryOperator(closure: (Int64, Int64) -> Int64)
+         * }
+         */
+        public static void closureLongBinaryOperator(java.util.function.LongBinaryOperator closure) {
+          SwiftModule.$closureLongBinaryOperator(closure);
+        }
+        """,
+        """
+        private static native void $closureLongBinaryOperator(java.util.function.LongBinaryOperator closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
   func emptyClosure_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -630,6 +656,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = [_0.getJValue(in: environment), _1.getJValue(in: environment)]
             return Int32(fromJNI: environment.interface.CallIntMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureLongBinaryOperator_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureLongBinaryOperator__Ljava_util_function_LongBinaryOperator_2")
+        public func Java_com_example_swift_SwiftModule__00024closureLongBinaryOperator__Ljava_util_function_LongBinaryOperator_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureLongBinaryOperator(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "applyAsLong", "(JJ)J")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = [_0.getJValue(in: environment), _1.getJValue(in: environment)]
+            return Int64(fromJNI: environment.interface.CallLongMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift (Int64, Int64) -> Int64 to the Java LongBinaryOperator functional interface