### PR TITLE
jextract: NFC Fix calling wrong function in the unittest

### DIFF
--- a/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
+++ b/Samples/SwiftAndJavaJarFFMSampleLib/src/test/java/com/example/swift/MySwiftLibraryTest.java
@@ -74,7 +74,7 @@ public class MySwiftLibraryTest {
 
     @Test
     void call_globalCallMeDoubleSupplier_noThrow() {
-        double result = MySwiftLibrary.globalCallMeBooleanSupplier(() -> { return 2.0; });
+        double result = MySwiftLibrary.globalCallMeDoubleSupplier(() -> { return 2.0; });
         assertEquals(2.0, result);
     }
 


### PR DESCRIPTION
Fix calling the wrong function from MySwiftLibrary in the unittest