### PR TITLE
Preparing release 0.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let swiftJavaJNICoreDep: Package.Dependency
 if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   swiftJavaJNICoreDep = .package(path: localPath)
 } else {
-  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", branch: "main")
+  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", from: "0.5.1")
 }
 
 // Set SWIFTJAVA_DOCC_PLUGIN_INSTALL=1 to install the docc-plugin automatically,


### PR DESCRIPTION
## Release 0.6.0

Minor release: new jextract Java functional-interface support, new public SwiftExtract API, and isolated-parameter import support, since 0.5.1.

### Highlights
- jextract: support for Java `IntConsumer`, `LongConsumer`, `DoubleConsumer`, `IntPredicate`, `LongPredicate`, `DoublePredicate`, `Int/Long/Double` Unary/Binary operator functional interfaces
- jextract: import functions with `isolated` parameters (#879)
- jextract: recognize actor (`distributed`) methods and extensions as async functions (#895)
- jextract: support extracting class members (#890)
- jextract: generate extensions of wrapper types owned by other modules (#852)
- SwiftExtract: SwiftExtract: fix private(set) being ignored for variables with explicit accessors (#908)
- SwiftExtract: make the analyzer instance API public and add `resolveType` (#903)
- SwiftExtract: pluggable diagnostics sink for skipped declarations (#900)
- SwiftExtract: typed throws, async/throws specifiers, existential and typealias handling
- Add support for Foundation `TimeInterval` (#871)
- JNI: fix non-compiling async thunks for protocol boxes and generic types (#905)
- JNI: gate the Java implements clause on extracted protocols (#888)
- Android: improve Core Library Desugaring trait (#910)

### Dependencies
- Pin `swift-java-jni-core` to `0.5.1`

Full commit list: https://github.com/swiftlang/swift-java/compare/0.5.1...release/0.6.0