### PR TITLE
Prepare next development cycle after 0.6.0 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let swiftJavaJNICoreDep: Package.Dependency
 if let localPath = Context.environment["SWIFT_JAVA_JNI_CORE_PATH"] {
   swiftJavaJNICoreDep = .package(path: localPath)
 } else {
-  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", from: "0.5.1")
+  swiftJavaJNICoreDep = .package(url: "https://github.com/swiftlang/swift-java-jni-core", branch: "main")
 }
 
 // Set SWIFTJAVA_DOCC_PLUGIN_INSTALL=1 to install the docc-plugin automatically,


### PR DESCRIPTION
Points swift-java-jni-core back at branch: "main" now that 0.6.0 has been tagged and released.