### PR TITLE
[SwiftExtract] Record the source file path on ExtractedFunc

### DIFF
--- a/Sources/SwiftExtract/ExtractedDecls.swift
+++ b/Sources/SwiftExtract/ExtractedDecls.swift
@@ -309,8 +309,8 @@ public final class ExtractedFunc: ExtractedSwiftDecl, CustomStringConvertible {
 
   public let functionSignature: SwiftFunctionSignature
 
-  // The short path from module root to the file in which this declaration was originally declared.
-  // E.g. for `Sources/Example/My/Types.swift` it would be `My/Types.swift`.
+  /// The short path from module root to the file in which this declaration was originally declared.
+  /// E.g. for `Sources/Example/My/Types.swift` it would be `My/Types.swift`.
   public let sourceFilePath: String?
 
   public var signatureString: String {

--- a/Sources/SwiftExtract/ExtractedDecls.swift
+++ b/Sources/SwiftExtract/ExtractedDecls.swift
@@ -309,6 +309,10 @@ public final class ExtractedFunc: ExtractedSwiftDecl, CustomStringConvertible {
 
   public let functionSignature: SwiftFunctionSignature
 
+  // The short path from module root to the file in which this declaration was originally declared.
+  // E.g. for `Sources/Example/My/Types.swift` it would be `My/Types.swift`.
+  public let sourceFilePath: String?
+
   public var signatureString: String {
     self.swiftDecl.signatureString
   }
@@ -390,12 +394,14 @@ public final class ExtractedFunc: ExtractedSwiftDecl, CustomStringConvertible {
     name: String,
     apiKind: SwiftAPIKind,
     functionSignature: SwiftFunctionSignature,
+    sourceFilePath: String? = nil,
   ) {
     self.module = module
     self.name = name
     self.swiftDecl = swiftDecl
     self.apiKind = apiKind
     self.functionSignature = functionSignature
+    self.sourceFilePath = sourceFilePath
   }
 
   public var description: String {
@@ -418,7 +424,8 @@ public final class ExtractedFunc: ExtractedSwiftDecl, CustomStringConvertible {
       swiftDecl: swiftDecl,
       name: name,
       apiKind: apiKind,
-      functionSignature: functionSignature
+      functionSignature: functionSignature,
+      sourceFilePath: sourceFilePath
     )
   }
 
@@ -469,7 +476,8 @@ public final class ExtractedFunc: ExtractedSwiftDecl, CustomStringConvertible {
           swiftDecl: swiftDecl,
           name: name,
           apiKind: apiKind,
-          functionSignature: newSignature
+          functionSignature: newSignature,
+          sourceFilePath: sourceFilePath
         )
       )
     }

--- a/Sources/SwiftExtract/SwiftAnalysisVisitor.swift
+++ b/Sources/SwiftExtract/SwiftAnalysisVisitor.swift
@@ -227,6 +227,7 @@ final class SwiftAnalysisVisitor {
       name: node.name.text.unescapedSwiftName,
       apiKind: apiKind,
       functionSignature: signature,
+      sourceFilePath: sourceFilePath,
     )
 
     log.debug("Record extracted method \(node.qualifiedNameForDebug)")
@@ -268,6 +269,7 @@ final class SwiftAnalysisVisitor {
           name: caseName,
           apiKind: .enumCase,
           functionSignature: signature,
+          sourceFilePath: sourceFilePath,
         )
 
         let extractedCase = ExtractedEnumCase(
@@ -318,6 +320,7 @@ final class SwiftAnalysisVisitor {
           in: typeContext,
           kind: .getter,
           name: varName,
+          sourceFilePath: sourceFilePath,
         )
       }
       if supportedAccessors.contains(.set) {
@@ -326,6 +329,7 @@ final class SwiftAnalysisVisitor {
           in: typeContext,
           kind: .setter,
           name: varName,
+          sourceFilePath: sourceFilePath,
         )
       }
     } catch {
@@ -375,6 +379,7 @@ final class SwiftAnalysisVisitor {
       name: "init",
       apiKind: .initializer,
       functionSignature: signature,
+      sourceFilePath: sourceFilePath,
     )
 
     typeContext.initializers.append(extracted)
@@ -403,6 +408,7 @@ final class SwiftAnalysisVisitor {
           in: typeContext,
           kind: .subscriptGetter,
           name: name,
+          sourceFilePath: sourceFilePath,
         )
       }
       if accessors.contains(.set) {
@@ -411,6 +417,7 @@ final class SwiftAnalysisVisitor {
           in: typeContext,
           kind: .subscriptSetter,
           name: name,
+          sourceFilePath: sourceFilePath,
         )
       }
     } catch {
@@ -452,6 +459,7 @@ final class SwiftAnalysisVisitor {
     in typeContext: ExtractedNominalType?,
     kind: SwiftAPIKind,
     name: String,
+    sourceFilePath: String,
   ) throws {
     let signature: SwiftFunctionSignature
 
@@ -481,6 +489,7 @@ final class SwiftAnalysisVisitor {
       name: name,
       apiKind: kind,
       functionSignature: signature,
+      sourceFilePath: sourceFilePath,
     )
 
     log.debug(


### PR DESCRIPTION
ExtractedNominalType already exposes sourceFilePath, but functions did not carry theirs, so a consumer that groups output by input file (e.g. BridgeJS's per-file imported-API skeletons) could not attribute global functions or accessors to a file. Thread the path through the visitor into every ExtractedFunc; synthesized declarations keep nil.

Depends on https://github.com/swiftlang/swift-java/pull/900