### PR TITLE
jextract: Support Java LongUnaryOperator func interface

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -80,6 +80,10 @@ public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
   run(1)
 }
 
+public func globalCallMeLongUnaryOperator(run: (Int64) -> Int64) -> Int64 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -118,6 +118,12 @@ public class MySwiftLibraryTest {
     }
 
     @Test
+    void call_globalCallMeLongUnaryOperator_noThrow() {
+        long result = MySwiftLibrary.globalCallMeLongBinaryOperator((long a) -> { return a; });
+        assertEquals(1L, result);
+    }
+
+    @Test
     void call_globalCallMeIntBinaryOperator_noThrow() {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);

--- a/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
+++ b/Samples/SwiftJavaExtractFFMSampleApp/Sources/MySwiftLibrary/MySwiftLibrary.swift
@@ -92,6 +92,10 @@ public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
   run(1)
 }
 
+public func globalCallMeLongUnaryOperator(run: (Int64) -> Int64) -> Int64 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftJavaExtractFFMSampleApp/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -230,6 +230,12 @@ public class MySwiftLibraryTest {
     }
 
     @Test
+    void call_globalCallMeLongUnaryOperator_noThrow() {
+        long result = MySwiftLibrary.globalCallMeLongUnaryOperator((long a) -> { return a; });
+        assertEquals(1L, result);
+    }
+
+    @Test
     void call_globalCallMeIntBinaryOperator_noThrow() {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);

--- a/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
+++ b/Samples/SwiftJavaExtractJNISampleApp/Sources/MySwiftLibrary/Closures.swift
@@ -65,6 +65,10 @@ public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
   run(1)
 }
 
+public func globalCallMeLongUnaryOperator(run: (Int64) -> Int64) -> Int64 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
+++ b/Samples/SwiftJavaExtractJNISampleApp/src/test/java/com/example/swift/ClosuresTest.java
@@ -112,6 +112,12 @@ public class ClosuresTest {
     }
 
     @Test
+    void globalCallMeLongUnaryOperator() {
+        long result = MySwiftLibrary.globalCallMeLongUnaryOperator((long a) -> { return a; });
+        assertEquals(1L, result);
+    }
+
+    @Test
     void globalCallMeIntBinaryOperator() {
         int result = MySwiftLibrary.globalCallMeIntBinaryOperator((int a, int b) -> { return a + b; });
         assertEquals(3, result);

--- a/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
+++ b/Sources/ExampleSwiftLibrary/MySwiftLibrary.swift
@@ -87,6 +87,10 @@ public func globalCallMeIntUnaryOperator(run: (Int32) -> Int32) -> Int32 {
   run(1)
 }
 
+public func globalCallMeLongUnaryOperator(run: (Int64) -> Int64) -> Int64 {
+  run(1)
+}
+
 public func globalCallMeIntBinaryOperator(run: (Int32, Int32) -> Int32) -> Int32 {
   run(1, 2)
 }

--- a/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
+++ b/Sources/JExtractSwiftLib/JavaTypes/JavaType+JDK.swift
@@ -85,6 +85,11 @@ extension JavaType {
     .class(package: "java.util.function", name: "IntUnaryOperator")
   }
 
+  /// The description of the type java.util.function.LongUnaryOperator.
+  static var javaUtilFunctionLongUnaryOperator: JavaType {
+    .class(package: "java.util.function", name: "LongUnaryOperator")
+  }
+
   /// The description of the type java.util.function.IntBinaryOperator.
   static var javaUtilFunctionIntBinaryOperator: JavaType {
     .class(package: "java.util.function", name: "IntBinaryOperator")

--- a/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
+++ b/Sources/JExtractSwiftLib/KnownFunctionalInterfaces.swift
@@ -106,6 +106,13 @@ struct KnownJavaFunctionalInterface: Sendable {
     result: .int
   )
 
+  static let longUnaryOperator = KnownJavaFunctionalInterface(
+    JavaType.javaUtilFunctionLongUnaryOperator,
+    method: "applyAsLong",
+    parameters: [.long],
+    result: .long
+  )
+
   static let intBinaryOperator = KnownJavaFunctionalInterface(
     JavaType.javaUtilFunctionIntBinaryOperator,
     method: "applyAsInt",
@@ -140,6 +147,7 @@ struct KnownJavaFunctionalInterface: Sendable {
     .longPredicate,
     .doublePredicate,
     .intUnaryOperator,
+    .longUnaryOperator,
     .intBinaryOperator,
     .longBinaryOperator,
     .doubleBinaryOperator,
@@ -223,6 +231,8 @@ struct KnownJavaFunctionalInterface: Sendable {
       return switch () {
       case _ where parameter.isInt32:
         intUnaryOperator
+      case _ where parameter.isInt64:
+        longUnaryOperator
       default:
         nil
       }

--- a/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
+++ b/Tests/JExtractSwiftTests/FuncCallbackImportTests.swift
@@ -48,6 +48,7 @@ final class FuncCallbackImportTests {
     public func callMeDoublePredicate(callback: (Double) -> Bool)
 
     public func callMeIntUnaryOperator(callback: (Int32) -> Int32)
+    public func callMeLongUnaryOperator(callback: (Int64) -> Int64)
 
     public func callMeIntBinaryOperator(callback: (Int32, Int32) -> Int32)
     public func callMeLongBinaryOperator(callback: (Int64, Int64) -> Int64)
@@ -759,6 +760,49 @@ final class FuncCallbackImportTests {
         public static void callMeIntUnaryOperator(java.util.function.IntUnaryOperator callback) {
           try(var arena$ = Arena.ofConfined()) {
             swiftjava___FakeModule_callMeIntUnaryOperator_callback.call(callMeIntUnaryOperator.$toUpcallStub(callback, arena$));
+          }
+        }
+        """
+      ]
+    )
+  }
+
+  @Test("Import: public func callMecallMeLongUnaryOperatorFunc(callback: (Int64) -> Int64)")
+  func func_callMecallMeLongUnaryOperatorFunc_callback() throws {
+    var config = Configuration()
+    config.swiftModule = "__FakeModule"
+    let st = makeSwiftJavaAnalyzer(config: config)
+    st.log.logLevel = .error
+
+    try st.analyze(path: "Fake.swift", text: Self.class_interfaceFile)
+
+    let funcDecl = st.extractedGlobalFuncs.first { $0.name == "callMeLongUnaryOperator" }!
+
+    let generator = FFMSwift2JavaGenerator(
+      config: config,
+      translator: st,
+      javaPackage: "com.example.swift",
+      swiftOutputDirectory: "/fake",
+      javaOutputDirectory: "/fake"
+    )
+
+    let output = JavaPrinter.toString { printer in
+      generator.printFunctionDowncallMethods(&printer, funcDecl)
+    }
+
+    assertOutput(
+      output,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func callMeLongUnaryOperator(callback: (Int64) -> Int64)
+         * }
+         */
+        public static void callMeLongUnaryOperator(java.util.function.LongUnaryOperator callback) {
+          try(var arena$ = Arena.ofConfined()) {
+            swiftjava___FakeModule_callMeLongUnaryOperator_callback.call(callMeLongUnaryOperator.$toUpcallStub(callback, arena$));
           }
         }
         """

--- a/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClosureTests.swift
@@ -34,6 +34,7 @@ struct JNIClosureTests {
     public func closureDoublePredicate(closure: (Double) -> Bool) {}
 
     public func closureIntUnaryOperator(closure: (Int32) -> Int32) {}
+    public func closureLongUnaryOperator(closure: (Int64) -> Int64) {}
 
     public func closureIntBinaryOperator(closure: (Int32, Int32) -> Int32) {}
     public func closureLongBinaryOperator(closure: (Int64, Int64) -> Int64) {}
@@ -337,6 +338,31 @@ struct JNIClosureTests {
         """,
         """
         private static native void $closureIntUnaryOperator(java.util.function.IntUnaryOperator closure);
+        """,
+      ]
+    )
+  }
+
+  @Test
+  func closureLongUnaryOperator_javaBindings() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .java,
+      expectedChunks: [
+        """
+        /**
+         * Downcall to Swift:
+         * {@snippet lang=swift :
+         * public func closureLongUnaryOperator(closure: (Int64) -> Int64)
+         * }
+         */
+        public static void closureLongUnaryOperator(java.util.function.LongUnaryOperator closure) {
+          SwiftModule.$closureLongUnaryOperator(closure);
+        }
+        """,
+        """
+        private static native void $closureLongUnaryOperator(java.util.function.LongUnaryOperator closure);
         """,
       ]
     )
@@ -709,6 +735,31 @@ struct JNIClosureTests {
             environment.interface.DeleteLocalRef(environment, class$)
             let arguments$: [jvalue] = [_0.getJValue(in: environment)]
             return Int32(fromJNI: environment.interface.CallIntMethodA(environment, closure, methodID$, arguments$), in: environment)
+          }
+          )
+        }
+        """
+      ]
+    )
+  }
+
+  @Test
+  func closureLongUnaryOperator_swiftThunks() throws {
+    try assertOutput(
+      input: source,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_SwiftModule__00024closureLongUnaryOperator__Ljava_util_function_LongUnaryOperator_2")
+        public func Java_com_example_swift_SwiftModule__00024closureLongUnaryOperator__Ljava_util_function_LongUnaryOperator_2(environment: UnsafeMutablePointer<JNIEnv?>!, thisClass: jclass, closure: jobject?) {
+          SwiftModule.closureLongUnaryOperator(closure: {
+            let class$ = environment.interface.GetObjectClass(environment, closure)
+            let methodID$ = environment.interface.GetMethodID(environment, class$, "applyAsLong", "(J)J")!
+            environment.interface.DeleteLocalRef(environment, class$)
+            let arguments$: [jvalue] = [_0.getJValue(in: environment)]
+            return Int64(fromJNI: environment.interface.CallLongMethodA(environment, closure, methodID$, arguments$), in: environment)
           }
           )
         }


### PR DESCRIPTION
Add support for translating Swift (Int64) -> Int64 to the Java LongUnaryOperator functional interface