### PR TITLE
JNI: gate the Java implements clause on extracted protocols

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+JavaBindingsPrinting.swift
@@ -590,10 +590,8 @@ extension JNISwift2JavaGenerator {
     }
     modifiers.append("final")
     var implements = ["JNISwiftInstance"]
-    implements += decl.inheritedTypes
-      .compactMap(\.asNominalTypeDeclaration)
-      .filter { $0.kind == .protocol }
-      .map(\.name)
+    // Only protocols that were actually extracted have a generated Java interface to implement.
+    implements += self.inheritedProtocols(of: decl).map(\.effectiveJavaSimpleName)
     let implementsClause = implements.joined(separator: .comma)
     // Specialized types are concrete — no generic clause on the Java side
     let genericClause = decl.javaGenericClause

--- a/Tests/JExtractSwiftTests/JNI/JNIProtocolTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIProtocolTests.swift
@@ -642,4 +642,44 @@ struct JNIProtocolTests {
       ]
     )
   }
+
+  // ==== -----------------------------------------------------------------------
+  // MARK: Unextracted protocols must not reach the `implements` clause
+
+  @Test
+  func excludedProtocolIsOmittedFromImplementsClause() throws {
+    let source = """
+      public protocol VisibleProtocol {
+        public func visibleMethod()
+      }
+
+      public protocol HiddenProtocol {
+        public func hiddenMethod()
+      }
+
+      public class Conformer: VisibleProtocol, HiddenProtocol {
+        public func visibleMethod() {}
+        public func hiddenMethod() {}
+      }
+      """
+
+    var filtered = config
+    filtered.swiftFilterExclude = ["HiddenProtocol"]
+
+    try assertOutput(
+      input: source,
+      config: filtered,
+      .jni,
+      .java,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        public final class Conformer implements JNISwiftInstance, VisibleProtocol {
+        """
+      ],
+      notExpectedChunks: [
+        "HiddenProtocol"
+      ]
+    )
+  }
 }


### PR DESCRIPTION
`printNominal` built the Java `implements` list straight from `decl.inheritedTypes` with no check that each protocol was actually extracted. 

Filtering could have excluded certain types, or they just failed to import. So we must use the `inheritedProtocols(of:)` API instead which applies filtering against imported types.
