### PR TITLE
JNI: fix non-compiling async thunks for protocol boxes and generic types

### DIFF
--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -1958,15 +1958,20 @@ extension JNISwift2JavaGenerator {
           """
         )
 
+        var selfCaptures: [(sendable: String, original: String)] = []
         if let selfParameter = nativeFunctionSignature.selfParameter {
-          for parameter in selfParameter.parameters {
-            printer.print("nonisolated(unsafe) let \(parameter.name)Sendable$ = \(parameter.name)$")
+          if case .extractSwiftProtocolValue = selfParameter.conversion {
+            for parameter in selfParameter.parameters {
+              selfCaptures.append(("\(parameter.name)ExistentialSendable$", "\(parameter.name)Existential$"))
+            }
+          } else {
+            for parameter in selfParameter.parameters {
+              selfCaptures.append(("\(parameter.name)Sendable$", "\(parameter.name)$"))
+            }
           }
         }
-        if let selfTypeParameter = nativeFunctionSignature.selfTypeParameter {
-          for parameter in selfTypeParameter.parameters {
-            printer.print("nonisolated(unsafe) let \(parameter.name)Sendable$ = \(parameter.name)$")
-          }
+        for capture in selfCaptures {
+          printer.print("nonisolated(unsafe) let \(capture.sendable) = \(capture.original)")
         }
 
         func printDo(printer: inout SwiftPrinter) {
@@ -2011,15 +2016,8 @@ extension JNISwift2JavaGenerator {
         }
 
         func printTaskBody(printer: inout SwiftPrinter) {
-          if let selfParameter = nativeFunctionSignature.selfParameter {
-            for parameter in selfParameter.parameters {
-              printer.print("let \(parameter.name)$ = \(parameter.name)Sendable$")
-            }
-          }
-          if let selfTypeParameter = nativeFunctionSignature.selfTypeParameter {
-            for parameter in selfTypeParameter.parameters {
-              printer.print("let \(parameter.name)$ = \(parameter.name)Sendable$")
-            }
+          for capture in selfCaptures {
+            printer.print("let \(capture.original) = \(capture.sendable)")
           }
           printer.printBraceBlock("defer") { printer in
             // Defer might on any thread, so we need to attach environment.

--- a/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
+++ b/Sources/JExtractSwiftLib/JNI/JNISwift2JavaGenerator+NativeTranslation.swift
@@ -1958,20 +1958,20 @@ extension JNISwift2JavaGenerator {
           """
         )
 
-        var selfCaptures: [(sendable: String, original: String)] = []
+        var selfCaptures: [(unsafeSendable: String, original: String)] = []
         if let selfParameter = nativeFunctionSignature.selfParameter {
           if case .extractSwiftProtocolValue = selfParameter.conversion {
             for parameter in selfParameter.parameters {
-              selfCaptures.append(("\(parameter.name)ExistentialSendable$", "\(parameter.name)Existential$"))
+              selfCaptures.append(("\(parameter.name)ExistentialUnsafeSendable$", "\(parameter.name)Existential$"))
             }
           } else {
             for parameter in selfParameter.parameters {
-              selfCaptures.append(("\(parameter.name)Sendable$", "\(parameter.name)$"))
+              selfCaptures.append(("\(parameter.name)UnsafeSendable$", "\(parameter.name)$"))
             }
           }
         }
         for capture in selfCaptures {
-          printer.print("nonisolated(unsafe) let \(capture.sendable) = \(capture.original)")
+          printer.print("nonisolated(unsafe) let \(capture.unsafeSendable) = \(capture.original)")
         }
 
         func printDo(printer: inout SwiftPrinter) {
@@ -2017,7 +2017,7 @@ extension JNISwift2JavaGenerator {
 
         func printTaskBody(printer: inout SwiftPrinter) {
           for capture in selfCaptures {
-            printer.print("let \(capture.original) = \(capture.sendable)")
+            printer.print("let \(capture.original) = \(capture.unsafeSendable)")
           }
           printer.printBraceBlock("defer") { printer in
             // Defer might on any thread, so we need to attach environment.

--- a/Tests/JExtractSwiftTests/JNI/JNIClassAsyncSelfCaptureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassAsyncSelfCaptureTests.swift
@@ -34,11 +34,11 @@ struct JNIAsyncSelfCaptureTests {
         """
         @_cdecl("Java_com_example_swift_MyClass__00024compute__JLjava_util_concurrent_CompletableFuture_2")
         ...
-        nonisolated(unsafe) let selfPointerSendable$ = selfPointer$
+        nonisolated(unsafe) let selfPointerUnsafeSendable$ = selfPointer$
         ...
         task = Task.immediate {
         ...
-        let selfPointer$ = selfPointerSendable$
+        let selfPointer$ = selfPointerUnsafeSendable$
         ...
         let swiftResult$ = await selfPointer$.pointee.compute()
         """
@@ -61,18 +61,18 @@ struct JNIAsyncSelfCaptureTests {
         """
         @_cdecl("Java_com_example_swift_WorkerBox__00024work__JJLjava_util_concurrent_CompletableFuture_2")
         ...
-        nonisolated(unsafe) let selfPointerExistentialSendable$ = selfPointerExistential$
+        nonisolated(unsafe) let selfPointerExistentialUnsafeSendable$ = selfPointerExistential$
         ...
         task = Task.immediate {
         ...
-        let selfPointerExistential$ = selfPointerExistentialSendable$
+        let selfPointerExistential$ = selfPointerExistentialUnsafeSendable$
         ...
         let swiftResult$ = await selfPointerExistential$.work()
         """
       ],
       notExpectedChunks: [
-        "nonisolated(unsafe) let selfPointerSendable$",
-        "nonisolated(unsafe) let selfTypePointerSendable$",
+        "nonisolated(unsafe) let selfPointerUnsafeSendable$",
+        "nonisolated(unsafe) let selfTypePointerUnsafeSendable$",
       ]
     )
   }
@@ -92,17 +92,17 @@ struct JNIAsyncSelfCaptureTests {
         """
         extension Box: _SwiftModule_Box_opener {
         ...
-        nonisolated(unsafe) let selfPointerSendable$ = selfPointer$
+        nonisolated(unsafe) let selfPointerUnsafeSendable$ = selfPointer$
         ...
         task = Task.immediate {
         ...
-        let selfPointer$ = selfPointerSendable$
+        let selfPointer$ = selfPointerUnsafeSendable$
         ...
         let swiftResult$ = await selfPointer$.pointee.compute()
         """
       ],
       notExpectedChunks: [
-        "selfTypePointerSendable$",
+        "selfTypePointerUnsafeSendable$"
       ]
     )
   }

--- a/Tests/JExtractSwiftTests/JNI/JNIClassAsyncSelfCaptureTests.swift
+++ b/Tests/JExtractSwiftTests/JNI/JNIClassAsyncSelfCaptureTests.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import JExtractSwiftLib
+import SwiftJavaConfigurationShared
+import Testing
+
+@Suite
+struct JNIAsyncSelfCaptureTests {
+
+  @Test("Import: class async method captures converted self pointer (Swift)")
+  func classAsyncMethod_swift() throws {
+    try assertOutput(
+      input: """
+        public class MyClass {
+          public func compute() async -> Int64 { 42 }
+        }
+        """,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_MyClass__00024compute__JLjava_util_concurrent_CompletableFuture_2")
+        ...
+        nonisolated(unsafe) let selfPointerSendable$ = selfPointer$
+        ...
+        task = Task.immediate {
+        ...
+        let selfPointer$ = selfPointerSendable$
+        ...
+        let swiftResult$ = await selfPointer$.pointee.compute()
+        """
+      ]
+    )
+  }
+
+  @Test("Import: protocol box async method captures loaded existential (Swift)")
+  func protocolBoxAsyncMethod_swift() throws {
+    try assertOutput(
+      input: """
+        public protocol Worker {
+          func work() async -> Int64
+        }
+        """,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        @_cdecl("Java_com_example_swift_WorkerBox__00024work__JJLjava_util_concurrent_CompletableFuture_2")
+        ...
+        nonisolated(unsafe) let selfPointerExistentialSendable$ = selfPointerExistential$
+        ...
+        task = Task.immediate {
+        ...
+        let selfPointerExistential$ = selfPointerExistentialSendable$
+        ...
+        let swiftResult$ = await selfPointerExistential$.work()
+        """
+      ],
+      notExpectedChunks: [
+        "nonisolated(unsafe) let selfPointerSendable$",
+        "nonisolated(unsafe) let selfTypePointerSendable$",
+      ]
+    )
+  }
+
+  @Test("Import: generic class async method captures only self pointer (Swift)")
+  func genericClassAsyncMethod_swift() throws {
+    try assertOutput(
+      input: """
+        public class Box<T> {
+          public func compute() async -> Int64 { 42 }
+        }
+        """,
+      .jni,
+      .swift,
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        extension Box: _SwiftModule_Box_opener {
+        ...
+        nonisolated(unsafe) let selfPointerSendable$ = selfPointer$
+        ...
+        task = Task.immediate {
+        ...
+        let selfPointer$ = selfPointerSendable$
+        ...
+        let swiftResult$ = await selfPointer$.pointee.compute()
+        """
+      ],
+      notExpectedChunks: [
+        "selfTypePointerSendable$",
+      ]
+    )
+  }
+}


### PR DESCRIPTION
### Motivation

Async methods in JNI mode capture `self` into the `Task` via `nonisolated(unsafe)`
bindings. The capture always referenced `<param>$`, but that binding only exists for
class/actor lowering (`.extractSwiftValue`). Protocol boxes load `self` into
`<param>Existential$`, and generic-Self downcalls render inside the opener extension
where `selfTypePointer` is never bound — so the generated Swift referenced unbound
identifiers and failed to compile.

### Changes

- Capture the binding the self lowering actually produced: `<param>$` for
  classes/actors, `<param>Existential$` for protocol boxes.
- Stop capturing the type-metadata parameter; the opener thunk neither receives
  nor binds it, and the task body never uses it.

### Testing

New `JNIAsyncSelfCaptureTests` pin the generated captures for all three self
shapes (class, protocol box, generic class); the generic and protocol tests fail
without this change. Full test suite passes (654 tests).

🤖 Fixed with help of Claude Code

https://github.com/swiftlang/swift-java/issues/865