### PR TITLE
SwiftExtract: fix private(set) being ignored for variables with explicit accessors

### DIFF
--- a/Sources/SwiftExtract/SwiftTypes/SwiftFunctionSignature.swift
+++ b/Sources/SwiftExtract/SwiftTypes/SwiftFunctionSignature.swift
@@ -545,15 +545,17 @@ extension VariableDeclSyntax {
       return [.get]
     }
 
-    if let accessorBlock = binding.accessorBlock {
-      return accessorBlock.supportedAccessorKinds()
-    }
-
-    // Account for private(set) and similar modifiers
+    // Account for private(set) and similar modifiers. This is checked before the
+    // accessor block, because a variable can restrict its setter's access level and
+    // still spell out its accessors explicitly.
     for modifier in self.modifiers where modifier.detail?.detail.text == "set" {
       if !minimumAccessLevel.matches(modifier) {
         return [.get]
       }
+    }
+
+    if let accessorBlock = binding.accessorBlock {
+      return accessorBlock.supportedAccessorKinds()
     }
 
     return [.get, .set]

--- a/Tests/JExtractSwiftTests/VariableImportTests.swift
+++ b/Tests/JExtractSwiftTests/VariableImportTests.swift
@@ -154,4 +154,38 @@ final class VariableImportTests {
       ]
     )
   }
+
+  let class_privateSetWithAccessorBlockInterfaceFile =
+    """
+    public class MySwiftClass {
+      public private(set) var counterInt: Int {
+        get { fatalError() }
+        set { fatalError() }
+      }
+    }
+    """
+
+  @Test("Import: public private(set) var counterInt: Int with an explicit accessor block emits only the getter")
+  func variable_int_privateSet_explicitAccessorBlock() throws {
+    try assertOutput(
+      input: class_privateSetWithAccessorBlockInterfaceFile,
+      .ffm,
+      .java,
+      swiftModuleName: "FakeModule",
+      detectChunkByInitialLines: 1,
+      expectedChunks: [
+        """
+        public long getCounterInt() throws SwiftIntegerOverflowException {
+          $ensureAlive();
+          long result$checked = swiftjava_FakeModule_MySwiftClass_counterInt$get.call(this.$memorySegment());
+          ...
+        }
+        """
+      ],
+      notExpectedChunks: [
+        "swiftjava_FakeModule_MySwiftClass_counterInt$set",
+        "setCounterInt",
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Fixes #535.

`supportedAccessorKinds(binding:minimumAccessLevel:)` returned early on
`binding.accessorBlock` before it reached the `private(set)` check, so a variable that both
restricts its setter's access level and spells out its accessors explicitly got a setter
binding emitted for a setter it cannot call:

```
error: cannot assign to property: 'bar' setter is inaccessible
 17 | public func swiftjava_MySwiftLibrary_Foo_bar$set(_ newValue: UnsafePointer<Int8>, _ self: UnsafeRawPointer) {
 18 |   self.assumingMemoryBound(to: Foo.self).pointee.bar = String(cString: newValue)
```

Moving the modifier check above the accessor block fixes it. The existing
`variable_int_privateSet` test already covers `public private(set) var` without an accessor
block, which is why this only shows up when the accessors are written out; the new test
covers that case.

`swift test` passes, 670 tests in 89 suites. The new test fails before the change and passes
after it.

### Not changed here

Subscripts have the same problem by a different path. `SwiftAnalysisVisitor.visit(subscriptDecl:)`
calls the no-argument `accessorBlock.supportedAccessorKinds()`, which never consults
`minimumAccessLevel`, so `public private(set) subscript` still emits a `$set` binding. I kept
this PR to the variable case. Happy to fold the subscript fix in here or open a separate
issue for it, whichever you prefer.
