### PR TITLE
jextract: Support Java IntUnaryOperator func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -76,6 +76,10 @@ public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
   run(1.0)
 }
 
+public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -112,6 +112,12 @@ public class MySwiftLibraryTest {
     }
 
     @Test
+    void call_globalCallMeIntUnaryOperator_noThrow() {
+        int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a) -> { return a; });
+        assertEquals(1, result);
+    }
+
+    @Test
     void call_globalCallMeIntBinaryOperator_noThrow() {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -88,6 +88,10 @@ public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
   run(1.0)
 }
 
+public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -224,6 +224,12 @@ public class MySwiftLibraryTest {
     }
 
     @Test
+    void call_globalCallMeIntUnaryOperator_noThrow() {
+        int result = MySwiftLibrary.globalCallMeIntUnaryOperator((int a) -> { return a; });
+        assertEquals(1, result);
+    }
+
+    @Test
     void call_globalCallMeIntBinaryOperator_noThrow() {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -61,6 +61,10 @@ public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
   run(1.0)
 }
 
+public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -106,6 +106,12 @@ public class ClosuresTest {
     }
 
     @Test
+    void globalCallMeIntUnaryOperator() {
+        int result = MySwiftLibrary.globalCallMeIntUnaryOperator((int a) -> { return a; });
+        assertEquals(1, result);
+    }
+
+    @Test
     void globalCallMeIntBinaryOperator() {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -83,6 +83,10 @@ public func globalCallMeDoublePredicate(run: (Double) -> Bool) -> Bool {
   run(1.0)
 }
 
+public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -80,6 +80,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "DoublePredicate")
   }
 
+  /// The description of the type java.util.function.IntUnaryOperator.
+  static var javaUtilFunctionIntUnaryOperator: JavaType {
+    .class(package: "java.util.function", name: "IntUnaryOperator")
+  }
+
   /// The description of the type java.util.function.IntBinaryOperator.
   static var javaUtilFunctionIntBinaryOperator: JavaType {
     .class(package: "java.util.function", name: "IntBinaryOperator")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -99,6 +99,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .boolean
   )
 
+  static let intUnaryOperator = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionIntUnaryOperator,
+    method: "applyAsInt",
+    parameters: [.int],
+    result: .int
+  )
+
   static let intBinaryOperator = KnownJavaFunctionalInterface(
     JavaType.javaUtilFunctionIntBinaryOperator,
     method: "applyAsInt",
@@ -132,6 +139,7 @@ struct KnownJavaFunctionalInterface: Sendable {
     .intPredicate,
     .longPredicate,
     .doublePredicate,
+    .intUnaryOperator,
     .intBinaryOperator,
     .longBinaryOperator,
     .doubleBinaryOperator,
@@ -204,6 +212,17 @@ struct KnownJavaFunctionalInterface: Sendable {
         longPredicate
       case _ where parameter.isDouble:
         doublePredicate
+      default:
+        nil
+      }
+    }
+
+    // Unary operators
+    if parameters.count == 1 && parameters[0].type == result {
+      let parameter = parameters[0].type
+      return switch () {
+      case _ where parameter.isInt32:
+        intUnaryOperator
       default:
         nil
       }

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -47,6 +47,8 @@ final class FuncCallbackImportTests {
     public func callMeLongPredicate(callback: (Int64) -> Bool)
     public func callMeDoublePredicate(callback: (Double) -> Bool)
 
+    public func callMeIntUnaryOperator(callback: (Int32) -> Int32)
+
     public func callMeIntBinaryOperator(callback: (Int32, Int32) -> Int32)
     public func callMeLongBinaryOperator(callback: (Int64, Int64) -> Int64)
     public func callMeDoubleBinaryOperator(callback: (Double, Double) -> Double)
@@ -714,6 +716,49 @@ final class FuncCallbackImportTests {
         public static void callMeDoublePredicate(java.util.function.DoublePredicate callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMeDoublePredicate_callback.call(callMeDoublePredicate.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
+    )
+  }
+
+  @Test("Import: public func callMecallMeIntUnaryOperatorFunc(callback: (Int32) -> Int32)")
+  func func_callMecallMeIntUnaryOperatorFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeIntUnaryOperator" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeIntUnaryOperator(callback: (Int32) -> Int32)
+         * }
+         */
+        public static void callMeIntUnaryOperator(java.util.function.IntUnaryOperator callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeIntUnaryOperator_callback.call(callMeIntUnaryOperator.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -33,6 +33,8 @@ struct JNIClosureTests {
     public func closureLongPredicate(closure: (Int64) -> Bool) {}
     public func closureDoublePredicate(closure: (Double) -> Bool) {}
 
+    public func closureIntUnaryOperator(closure: (Int32) -> Int32) {}
+
     public func closureIntBinaryOperator(closure: (Int32, Int32) -> Int32) {}
     public func closureLongBinaryOperator(closure: (Int64, Int64) -> Int64) {}
     public func closureDoubleBinaryOperator(closure: (Double, Double) -> Double) {}
@@ -310,6 +312,31 @@ struct JNIClosureTests {
         """,
         """
         private static native void $closureDoublePredicate(java.util.function.DoublePredicate closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func closureIntUnaryOperator_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureIntUnaryOperator(closure: (Int32) -> Int32)
+         * }
+         */
+        public static void closureIntUnaryOperator(java.util.function.IntUnaryOperator closure) {
+          SwiftModule.$closureIntUnaryOperator(closure);
+        }
+        """,
+        """
+        private static native void $closureIntUnaryOperator(java.util.function.IntUnaryOperator closure);
         """,
       ]
     )
@@ -657,6 +684,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = [_0.getJValue(in: environment)]
             return Bool(fromJNI: environment.interface.CallBooleanMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureIntUnaryOperator_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureIntUnaryOperator__Ljava_util_function_IntUnaryOperator_2")
+        public func Java_com_example_swift_SwiftModule__00024closureIntUnaryOperator__Ljava_util_function_IntUnaryOperator_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureIntUnaryOperator(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "applyAsInt", "(I)I")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = [_0.getJValue(in: environment)]
+            return Int32(fromJNI: environment.interface.CallIntMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift (Int32) -> Int32 to the Java IntUnaryOperator functional interface