### PR TITLE
jextract: Support Java DoubleBinaryOperator func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -84,6 +84,10 @@ public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int6
   run(1, 2)
 }
 
+public func globalCallMeDoubleBinaryOperator(run: (Double, Double) -> Double) -> Double {
+  run(1.0, 2.0)
+}
+
 // ==== Internal helpers
 
 func p(_ msg: String, file: String = #fileID, line: UInt = #line, function: String = #function) {

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -122,4 +122,10 @@ public class MySwiftLibraryTest {
         long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a, long b) -> { return a + b; });
         assertEquals(3L, result);
     }
+
+    @Test
+    void call_globalCallMeDoubleBinaryOperator_noThrow() {
+        double result = MySwiftLibrary.globalCallMeDoubleBinaryOperator((double a, double b) -> { return a + b; });
+        assertEquals(3.0, result);
+    }
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -96,6 +96,10 @@ public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int6
   run(1, 2)
 }
 
+public func globalCallMeDoubleBinaryOperator(run: (Double, Double) -> Double) -> Double {
+  run(1.0, 2.0)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -234,4 +234,10 @@ public class MySwiftLibraryTest {
         long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a, long b) -> { return a + b; });
         assertEquals(3L, result);
     }
+
+    @Test
+    void call_globalCallMeDoubleBinaryOperator_noThrow() {
+        double result = MySwiftLibrary.globalCallMeDoubleBinaryOperator((double a, double b) -> { return a + b; });
+        assertEquals(3.0, result);
+    }
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -69,6 +69,10 @@ public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int6
   run(1, 2)
 }
 
+public func globalCallMeDoubleBinaryOperator(run: (Double, Double) -> Double) -> Double {
+  run(1.0, 2.0)
+}
+
 public func closureMultipleArguments(
   input1: Int64,
   input2: Int64,

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -116,4 +116,10 @@ public class ClosuresTest {
         long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a, long b) -> { return a + b; });
         assertEquals(3L, result);
     }
+
+    @Test
+    void globalCallMeDoubleBinaryOperator() {
+        double result = MySwiftLibrary.globalCallMeDoubleBinaryOperator((double a, double b) -> { return a + b; });
+        assertEquals(3.0, result);
+    }
 }

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -91,6 +91,10 @@ public func globalCallMeLongBinaryOperator(run: (Int64, Int64) -> Int64) -> Int6
   run(1, 2)
 }
 
+public func globalCallMeDoubleBinaryOperator(run: (Double, Double) -> Double) -> Double {
+  run(1.0, 2.0)
+}
+
 public func globalReceiveRawBuffer(buf: UnsafeRawBufferPointer) -> Int {
   buf.count
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -90,6 +90,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "LongBinaryOperator")
   }
 
+  /// The description of the type java.util.function.DoubleBinaryOperator.
+  static var javaUtilFunctionDoubleBinaryOperator: JavaType {
+    .class(package: "java.util.function", name: "DoubleBinaryOperator")
+  }
+
   /// The description of the type java.lang.Class.
   static var javaLangClass: JavaType {
     .class(package: "java.lang", name: "Class")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -113,6 +113,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .long
   )
 
+  static let doubleBinaryOperator = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionDoubleBinaryOperator,
+    method: "applyAsDouble",
+    parameters: [.double, .double],
+    result: .double
+  )
+
   static let all: [KnownJavaFunctionalInterface] = [
     .runnable,
     .booleanSupplier,
@@ -127,6 +134,7 @@ struct KnownJavaFunctionalInterface: Sendable {
     .doublePredicate,
     .intBinaryOperator,
     .longBinaryOperator,
+    .doubleBinaryOperator,
   ]
 
   static func find(parameters: [JavaType], result: JavaType) -> KnownJavaFunctionalInterface? {
@@ -209,6 +217,8 @@ struct KnownJavaFunctionalInterface: Sendable {
         intBinaryOperator
       case _ where parameter.isInt64:
         longBinaryOperator
+      case _ where parameter.isDouble:
+        doubleBinaryOperator
       default:
         nil
       }

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -49,6 +49,7 @@ final class FuncCallbackImportTests {
 
     public func callMeIntBinaryOperator(callback: (Int32, Int32) -> Int32)
     public func callMeLongBinaryOperator(callback: (Int64, Int64) -> Int64)
+    public func callMeDoubleBinaryOperator(callback: (Double, Double) -> Double)
 
     public func callMeMore(callback: (UnsafeRawPointer, Float) -> Int, fn: () -> ())
     public func withBuffer(body: (UnsafeRawBufferPointer) -> Int)
@@ -799,6 +800,49 @@ final class FuncCallbackImportTests {
         public static void callMeLongBinaryOperator(java.util.function.LongBinaryOperator callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMeLongBinaryOperator_callback.call(callMeLongBinaryOperator.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
+    )
+  }
+
+  @Test("Import: public func callMecallMeDoubleBinaryOperatorFunc(callback: (Double, Double) -> Double)")
+  func func_callMecallMeDoubleBinaryOperatorFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeDoubleBinaryOperator" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeDoubleBinaryOperator(callback: (Double, Double) -> Double)
+         * }
+         */
+        public static void callMeDoubleBinaryOperator(java.util.function.DoubleBinaryOperator callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeDoubleBinaryOperator_callback.call(callMeDoubleBinaryOperator.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -35,6 +35,7 @@ struct JNIClosureTests {
 
     public func closureIntBinaryOperator(closure: (Int32, Int32) -> Int32) {}
     public func closureLongBinaryOperator(closure: (Int64, Int64) -> Int64) {}
+    public func closureDoubleBinaryOperator(closure: (Double, Double) -> Double) {}
 
     public func closureWithArgumentsAndReturn(closure: (Int64, Bool) -> Int64) {}
     """
@@ -365,6 +366,31 @@ struct JNIClosureTests {
   }
 
   @Test
+  func closureDoubleBinaryOperator_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureDoubleBinaryOperator(closure: (Double, Double) -> Double)
+         * }
+         */
+        public static void closureDoubleBinaryOperator(java.util.function.DoubleBinaryOperator closure) {
+          SwiftModule.$closureDoubleBinaryOperator(closure);
+        }
+        """,
+        """
+        private static native void $closureDoubleBinaryOperator(java.util.function.DoubleBinaryOperator closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
   func emptyClosure_swiftThunks() throws {
     try assertOutput(
       input: source,
@@ -681,6 +707,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = [_0.getJValue(in: environment), _1.getJValue(in: environment)]
             return Int64(fromJNI: environment.interface.CallLongMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureDoubleBinaryOperator_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureDoubleBinaryOperator__Ljava_util_function_DoubleBinaryOperator_2")
+        public func Java_com_example_swift_SwiftModule__00024closureDoubleBinaryOperator__Ljava_util_function_DoubleBinaryOperator_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureDoubleBinaryOperator(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "applyAsDouble", "(DD)D")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = [_0.getJValue(in: environment), _1.getJValue(in: environment)]
+            return Double(fromJNI: environment.interface.CallDoubleMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift (Double, Double) -> Double to the Java DoubleBinaryOperator functional interface