### PR TITLE
[SwiftExtract] Make the analyzer instance API public and add resolveType

### DIFF
--- a/Sources/SwiftExtract/SwiftAnalyzer.swift
+++ b/Sources/SwiftExtract/SwiftAnalyzer.swift
@@ -124,7 +124,7 @@ extension SwiftAnalyzer {
     )
   }
 
-  package func add(filePath: String, text: String) {
+  public func add(filePath: String, text: String) {
     log.debug("Adding: \(filePath)")
     let sourceFileSyntax = Parser.parse(source: text)
     self.inputs.append(SwiftInputFile(syntax: sourceFileSyntax, path: filePath))
@@ -150,7 +150,7 @@ extension SwiftAnalyzer {
   /// the analyzer's natively-registered ones. Without the hook, those
   /// specializations are registered too late and any constrained extension
   /// (`extension Box where T == ConcreteT { … }`) is silently dropped.
-  package func analyze(
+  public func analyze(
     beforeProcessingDeferredExtensions hook: (SwiftAnalyzer) throws -> Void = { _ in }
   ) throws {
     prepareForTranslation()
@@ -281,6 +281,15 @@ extension SwiftAnalyzer {
     }
     try analyzer.analyze(beforeProcessingDeferredExtensions: hook)
     return analyzer.result
+  }
+
+  /// Resolve a type reference found outside of a declaration signature
+  /// (e.g. inside an attribute argument such as `@JavaExport(as: Foo.self)`)
+  /// against the analyzed module's symbol tables. Only valid after
+  /// `analyze()` has run.
+  public func resolveType(_ syntax: TypeSyntax) throws -> SwiftType {
+    precondition(lookupContext != nil, "resolveType may only be called after analyze()")
+    return try SwiftType(syntax, lookupContext: lookupContext)
   }
 
   package func prepareForTranslation() {


### PR DESCRIPTION
The static `SwiftAnalyzer.analyze()` entry point returns only the `AnalysisResult`, but some consumers need the analyzer itself after the run: type references can appear outside declaration signatures (e.g. in attribute arguments like `@JavaExport(as: Foo.self)` or BridgeJS's `@JS(as: Foo.self)`), and resolving those requires the module's symbol tables. Make `add(filePath:text:)` and `analyze(beforeProcessing...:)` public so a consumer can drive an analyzer instance directly, and add `resolveType(_:)` to resolve a `TypeSyntax` against the analyzed module after analysis.